### PR TITLE
wow! no more captains mentioned on round start!

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -387,7 +387,7 @@ SUBSYSTEM_DEF(ticker)
 		var/mob/dead/new_player/N = i
 		var/mob/living/carbon/human/player = N.new_character
 		if(istype(player) && player.mind && player.mind.assigned_role)
-			if(player.mind.assigned_role == "Captain")
+			if(player.mind.assigned_role == "Prince")
 				captainless=0
 			if(player.mind.assigned_role != player.mind.special_role)
 				SSjob.EquipRank(N, player.mind.assigned_role, 0)
@@ -398,7 +398,7 @@ SUBSYSTEM_DEF(ticker)
 		for(var/i in GLOB.new_player_list)
 			var/mob/dead/new_player/N = i
 			if(N.new_character)
-				to_chat(N, "<span class='notice'>Captainship not forced on anyone.</span>")
+				to_chat(N, "<span class='notice'>The Prince is not currently present.</span>")
 			CHECK_TICK
 
 /datum/controller/subsystem/ticker/proc/transfer_characters()


### PR DESCRIPTION
## About The Pull Request

Have you been informed there are no captains in San Francisco when a new round starts? Weird, huh? No more!

## Why It's Good For The Game

Immersion.

## Changelog

:cl: Yinadele
fix: Roundstart captaincy will have proper checks for the Prince, and flavor text accordingly.
/:cl:
