### PR TITLE
Fix various preferences runtimes

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -22,7 +22,6 @@ SUBSYSTEM_DEF(job)
 		SetupOccupations()
 	if(CONFIG_GET(flag/load_jobs_from_txt))
 		LoadJobs()
-	generate_selectable_species()
 	set_overflow_role(CONFIG_GET(string/overflow_job))
 	return ..()
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -377,7 +377,7 @@
 /mob/living/carbon/proc/create_dna()
 	dna = new /datum/dna(src)
 	if(!dna.species)
-		var/rando_race = pick(GLOB.roundstart_races)
+		var/rando_race = pick(get_roundstart_species())
 		dna.species = new rando_race()
 
 //proc used to update the mob's appearance after its dna UI has been changed

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -605,7 +605,7 @@ What a mess.*/
 							active1.fields["age"] = t1
 					if("species")
 						if(istype(active1, /datum/data/record))
-							var/t1 = input("Select a species", "Species Selection") as null|anything in GLOB.selectable_races
+							var/t1 = input("Select a species", "Species Selection") as null|anything in get_selectable_species()
 							if(!canUseSecurityRecordsConsole(usr, t1, a1))
 								return
 							active1.fields["species"] = t1
@@ -844,7 +844,7 @@ What a mess.*/
 				if(6)
 					R.fields["m_stat"] = pick("*Insane*", "*Unstable*", "*Watch*", "Stable")
 				if(7)
-					R.fields["species"] = pick(GLOB.roundstart_races)
+					R.fields["species"] = pick(get_roundstart_species())
 				if(8)
 					var/datum/data/record/G = pick(GLOB.data_core.general)
 					R.fields["photo_front"] = G.fields["photo_front"]

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -166,7 +166,7 @@ GLOBAL_LIST_EMPTY(las_mirrors)
 	..()
 
 /obj/structure/mirror/magic/lesser/New()
-	choosable_races = GLOB.roundstart_races.Copy()
+	choosable_races = get_roundstart_species().Copy()
 	..()
 
 /obj/structure/mirror/magic/badmin/New()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2245,10 +2245,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 					var/list/archetypes = list()
 					for(var/i in subtypesof(/datum/archetype))
-						archetypes += i
+						var/datum/archetype/the_archetype = i
+						archetypes[initial(the_archetype.name)] = i
 					var/result = tgui_input_list(user, "Select an archetype", "Attributes Selection", sortList(archetypes))
 					if(result)
-						archetype = result
+						archetype = archetypes[result]
 						var/datum/archetype/archetip = new archetype()
 						physique = archetip.start_physique
 						dexterity = archetip.start_dexterity

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -285,12 +285,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	headshot_link = null // TFN EDIT
 	save_character()
 
-/proc/reset_shit(mob/M)
-	if(M.key)
-		var/datum/preferences/P = GLOB.preferences_datums[ckey(M.key)]
-		if(P)
-			P.reset_character()
-
 /datum/preferences/New(client/C)
 	parent = C
 
@@ -311,7 +305,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	//we couldn't load character data so just randomize the character appearance + name
 	random_species()
 	random_character()		//let's create a random character then - rather than a fat, bald and naked man.
-	reset_shit(C?.mob)
 	key_bindings = deepCopyList(GLOB.hotkey_keybinding_list_by_key) // give them default keybinds and update their movement keys
 	C?.set_macros()
 //	pref_species = new /datum/species/kindred()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2457,7 +2457,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						return
 
 					var/list/choose_species = list()
-					for (var/key in GLOB.selectable_races)
+					for (var/key in get_selectable_species())
 						var/newtype = GLOB.species_list[key]
 						var/datum/species/selecting_species = new newtype
 						if (!selecting_species.selectable)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -325,6 +325,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		return coolfont
 
 /datum/preferences/proc/ShowChoices(mob/user)
+	if(!SSatoms.initialized)
+		to_chat(user, span_warning("Please wait for the game to do a little more setup first...!"))
+		return TRUE
 	if(slot_randomized)
 		load_character(default_slot) // Reloads the character slot. Prevents random features from overwriting the slot if saved.
 		slot_randomized = FALSE
@@ -542,8 +545,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						gifts_text += "[ACT.name].<BR>"
 					qdel(ACT)
 				dat += "<b>Initial Gifts:</b> [gifts_text]"
-				var/mob/living/carbon/werewolf/crinos/DAWOF = new(get_turf(parent.mob))
-				var/mob/living/carbon/werewolf/lupus/DAWOF2 = new(get_turf(parent.mob))
+				// These mobs should be made in nullspace to avoid dumping them onto the map somewhere.
+				var/mob/living/carbon/werewolf/crinos/DAWOF = new
+				var/mob/living/carbon/werewolf/lupus/DAWOF2 = new
 
 				DAWOF.sprite_color = werewolf_color
 				DAWOF2.sprite_color = werewolf_color
@@ -2662,7 +2666,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference", UI_style)  as null|anything in sortList(GLOB.available_ui_styles)
 					if(pickedui)
 						UI_style = pickedui
-						if (parent && parent.mob && parent.mob.hud_used)
+						if (parent?.mob?.hud_used)
 							parent.mob.hud_used.update_ui_style(ui_style2icon(UI_style))
 				if("pda_style")
 					var/pickedPDAStyle = input(user, "Choose your PDA style.", "Character Preference", pda_style)  as null|anything in GLOB.pda_styles
@@ -2945,17 +2949,17 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("parallaxup")
 					parallax = WRAP(parallax + 1, PARALLAX_INSANE, PARALLAX_DISABLE + 1)
-					if (parent && parent.mob && parent.mob.hud_used)
+					if (parent?.mob?.hud_used)
 						parent.mob.hud_used.update_parallax_pref(parent.mob)
 
 				if("parallaxdown")
 					parallax = WRAP(parallax - 1, PARALLAX_INSANE, PARALLAX_DISABLE + 1)
-					if (parent && parent.mob && parent.mob.hud_used)
+					if (parent?.mob?.hud_used)
 						parent.mob.hud_used.update_parallax_pref(parent.mob)
 
 				if("ambientocclusion")
 					ambientocclusion = !ambientocclusion
-					if(parent?.screen && parent.screen.len)
+					if(length(parent?.screen))
 						var/atom/movable/screen/plane_master/game_world/PM = locate(/atom/movable/screen/plane_master/game_world) in parent.screen
 						PM.backdrop(parent.mob)
 

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -44,7 +44,7 @@
 	if(randomise[RANDOM_EYE_COLOR])
 		eye_color = random_eye_color()
 	if(!pref_species)
-		var/rando_race = pick(GLOB.roundstart_races)
+		var/rando_race = pick(get_roundstart_species())
 		pref_species = new rando_race()
 	features = random_features()
 	if(gender in list(MALE, FEMALE))
@@ -53,7 +53,7 @@
 		body_type = pick(MALE, FEMALE)
 
 /datum/preferences/proc/random_species()
-	var/random_species_type = GLOB.species_list[pick(GLOB.roundstart_races)]
+	var/random_species_type = GLOB.species_list[pick(get_roundstart_species())]
 	pref_species = new random_species_type
 	if(randomise[RANDOM_NAME])
 		real_name = pref_species.random_name(gender,1)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -125,6 +125,8 @@
 		available_hardcore_quirks -= picked_quirk
 
 /datum/preferences/proc/update_preview_icon()
+	if(!parent) // If we don't have anyone to show, don't waste our time making a preview
+		return
 	// Determine what job is marked as 'High' priority, and dress them up as such.
 	var/datum/job/previewJob
 	var/highest_pref = 0

--- a/code/modules/mob/living/brain/brain.dm
+++ b/code/modules/mob/living/brain/brain.dm
@@ -24,7 +24,7 @@
 /mob/living/brain/proc/create_dna()
 	stored_dna = new /datum/dna/stored(src)
 	if(!stored_dna.species)
-		var/rando_race = pick(GLOB.roundstart_races)
+		var/rando_race = pick(get_roundstart_species())
 		stored_dna.species = new rando_race()
 
 /mob/living/brain/Destroy()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -232,6 +232,18 @@ GLOBAL_LIST_EMPTY(selectable_races)
 		GLOB.roundstart_races += "kindred"
 	*/
 
+/proc/get_roundstart_species()
+	RETURN_TYPE(/list)
+	if(!length(GLOB.roundstart_races))
+		generate_selectable_species()
+	return GLOB.roundstart_races
+
+/proc/get_selectable_species()
+	RETURN_TYPE(/list)
+	if(!length(GLOB.selectable_races))
+		generate_selectable_species()
+	return GLOB.selectable_races
+
 /**
  * Checks if a species is eligible to be picked at roundstart.
  *

--- a/code/modules/mob/living/carbon/werewolf/transformation.dm
+++ b/code/modules/mob/living/carbon/werewolf/transformation.dm
@@ -1,3 +1,5 @@
+// this is evil
+// todo: use a datum or something instead lol
 /obj/werewolf_holder/transformation
 	var/mob/living/carbon/human/human_form
 	var/mob/living/carbon/werewolf/crinos/crinos_form
@@ -6,6 +8,10 @@
 	var/transformating = FALSE
 	var/given_quirks = FALSE
 
+// we should really initialize on creation always
+// if this were a datum we'd just use New()
+// but since it's an atom subtype we have to use INITIALIZE_IMMEDIATE
+INITIALIZE_IMMEDIATE(/obj/werewolf_holder/transformation)
 /obj/werewolf_holder/transformation/Initialize()
 	. = ..()
 	crinos_form = new()


### PR DESCRIPTION
## About The Pull Request
`reset_shit()` is entirely useless so I cut it. It attempts to call `reset_character()` on a ckey's preferences datum, but it's called *when creating a new preferences datum,* so it will always fail to fetch one (a new datum is only created if one doesn't exist in `GLOB.preferences_datums`) which makes it pointless. If it *did* fetch one, it'd be the one that called `reset_shit()`, and `reset_character()` is already called for it on the line before `reset_shit()`, so it wouldn't even work if it *did* work. Funny, that.

Prevents running ShowChoices prior to SSatoms init because that can cause a bunch of bugs. It just warns you to try again after the game has done just a little more setup.
Fixes issues with loading prefs with a werewolf character selected prior to SSatoms init.

Fixes a runtime if the client for a preferences datum disconnects mid-preview-creation. Adds a bunch of null `parent` guards to hopefully prevent that from cropping up elsewhere.

Makes archetype selection show the name instead of the typepath. Hooray!

## Why It's Good For The Game
Fixes some issues with preferences.
Makes archetype selection use the actual names rather than the typepaths.

## Testing Photographs and Procedure
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/38d01577-9465-49ef-b407-487cf8dc866c)
![image](https://github.com/user-attachments/assets/6f3a1e88-b597-48f8-9a62-960cccac5cf9)

</details>

## Changelog

:cl:
qol: archetype selection now shows the archetype name rather than the internal typepath
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
