### PR TITLE
Humanity Loss Changes - (This PR Makes Humanity Babymode)

### DIFF
--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -232,7 +232,7 @@
 					SEND_SOUND(src, sound('code/modules/wod13/sounds/feed_failed.ogg', 0, 0, 75))
 					to_chat(src, "<span class='warning'>This sad sacrifice for your own pleasure affects something deep in your mind.</span>")
 					AdjustMasquerade(-1)
-					SEND_SIGNAL(src, COMSIG_PATH_HIT, PATH_SCORE_DOWN)
+					SEND_SIGNAL(src, COMSIG_PATH_HIT, 3)
 					mob.death()
 			if(!ishuman(mob))
 				if(mob.stat != DEAD)

--- a/code/modules/wod13/lombard.dm
+++ b/code/modules/wod13/lombard.dm
@@ -54,8 +54,7 @@
 			return
 
 	if(istype(W, /obj/item/organ))
-		to_chat(H, span_userdanger("<b>Selling organs is a depraved act... If I keep doing this, I will become a wight!</b>"))
-		SEND_SIGNAL(H, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 0)
+		SEND_SIGNAL(H, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 3)
 	else if(istype(W, /obj/item/reagent_containers/food/drinks/meth/cocaine))
 		SEND_SIGNAL(H, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 5)
 	else if(istype(W, /obj/item/reagent_containers/food/drinks/meth))

--- a/code/modules/wod13/lombard.dm
+++ b/code/modules/wod13/lombard.dm
@@ -58,7 +58,7 @@
 	else if(istype(W, /obj/item/reagent_containers/food/drinks/meth/cocaine))
 		SEND_SIGNAL(H, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 5)
 	else if(istype(W, /obj/item/reagent_containers/food/drinks/meth))
-		SEND_SIGNAL(H, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 4)
+		SEND_SIGNAL(H, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 5)
 	else if(illegal)
 		SEND_SIGNAL(H, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 7)
 

--- a/code/modules/wod13/npc_movement.dm
+++ b/code/modules/wod13/npc_movement.dm
@@ -45,7 +45,7 @@
 			if(istype(last_attacker, /mob/living/simple_animal/hostile))
 				var/mob/living/simple_animal/hostile/HS = last_attacker
 				if(HS.my_creator)
-					SEND_SIGNAL(HS.my_creator, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 0)
+					SEND_SIGNAL(HS.my_creator, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 3)
 					HS.my_creator.last_nonraid = world.time
 					HS.my_creator.killed_count = HS.my_creator.killed_count+1
 					if(!HS.my_creator.warrant && !HS.my_creator.ignores_warrant)

--- a/code/modules/wod13/npc_movement.dm
+++ b/code/modules/wod13/npc_movement.dm
@@ -60,7 +60,7 @@
 			else
 				if(ishuman(last_attacker))
 					var/mob/living/carbon/human/HM = last_attacker
-					SEND_SIGNAL(HM, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 0)
+					SEND_SIGNAL(HM, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 3)
 					HM.last_nonraid = world.time
 					HM.killed_count = HM.killed_count+1
 					if(!HM.warrant && !HM.ignores_warrant)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This PR changes humanity loss so that most humanity draining actions only lower it down to a certain point.
This means that murder and organ sales will only lower your humanity to 3 at most, but completely heinous acts committed because of self-abasement or pure, purposeless malice will still lower it down to zero. It's kind of like how it is in VtM:B

It's meant to kind of be in line with the hierarchy of sins where you really do have to do something incredibly heinous to full on wassail. 
https://whitewolf.fandom.com/wiki/Humanity_(VTM)#Hierarchy_of_Sins


I get the feeling this is kind of a controversial change/suggestion. It's also a really trivial change, so there's not really much more to say here. 


I also made selling meth only lower you down to 5, since that's however much selling cocaine dips you. I don't think they're actually that different morally, so I don't think it's any harm done. 
## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

I've seen people complain about humanity a lot in the discord, and a lot of the npc elder characters in the clanbooks tend to hover at around 3 humanity or so even after doing a lot of things that would get you to wassail in The Final Nights.
For example: https://whitewolf.fandom.com/wiki/Enver_Frasheri
Enver Frasheri is a toreador that enjoys using protean to turn himself into a wolf and kill/feed on people in incredibly sadistic ways, nonetheless, he maintains his humanity at 3, presumably because he does in fact do this to feed and the sheer cruelty of the methods he employs presumably tickles his sadistic desires in such a way that only a human ever could, and not a sort of proto-ID whose only goals are drinking blood and surviving another night. 

## Testing

Humanity loss from organ sales does in fact stop at 3.

![HumLoss](https://github.com/user-attachments/assets/64bdaaa9-6452-4cd8-b204-ba4530e5a3f1)


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: It's easier to sit at low humanity now at the cost of permanently teetering on the edge of frenzy. Completely depraved acts will still wassail you. 
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
