### PR TITLE
Werewolf Gifts Cooldown Timer Var (and bugfix)

### DIFF
--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -300,7 +300,7 @@
 	button_icon_state = "blur_of_the_milky_eye"
 	rage_req = 2
 	//gnosis_req = 1
-	cool_down_timer = 200
+	cool_down_timer = 20 SECONDS
 
 /datum/action/gift/blur_of_the_milky_eye/Trigger()
 	. = ..()

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -266,7 +266,7 @@
 	desc = "This Gift allows the werewolf to sense the presence of Wyrm."
 	button_icon_state = "sense_wyrm"
 	rage_req = 1
-	cool_down_timer = 200
+	cool_down_timer = 20 SECONDS
 
 /datum/action/gift/sense_wyrm/Trigger()
 	. = ..()

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -284,7 +284,7 @@
 	desc = "This Gift allows the Garou to communicate with encountered spirits."
 	button_icon_state = "spirit_speech"
 	//gnosis_req = 1
-	cool_down_timer = 200
+	cool_down_timer = 20 SECONDS
 
 /datum/action/gift/spirit_speech/Trigger()
 	. = ..()

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -5,6 +5,7 @@
 	var/rage_req = 0
 	var/gnosis_req = 0
 	var/cool_down = 0
+	var/cool_down_timer = 150
 
 	var/allowed_to_proceed = FALSE
 
@@ -31,7 +32,7 @@
 				SEND_SOUND(owner, sound('code/modules/wod13/sounds/werewolf_cast_failed.ogg', 0, 0, 75))
 				allowed_to_proceed = FALSE
 				return
-		if(cool_down+150 >= world.time)
+		if(cool_down+cool_down_timer >= world.time)
 			allowed_to_proceed = FALSE
 			return
 		cool_down = world.time
@@ -231,6 +232,7 @@
 	button_icon_state = "scent_of_the_true_form"
 	rage_req = 1
 	//gnosis_req = 1
+	cool_down_timer = 200
 
 /datum/action/gift/scent_of_the_true_form/Trigger()
 	. = ..()
@@ -264,6 +266,7 @@
 	desc = "This Gift allows the werewolf to sense the presence of Wyrm."
 	button_icon_state = "sense_wyrm"
 	rage_req = 1
+	cool_down_timer = 200
 
 /datum/action/gift/sense_wyrm/Trigger()
 	. = ..()
@@ -281,6 +284,7 @@
 	desc = "This Gift allows the Garou to communicate with encountered spirits."
 	button_icon_state = "spirit_speech"
 	//gnosis_req = 1
+	cool_down_timer = 200
 
 /datum/action/gift/spirit_speech/Trigger()
 	. = ..()
@@ -296,6 +300,7 @@
 	button_icon_state = "blur_of_the_milky_eye"
 	rage_req = 2
 	//gnosis_req = 1
+	cool_down_timer = 200
 
 /datum/action/gift/blur_of_the_milky_eye/Trigger()
 	. = ..()

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -232,7 +232,7 @@
 	button_icon_state = "scent_of_the_true_form"
 	rage_req = 1
 	//gnosis_req = 1
-	cool_down_timer = 200
+	cool_down_timer = 20 SECONDS
 
 /datum/action/gift/scent_of_the_true_form/Trigger()
 	. = ..()

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -5,7 +5,7 @@
 	var/rage_req = 0
 	var/gnosis_req = 0
 	var/cool_down = 0
-	var/cool_down_timer = 150
+	var/cool_down_timer = 15 SECONDS
 
 	var/allowed_to_proceed = FALSE
 

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -185,7 +185,7 @@
 	button_icon_state = "elemental_improvement"
 	rage_req = 2
 	gnosis_req = 1
-	cool_down_timer = 200
+	cool_down_timer = 20 SECONDS
 
 /datum/action/gift/elemental_improvement/Trigger()
 	. = ..()

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -38,7 +38,7 @@
 	button_icon_state = "freezing_wind"
 	rage_req = 1
 	//gnosis_req = 1
-	cool_down_timer = 200
+	cool_down_timer = 20 SECONDS
 
 /datum/action/gift/freezing_wind/Trigger()
 	. = ..()

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -38,6 +38,7 @@
 	button_icon_state = "freezing_wind"
 	rage_req = 1
 	//gnosis_req = 1
+	cool_down_timer = 200
 
 /datum/action/gift/freezing_wind/Trigger()
 	. = ..()
@@ -184,6 +185,7 @@
 	button_icon_state = "elemental_improvement"
 	rage_req = 2
 	gnosis_req = 1
+	cool_down_timer = 200
 
 /datum/action/gift/elemental_improvement/Trigger()
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Improves functionality of Freezing Wind, Elemental Improvement, Scent of the True Form, Sense Wyrm, Spirit Speech, and Blur of the Milky Eye Werewolf Gifts

They lasted 20 seconds but had a CD of 15 seconds; if you used them before the first one wore off, they'd end early and cost you the full thing. Now, their CD is 20 seconds. This fixes the problem.

Allows editing of individual Gift cooldowns by adding "cool_down_timer" var (default 15 seconds)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Every Gift having a CD of 15 seconds caused problems. Now all Gift CDs can be changed if necessary

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/bb6b09e8-6f79-4847-aa11-469010e27e1d

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: plague
fix: Affected Gifts (Freezing Wind, Elemental Improvement, Scent of the True Form, Sense Wyrm, Spirit Speech, and Blur of the Milky Eye) have 20s cooldowns now
code: Werewolf Gift cooldowns can be changed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
