### PR TITLE
As #27, (Kiai Rework) but rebased to current codebase

### DIFF
--- a/code/modules/vtmb/chi_disciplines.dm
+++ b/code/modules/vtmb/chi_disciplines.dm
@@ -152,7 +152,7 @@
 	if(target.stat == DEAD && dead_restricted)
 		return FALSE
 
-	if(target.resistant_to_disciplines)
+	if(target.resistant_to_disciplines || target.spell_immunity)
 		to_chat(caster, "<span class='danger'>[target] resists your powers!</span>")
 		return FALSE
 
@@ -417,9 +417,11 @@
 		if(3)
 			ADD_TRAIT(caster, TRAIT_PASS_THROUGH_WALLS, "jade shintai 3")
 			caster.alpha = 128
+			caster.obfuscate_level = 3
 			caster.add_movespeed_modifier(/datum/movespeed_modifier/wall_passing)
 			spawn(delay+caster.discipline_time_plus)
 				if(caster)
+					caster.obfuscate_level = 0
 					caster.alpha = 255
 					REMOVE_TRAIT(caster, TRAIT_PASS_THROUGH_WALLS, "jade shintai 3")
 					caster.remove_movespeed_modifier(/datum/movespeed_modifier/wall_passing)
@@ -986,6 +988,9 @@
 /datum/movespeed_modifier/tentacles1
 	multiplicative_slowdown = -0.5
 
+/datum/movespeed_modifier/kiai
+	multiplicative_slowdown = -0.3
+
 /datum/movespeed_modifier/demonform1
 	multiplicative_slowdown = -0.5
 /datum/movespeed_modifier/demonform2
@@ -1196,7 +1201,7 @@
 			target.clear_fullscreen("yomi", 5)
 			if(ishuman(target))
 				var/mob/living/carbon/human/human_target = target
-				var/datum/cb = CALLBACK(human_target, TYPE_PROC_REF(/mob/living/carbon/human, attack_myself_command))
+				var/datum/cb = CALLBACK(human_target, /mob/living/carbon/human/proc/attack_myself_command)
 				for(var/i in 1 to 20)
 					addtimer(cb, (i - 1) * 1.5 SECONDS)
 				target.emote("scream")
@@ -1264,43 +1269,64 @@
 			sound_gender = 'code/modules/wod13/sounds/kiai_male.ogg'
 		if(FEMALE)
 			sound_gender = 'code/modules/wod13/sounds/kiai_female.ogg'
-	caster.emote("scream")
 	playsound(caster.loc, sound_gender, 100, FALSE)
+	caster.visible_message("<span class='danger'>[caster] SCREAMS!</span>")
 	var/mypower = caster.get_total_social()
-	var/theirpower = caster.get_total_mentality()
-	if(theirpower >= mypower)
-		to_chat(caster, "<span class='warning'>[target]'s mind is too powerful to affect!</span>")
-		return
+	var/theirpower = target.get_total_mentality()
+	var/total_power = 1 //The proportion of your Social to their Mentality. Higher social means higher total_power and higher effect. If this is 1 or more, our social is at least as high as their mentality
 	switch(level_casting)
 		if(1)
-			target.emote(pick("shiver", "pale"))
-			target.Stun(2 SECONDS)
+			caster.physique += 2
+			caster.dexterity += 2
+			caster.athletics += 2
+			caster.add_movespeed_modifier(/datum/movespeed_modifier/kiai)
+			ADD_TRAIT(caster, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
+			caster.do_jitter_animation(1 SECONDS)
+			spawn(delay+caster.discipline_time_plus)
+				if(caster)
+					caster.physique -= 2
+					caster.dexterity -= 2
+					caster.athletics -= 2
+					caster.remove_movespeed_modifier(/datum/movespeed_modifier/kiai)
+					REMOVE_TRAIT(caster, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
 		if(2)
-			target.emote("stare")
-			if(ishuman(target))
-				var/mob/living/carbon/human/human_target = target
-				var/datum/cb = CALLBACK(human_target, TYPE_PROC_REF(/mob/living/carbon/human, combat_to_caster))
-				for(var/i in 1 to 20)
-					addtimer(cb, (i - 1) * 1.5 SECONDS)
+			for(var/mob/living/carbon/hearer in ohearers(2, caster))
+				total_power = mypower / hearer.get_total_mentality()
+				step_away(hearer, caster)
+				hearer.apply_effect(total_power * 2, EFFECT_EYE_BLUR)
+				if(total_power >= 1)
+					hearer.apply_effect(total_power * 0.2 SECONDS, EFFECT_STUN)
 		if(3)
-			target.emote("scream")
-			if(ishuman(target))
-				var/mob/living/carbon/human/human_target = target
-				var/datum/cb = CALLBACK(human_target, TYPE_PROC_REF(/mob/living/carbon/human, step_away_caster))
-				for(var/i in 1 to 20)
-					addtimer(cb, (i - 1) * 1.5 SECONDS)
+			total_power = mypower / theirpower
+			step_away(target, caster)
+			if(total_power > 1)
+				target.apply_effect(total_power * 0.2 SECONDS, EFFECT_KNOCKDOWN)
+			if(mypower >= (theirpower - 2))
+				target.do_jitter_animation(1 SECONDS)
+				new /datum/hallucination/fire(target, TRUE)
 		if(4)
-			if(prob(25))
-				target.resist_fire()
-			new /datum/hallucination/fire(target, TRUE)
+			var/target_phys = target.get_total_physique()
+			target.add_splatter_floor(get_turf(target))
+			target.add_splatter_floor(get_turf(get_step(target, caster.dir)))
+			switch(vampireroll(mypower, target_phys))
+				if(DICE_WIN, DICE_CRIT_WIN)
+					target.apply_damage(5*mypower, BRUTE)
+					target.apply_damage(2*mypower, CLONE)
+					target.visible_message("<span class='danger'>[target]'s flesh tears!</span>", "<span class='userdanger'>[caster]'s scream rips the flesh from your bones!</span>")
+				if(DICE_FAILURE, DICE_CRIT_FAILURE)
+					target.apply_damage(3*mypower, BRUTE)
+					target.visible_message("<span class='danger'>Bleeding wounds open up on [target]!</span>", "<span class='userdanger'>[caster]'s scream tears at your flesh!</span>")
 		if(5)
-			if(prob(25))
-				target.resist_fire()
-			new /datum/hallucination/fire(target, TRUE)
-			for(var/mob/living/hallucinating_mob in (oviewers(5, target) - caster))
-				if(prob(20))
-					hallucinating_mob.resist_fire()
-				new /datum/hallucination/fire(hallucinating_mob, TRUE)
+			for(var/mob/living/carbon/hearer in ohearers(5, caster))
+				theirpower = hearer.get_total_mentality()
+				total_power = (mypower - 2) / theirpower //same as dot 3, but your power is treated as 2 points lower for determining the effects)
+				step_away(hearer, caster)
+				if(total_power > 1)
+					hearer.apply_effect(total_power * 0.2 SECONDS, EFFECT_KNOCKDOWN)
+					hearer.visible_message("<span class='danger'>[target] is knocked to the floor!</span>", "<span class='userdanger'>[caster]'s scream knocks you off your feet!</span>")
+				if(mypower >= theirpower)
+					hearer.do_jitter_animation(1 SECONDS)
+					new /datum/hallucination/fire(target, TRUE)
 
 /datum/chi_discipline/beast_shintai
 	name = "Beast Shintai"
@@ -2157,8 +2183,10 @@
 	switch(level_casting)
 		if(1)
 			animate(caster, alpha = 10, time = 1 SECONDS)
+			caster.obfuscate_level = 3
 			spawn(delay+caster.discipline_time_plus)
 				if(caster)
+					caster.obfuscate_level = 0
 					if(caster.alpha != 255)
 						caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/obfuscate_deactivate.ogg', 50, FALSE)
 						caster.alpha = 255

--- a/code/modules/vtmb/chi_disciplines.dm
+++ b/code/modules/vtmb/chi_disciplines.dm
@@ -1306,7 +1306,7 @@
 			var/target_phys = target.get_total_physique()
 			target.add_splatter_floor(get_turf(target))
 			target.add_splatter_floor(get_turf(get_step(target, caster.dir)))
-			switch(vampireroll(mypower, target_phys))
+			switch(vampireroll(mypower, target_phys + 3))
 				if(DICE_WIN, DICE_CRIT_WIN)
 					target.apply_damage(5*mypower, BRUTE)
 					target.apply_damage(2*mypower, CLONE)

--- a/code/modules/vtmb/chi_disciplines.dm
+++ b/code/modules/vtmb/chi_disciplines.dm
@@ -152,7 +152,7 @@
 	if(target.stat == DEAD && dead_restricted)
 		return FALSE
 
-	if(target.resistant_to_disciplines || target.spell_immunity)
+	if(target.resistant_to_disciplines)
 		to_chat(caster, "<span class='danger'>[target] resists your powers!</span>")
 		return FALSE
 
@@ -417,11 +417,9 @@
 		if(3)
 			ADD_TRAIT(caster, TRAIT_PASS_THROUGH_WALLS, "jade shintai 3")
 			caster.alpha = 128
-			caster.obfuscate_level = 3
 			caster.add_movespeed_modifier(/datum/movespeed_modifier/wall_passing)
 			spawn(delay+caster.discipline_time_plus)
 				if(caster)
-					caster.obfuscate_level = 0
 					caster.alpha = 255
 					REMOVE_TRAIT(caster, TRAIT_PASS_THROUGH_WALLS, "jade shintai 3")
 					caster.remove_movespeed_modifier(/datum/movespeed_modifier/wall_passing)
@@ -2183,10 +2181,8 @@
 	switch(level_casting)
 		if(1)
 			animate(caster, alpha = 10, time = 1 SECONDS)
-			caster.obfuscate_level = 3
 			spawn(delay+caster.discipline_time_plus)
 				if(caster)
-					caster.obfuscate_level = 0
 					if(caster.alpha != 255)
 						caster.playsound_local(caster.loc, 'code/modules/wod13/sounds/obfuscate_deactivate.ogg', 50, FALSE)
 						caster.alpha = 255


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

blah blah, #27 is testmergeable but needs rebasing, i'm doing it through brute force

[Kiai](https://whitewolf.fandom.com/wiki/Kiai) is a Kuei-jin discipline available in-game. This PR replaces almost all its abilities, using some new methods for determining the effect of mental disciplines (I'll go into that in a sec). This is also kind of an experiment in testing two ways mental disciplines can be more interesting for both sides than a plain, predetermined pass/fail. Several abilities scale with the variable "total_power", which is _your_ effective Social stat divided by _the target's_ effective Mentality. This means that even if your target doesn't have a high enough Mentality to resist the main effect, the dots they _do_ have will still matter in determining the severity of the effect. 
The 5 dots:

1. A temporary buff to your speed (-0.3 delay), physique, athletics and dexterity (+2), and slowdown immunity. _"This power allows the Kuei-jin to bring his body, mind, and souls into focus in one brief, transcendent moment marked by a loud shout."_
2. Enemies within short range (2 tiles) have their vision blurred for a scaling duration. _If_ your Total Power is at least 1 (i.e. your Social is at least as high as their Mentality) they are stunned for 0.2-1.6 seconds, depending on your Total Power. _"The Kuei-jin can irritate his opponent in hand-to-hand combat"_
3. One targeted enemy is pushed back a single tile. If your Total Power is more than 1 (i.e. your Social is **higher** than their Mentality) they are knocked down for a scaling duration; if their Mentality is _no more than 2 higher than_ your Social, they hallucinate that they're burning. _"the Kuei-jin can let loose an intimidating scream that sends his opponent running for his life"_
4. This is an experiment with a different method, where there's a scaling benefit recieved from raising your social. You roll* with X = your Social, and Y = the target's physique. On a failed roll, you deal 3 brute damage per point of social. On a successful roll, you deal 5 brute and 2 clone damage per point of social. This is technically a 6 dot ability in canon, but... shush, it's cool to flense flesh from bone with a demon-scream.
5. As 3, but it targets everyone within 5 tiles, and your Social stat is treated as being 2 points lower for all calculations.

*The vampireroll() proc rolls X number of dice (first argument), requiring at least one roll of Y (second argument) or more to succeed. See code\modules\wod13\procs.dm line 203.

## Why It's Good For The Game

Kiai feels like a neutered Presence at the moment. Its implementation isn't particularly interesting, nor does it live up to the way the way the discipline works in canon. There's also been plenty of discourse over the rocket-tag nature of mental disciplines right now, so I decided to use this as a test of different methods that could be more engaging for the players involved.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: completely reworks the kiai discipline to include self-buffing, damaging and knockback abilities
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
