### PR TITLE
makes the Dancer quirk work

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -218,11 +218,10 @@ Dancer
 	if(last_added_humanity+6000 < world.time)
 		for(var/obj/machinery/jukebox/J in range(7, owner))
 			if(J)
-				if(J.active)
-					if(ishuman(owner))
-						var/mob/living/carbon/human/human = owner
-						human.AdjustHumanity(1, 8)
-						last_added_humanity = world.time
+				if(ishuman(owner))
+					var/mob/living/carbon/human/human = owner
+					human.AdjustHumanity(1, 8)
+					last_added_humanity = world.time
 
 /datum/quirk/dwarf
 	name = "Dwarf"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The Dancer quirk, when used near a jukebox, raises your humanity by 1 (up to 8) on a long cooldown. Except it doesn't, because it requires the jukebox to be active, and they don't currently work on the live server. This removes the check of whether the jukebox is active and lets you dance near an inactive one.

## Why It's Good For The Game

Humanity gamers are already having a harder time than Enlightenment users, please throw us a bone 

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:
qol: the Dancer quirk no longer requires the jukebox nearby to be on in order to restore Humanity
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
