### PR TITLE
Caps Garou passive rage gain at 7, makes them lose it during Frenzy

### DIFF
--- a/code/modules/mob/living/carbon/werewolf/life.dm
+++ b/code/modules/mob/living/carbon/werewolf/life.dm
@@ -43,7 +43,7 @@
 			//	transformator.trans_gender(src, auspice.base_breed)
 
 			if(gaining_rage && client)
-				if((last_rage_gain + 1 MINUTES) < world.time)
+				if(((last_rage_gain + 1 MINUTES) < world.time) && (auspice.rage <= 6))
 					last_rage_gain = world.time
 					adjust_rage(1, src, TRUE)
 

--- a/code/modules/vtmb/frenzy.dm
+++ b/code/modules/vtmb/frenzy.dm
@@ -58,6 +58,7 @@
 	in_frenzy = TRUE
 	add_client_colour(/datum/client_colour/glass_colour/red)
 	demon_chi = 0
+	adjust_rage(-10, src, TRUE)
 	GLOB.frenzy_list += src
 
 /mob/living/carbon/proc/exit_frenzymod()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Caps passive Rage (what you get every one minute anytime you're out of your breed form) at 7. Frenzy rolls proc at 9+, for reference.
Frenzying removes all your rage. Does not prevent you from gaining it back during or after the Frenzy.


## Why It's Good For The Game

Makes it easier for Metis and Lupus players to roleplay in the predominantly-used Homid form. A few bad grabs can still push them over the edge if they don't pay attention. Losing Rage during Frenzy makes it harder to heal and spam Gifts while under it, and a riskier gambit overall.
You can still easily on-demand Frenzy by grabbing/attacking yourself and howling while at the limit. Ideally, the whole thing could be reworked to not be a noobtrap or an anti-fun 1v1 Crinos crutch, but it's out of my skill level.

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="402" alt="showcase1" src="https://github.com/user-attachments/assets/b3ba4292-a23c-4253-94a9-67b2d6b706dd" />
<img width="332" alt="showcase2" src="https://github.com/user-attachments/assets/60c4bff3-6255-4f0a-bee7-6d36b2f63273" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Garou passive rage gain capped at 7
add: Frenzying Garou drop Rage to 0
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
