### PR TITLE
Paperwork Crate

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -65,6 +65,15 @@
 	contains = list(/obj/item/melee/vampirearms/tire)
 	crate_name = "weapon crate"
 
+/datum/supply_pack/vampire/paperwork
+	name = "Paperwork Kit"
+	desc = "Contains all your writing needs."
+	cost = 100
+	contains = list(
+		/obj/item/paper_bin,
+		/obj/item/pen = 5,)
+	crate_name = "paperwork crate"
+
 /datum/supply_pack/vampire/cuffs
 	name = "Box of Handcuffs"
 	desc = "Contains a box of handcuffs."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds a crate containing five pens and a paper bin to the supply depot console. Costs 100 dollars.

## Why It's Good For The Game

It's not easy to get more pens or paper without stealing them from other areas as it is currently. This would allow people to get more things to write on and with.

## Testing Photographs and Procedure

![p2](https://github.com/user-attachments/assets/0b145a2b-6f12-4d9f-b3f0-8f13e7982396)
![p1](https://github.com/user-attachments/assets/bc0abac1-bb5c-40a5-9b2f-ad434580cc2d)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added a crate containing pens and paper to the supply depot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
