### PR TITLE
allows werewolves to see their bank accounts. be free.

### DIFF
--- a/code/modules/vtmb/werewolf_species.dm
+++ b/code/modules/vtmb/werewolf_species.dm
@@ -93,6 +93,11 @@
 			dat += "<b>I know some other of my kind in this city. Need to check my phone, there definetely should be:</b><BR>"
 			for(var/i in host.knowscontacts)
 				dat += "-[i] contact<BR>"
+		if(istype(host, /mob/living/carbon/human))
+			var/mob/living/carbon/human/H = host
+			for(var/datum/vtm_bank_account/account in GLOB.bank_account_list)
+				if(H.bank_id == account.bank_id)
+					dat += "<b>My bank account code is: [account.code]</b><BR>"
 		host << browse(dat, "window=vampire;size=400x450;border=1;can_resize=1;can_minimize=0")
 		onclose(host, "vampire", src)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

allows garou to see their bank accounts when homid.

## Why It's Good For The Game

maybe endron shouldn't be broke. nor should the tech store. maybe werewolves do have money.

## Changelog

:cl: Yinadele
fix: Werewolves can now see their bank account.
/:cl: