### PR TITLE
Low Humanity's Visible on Examine - Testing Evidence Included

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -426,11 +426,11 @@
 			else
 				if(humanity <= 3)
 					msg += "<span class='danger'><b>[p_they(TRUE)] seem as still as a statue and [p_their()] chest does not rise with breath.</b></span><br>"
-				if(humanity <= 5)
+				else if(humanity <= 5)
 					msg += "[p_they(TRUE)] stare at people as they would a wolf and their prey.<br>"
-				if(humanity <= 8)
+				else if(humanity <= 8)
 					msg += "Glassy eyes which never blink or waver, a deadpan face which never rouses with emotion.<br>"
-				if(humanity <= 10)
+				else if(humanity <= 10)
 					msg += "Every twitch of [p_their()] muscles, every ripple of the faintest microexpression on their face exudes cold deliberation.<b>"
 
 		if(getorgan(/obj/item/organ/brain))

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -418,10 +418,10 @@
 					msg += "<span class='danger'><b>[p_they(TRUE)] [p_are()] a skeletonised corpse!</b></span><br>"
 			//Low humanity now makes you look ghoulish
 			if(!clane.enlightenment)
-				if(humanity <= 5)
-					msg += "[p_they(TRUE)] [p_have()] an eerie red tint in their eyes.<br>"
-				else if(humanity <= 3)
+				if(humanity <= 3)
 					msg += "<span class='danger'><b>Cold, grey skin, long jagged canines, hideously jaundiced eyes! [p_they(TRUE)] [p_are()] a monster!</b></span><br>"
+				else if(humanity <= 5)
+					msg += "[p_they(TRUE)] [p_have()] an eerie red tint in their eyes.<br>"
 
 		if(getorgan(/obj/item/organ/brain))
 			if(ai_controller?.ai_status == AI_STATUS_ON)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -419,7 +419,7 @@
 			//Low humanity now makes you look ghoulish
 			if(!clane.enlightenment)
 				if(humanity <= 3)
-					msg += "<span class='danger'><b>Cold, grey skin, long jagged canines, hideously jaundiced eyes! [p_they(TRUE)] [p_are()] a monster!</b></span><br>"
+					msg += "<span class='danger'><b>They seem sickly and malnourished.</b></span><br>"
 				else if(humanity <= 5)
 					msg += "[p_they(TRUE)] [p_have()] an eerie red tint in their eyes.<br>"
 			//Path of enlightenmentoids now seem inhuman at every step of the journey.

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -422,6 +422,16 @@
 					msg += "<span class='danger'><b>Cold, grey skin, long jagged canines, hideously jaundiced eyes! [p_they(TRUE)] [p_are()] a monster!</b></span><br>"
 				else if(humanity <= 5)
 					msg += "[p_they(TRUE)] [p_have()] an eerie red tint in their eyes.<br>"
+			//Path of enlightenmentoids now seem inhuman at every step of the journey.
+			else
+				if(humanity <= 3)
+					msg += "<span class='danger'><b>[p_they(TRUE)] seem as still as a statue and [p_their()] chest does not rise with breath.</b></span><br>"
+				if(humanity <= 5)
+					msg += "[p_they(TRUE)] stare at people as they would a wolf and their prey.<br>"
+				if(humanity <= 8)
+					msg += "Glassy eyes which never blink or waver, a deadpan face which never rouses with emotion.<br>"
+				if(humanity <= 10)
+					msg += "Every twitch of [p_their()] muscles, every ripple of the faintest microexpression on their face exudes cold deliberation.<b>"
 
 		if(getorgan(/obj/item/organ/brain))
 			if(ai_controller?.ai_status == AI_STATUS_ON)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -418,20 +418,18 @@
 					msg += "<span class='danger'><b>[p_they(TRUE)] [p_are()] a skeletonised corpse!</b></span><br>"
 			//Low humanity now makes you look ghoulish
 			if(!clane.enlightenment)
-				if(humanity <= 3)
-					msg += "<span class='danger'><b>They seem sickly and malnourished.</b></span><br>"
+				if(humanity <= 1)//The mandatory cryptid feature
+					msg += "<span class='danger'><b>Thin, jaundiced skin, gums as red as a ground cherry...</b></span><br>"
+				else if(humanity <= 3)
+					msg += "<span class='danger'>[p_their()] skin is a thin membrane, wrapped taut over bone.</span><br>"
 				else if(humanity <= 5)
-					msg += "[p_they(TRUE)] [p_have()] an eerie red tint in their eyes.<br>"
+					msg += "[p_they(TRUE)] seem sickly and malnourished.<br>"
 			//Path of enlightenmentoids now seem inhuman at every step of the journey.
 			else
 				if(humanity <= 3)
-					msg += "<span class='danger'><b>[p_they(TRUE)] seem as still as a statue and [p_their()] chest does not rise with breath.</b></span><br>"
+					msg += "[p_their()] eyes are dim, functuating to an unknown calculus.<br>"
 				else if(humanity <= 5)
-					msg += "[p_they(TRUE)] stare at people as they would a wolf and their prey.<br>"
-				else if(humanity <= 8)
-					msg += "Glassy eyes which never blink or waver, a deadpan face which never rouses with emotion.<br>"
-				else if(humanity <= 10)
-					msg += "Every twitch of [p_their()] muscles, every ripple of the faintest microexpression on their face exudes cold deliberation.<b>"
+					msg += "[p_their()] posture and movements are eerily controlled.<br>"
 
 		if(getorgan(/obj/item/organ/brain))
 			if(ai_controller?.ai_status == AI_STATUS_ON)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -416,6 +416,12 @@
 					msg += "<span class='danger'><b>[p_they(TRUE)] [p_are()] a decayed corpse!</b></span><br>"
 				if ("rotten4")
 					msg += "<span class='danger'><b>[p_they(TRUE)] [p_are()] a skeletonised corpse!</b></span><br>"
+			//Low humanity now makes you look ghoulish
+			if(!clane.enlightenment)
+				if(humanity <= 5)
+					msg += "[p_they(TRUE)] [p_have()] an eerie red tint in their eyes.<br>"
+				else if(humanity <= 3)
+					msg += "<span class='danger'><b>Cold, grey skin, long jagged canines, hideously jaundiced eyes! [p_they(TRUE)] [p_are()] a monster!</b></span><br>"
 
 		if(getorgan(/obj/item/organ/brain))
 			if(ai_controller?.ai_status == AI_STATUS_ON)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -421,15 +421,15 @@
 				if(humanity <= 1)//The mandatory cryptid feature
 					msg += "<span class='danger'><b>Thin, jaundiced skin, gums as red as a ground cherry...</b></span><br>"
 				else if(humanity <= 3)
-					msg += "<span class='danger'>[p_their()] skin is a thin membrane, wrapped taut over bone.</span><br>"
+					msg += "<span class='danger'>[p_their(TRUE)] skin is a thin membrane, wrapped taut over bone.</span><br>"
 				else if(humanity <= 5)
-					msg += "[p_they(TRUE)] seem sickly and malnourished.<br>"
+					msg += "[p_they(TRUE)] seem[p_s()] sickly and malnourished.<br>"
 			//Path of enlightenmentoids now seem inhuman at every step of the journey.
 			else
 				if(humanity <= 3)
-					msg += "[p_their()] eyes are dim, functuating to an unknown calculus.<br>"
+					msg += "[p_their(TRUE)] eyes are dim, functuating to an unknown calculus.<br>"
 				else if(humanity <= 5)
-					msg += "[p_their()] posture and movements are eerily controlled.<br>"
+					msg += "[p_their(TRUE)] posture and movements are eerily controlled.<br>"
 
 		if(getorgan(/obj/item/organ/brain))
 			if(ai_controller?.ai_status == AI_STATUS_ON)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The tabletop rpg wiki says that having humanity at about 1-5 makes you look pretty freaky to kine and kindred. This adds that as an addendum to your description.

Basically at 4-5 humanity, you'll get some freaky red eyes. 
At 3 and lower? Your shit's all fucked up and you're obviously such a fucking monster even other kindred don't want to mess with you.

Vampires on paths of enlightenment aren't affected by this because they reject the entire concept of humanity being a thing. In all moments, they are euphoric, not because of some phony morality system, but because of how in-tune they are with their inner beast. 

## Why It's Good For The Game

You're now forced to roleplay just how unhinged you are from your lack of humanity since everyone can clearly tell you're a fucking monster at a glance. It's good because people can't just brush off the fact they're a complete lunatic anymore. 
It also incentivizes buying humanity with experience. 

The downside is that this also sort of buffs paths of enlightenment. Personally I think only clans like the tzimisce, baali and a few of the others should be able to pick them out the gate. But that's something for another PR to accomplish. For now we can just socially ostracise path of dowhateverIwants. 


## Testing Photographs and Procedure
It works.

![Humanity5](https://github.com/user-attachments/assets/64ff71bc-76fe-4575-a1b1-ec06cb563b29)

![Sub3Humanity](https://github.com/user-attachments/assets/ad1acf34-8ca2-4527-acb8-372f7e9db29a)

Capitalization and pluralization issues have since been rectified.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: People with low humanity now look freaky as fuck
:cl:

