### PR TITLE
port alt job titles from tegustation

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -519,10 +519,13 @@
 		return
 	if((character.mind.assigned_role == "Cyborg") || (character.mind.assigned_role == character.mind.special_role))
 		return
-
+	// TFN EDIT START: alt job titles
+	var/displayed_rank = rank
+	if(character?.client?.prefs?.alt_titles_preferences[rank])
+		displayed_rank = character.client.prefs.alt_titles_preferences[rank]
 	var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
-	announcer.announce("ARRIVAL", character.real_name, rank, list()) //make the list empty to make it announce it in common
-
+	announcer.announce("ARRIVAL", character.real_name, displayed_rank, list()) //make the list empty to make it announce it in common
+	// TFN EDIT END
 /proc/lavaland_equipment_pressure_check(turf/T)
 	. = FALSE
 	if(!istype(T))

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -547,7 +547,13 @@ SUBSYSTEM_DEF(job)
 	if(living_mob.mind)
 		living_mob.mind.assigned_role = rank
 
-	to_chat(M, "<b>You are the [rank].</b>")
+	// TFN EDIT START: alt job titles
+	var/display_rank = rank
+	if(M?.client?.prefs?.alt_titles_preferences[rank])
+		display_rank = M.client.prefs.alt_titles_preferences[rank]
+	// TFN EDIT START
+
+	to_chat(M, "<b>You are the [display_rank].</b>")
 	if(job)
 		var/new_mob = job.equip(living_mob, null, null, joined_late , null, M.client)//silicons override this proc to return a mob
 		if(ismob(new_mob))
@@ -565,15 +571,15 @@ SUBSYSTEM_DEF(job)
 			else
 				handle_auto_deadmin_roles(M.client, rank)
 
-		to_chat(M, "<b>As the [rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
+		to_chat(M, "<b>As the [display_rank] you answer directly to [job.supervisors]. Special circumstances may change this.</b>")
 		var/mob/living/carbon/human/human = living_mob
 		if((iskindred(human) && human.clane) || iscathayan(human) || isgarou(human))
 			if(job.v_duty && job.v_duty != "")
-				to_chat(M, "<span class='notice'><b>[job.v_duty]</b></span>")
+				to_chat(M, span_notice("<b>[job.v_duty]</b>"))
 			if(job.title != "Prince")
 				to_chat(M, "<span class='notice' style='color:red;'><b>The Camarilla rule the city. You should obey them, their laws and the Prince, at least in public.</b></span>")
 			if(job.title == "Chantry Archivist")
-				to_chat(M, "<span class='notice'><b>As a member of the Chantry, you are part of the Tremere Pyramid and are blood bonded to the Regent. Always be loyal.</b></span>")
+				to_chat(M, span_notice("<b>As a member of the Chantry, you are part of the Tremere Pyramid and are blood bonded to the Regent. Always be loyal.</b>"))
 		else if(job.duty && job.duty != "")
 			to_chat(M, "<span class='notice'><b>[job.duty]</b></span>")
 //		job.radio_help_message(M)

--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -168,7 +168,7 @@
 		var/has_department = FALSE
 		for(var/department in departments)
 			var/list/jobs = departments[department]
-			if(rank in jobs)
+			if(rank in jobs || (t.fields["truerank"] && (t.fields["truerank"] in jobs))) // TFN EDIT: alt job titles
 				if(!manifest_out[department])
 					manifest_out[department] = list()
 				manifest_out[department] += list(list(
@@ -223,12 +223,19 @@
 	var/static/list/show_directions = list(SOUTH, WEST)
 	if(H.mind && (H.mind.assigned_role != H.mind.special_role))
 		var/assignment
+		var/trueassignment // TFN EDIT: alt job titles
 		if(H.mind.assigned_role)
 			assignment = H.mind.assigned_role
 		else if(H.job)
 			assignment = H.job
 		else
 			assignment = "Unassigned"
+
+		// TFN EDIT START: alt job titles
+		if(C?.prefs?.alt_titles_preferences[assignment])
+			trueassignment = assignment
+			assignment = C.prefs.alt_titles_preferences[assignment]
+		// TFN EDIT END
 
 		var/static/record_id_num = 1001
 		var/id = num2hex(record_id_num++,6)
@@ -252,6 +259,7 @@
 		G.fields["id"]			= id
 		G.fields["name"]		= H.real_name
 		G.fields["rank"]		= assignment
+		G.fields["truerank"] = trueassignment // TFN EDIT: alt job titles
 		G.fields["age"]			= H.age
 		G.fields["species"]	= H.dna.species.name
 		G.fields["fingerprint"]	= md5(H.dna.uni_identity)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -158,7 +158,7 @@
  *
  * If visualsOnly is true, you can omit any work that doesn't visually appear on the character sprite
  */
-/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source = null) // TFN EDIT: alt job titles
 	pre_equip(H, visualsOnly)
 
 	//Start with uniform,suit,backpack for additional slots
@@ -228,7 +228,7 @@
 		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit
 		HS.ToggleHelmet()
 
-	post_equip(H, visualsOnly)
+	post_equip(H, visualsOnly, preference_source) // TFN EDIT: alt job titles
 
 	if(!visualsOnly)
 		apply_fingerprints(H)

--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -169,7 +169,7 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 		if (id_card)
 			entry["name"] = id_card.registered_name
 			entry["assignment"] = id_card.assignment
-			entry["ijob"] = jobs[id_card.assignment]
+			entry["ijob"] = jobs[id_card.GetJobName()] // TFN EDIT: alt job titles
 
 		// Binary living/dead status
 		if (sensor_mode >= SENSOR_LIVING)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -498,6 +498,15 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	READ_FILE(S["all_quirks"], all_quirks)
 
 	READ_FILE(S["headshot_link"], headshot_link) // TFN EDIT: headshot loading
+	// TFN EDIT START: alt job titles
+	READ_FILE(S["alt_titles_preferences"], alt_titles_preferences)
+	alt_titles_preferences = SANITIZE_LIST(alt_titles_preferences)
+	if(SSjob)
+		for(var/datum/job/job in sortList(SSjob.occupations, /proc/cmp_job_display_asc))
+			if(alt_titles_preferences[job.title])
+				if(!(alt_titles_preferences[job.title] in job.alt_titles))
+					alt_titles_preferences.Remove(job.title)
+	// TFN EDIT END
 	//try to fix any outdated data if necessary
 	//preference updating will handle saving the updated data for us.
 	if(needs_update >= 0)
@@ -813,6 +822,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	WRITE_FILE(S["headshot_link"], headshot_link) // TFN EDIT: headshot saving
 
+	WRITE_FILE(S["alt_titles_preferences"], alt_titles_preferences) // TFN EDIT: alt job titles
 	return TRUE
 
 

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -389,4 +389,9 @@
 		return jobName
 	if(jobName in get_all_centcom_jobs()) //Return with the NT logo if it is a CentCom job
 		return "CentCom"
+	// TFN EDIT START: alt job titles
+	for(var/datum/job/J in SSjob.occupations)
+		if(jobName in J.alt_titles)
+			return J.title
+	// TFN EDIT END
 	return "Unknown" //Return unknown if none of the above apply

--- a/code/modules/jobs/job_types/_job.dm
+++ b/code/modules/jobs/job_types/_job.dm
@@ -179,10 +179,15 @@
 
 	//Equip the rest of the gear
 	H.dna.species.before_equip_job(src, H, visualsOnly)
+	// TFN EDIT START: alt job titles
+	if(outfit && preference_source?.prefs?.alt_titles_preferences[title] && !outfit_override)
+		var/outfitholder = "[outfit]/[ckey(preference_source.prefs.alt_titles_preferences[title])]"
+		if(text2path(outfitholder) || !outfitholder)
+			outfit_override = text2path(outfitholder)
 
 	if(outfit_override || outfit)
-		H.equipOutfit(outfit_override ? outfit_override : outfit, visualsOnly)
-
+		H.equipOutfit(outfit_override ? outfit_override : outfit, visualsOnly, preference_source)
+	// TFN EDIT END
 	H.dna.species.after_equip_job(src, H, visualsOnly)
 
 	if(!visualsOnly && announce)
@@ -300,7 +305,7 @@
 		holder = "[uniform]"
 	uniform = text2path(holder)
 
-/datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+/datum/outfit/job/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source = null) // TFN EDIT: alt job titles
 	if(visualsOnly)
 		return
 
@@ -314,7 +319,12 @@
 			C.access = J.get_access()
 			shuffle_inplace(C.access) // Shuffle access list to make NTNet passkeys less predictable
 			C.registered_name = H.real_name
-			C.assignment = J.title
+			// TFN EDIT START: alt job titles
+			if(preference_source?.prefs?.alt_titles_preferences[J.title])
+				C.assignment = preference_source.prefs.alt_titles_preferences[J.title]
+			else
+				C.assignment = J.title
+			// TFN EDIT END
 			if(H.age)
 				C.registered_age = H.age
 			C.update_label()
@@ -327,7 +337,12 @@
 	var/obj/item/pda/PDA = H.get_item_by_slot(pda_slot)
 	if(istype(PDA))
 		PDA.owner = H.real_name
-		PDA.ownjob = J.title
+		// TFN EDIT START: alt job titles
+		if(preference_source?.prefs?.alt_titles_preferences[J.title])
+			PDA.ownjob = preference_source.prefs.alt_titles_preferences[J.title]
+		else
+			PDA.ownjob = J.title
+		// TFN EDIT END
 		PDA.update_label()
 
 	if(H.client?.prefs.playtime_reward_cloak)

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -32,6 +32,8 @@ Assistant
 
 /datum/outfit/job/assistant/pre_equip(mob/living/carbon/human/H)
 	..()
+	if(uniform != /obj/item/clothing/under/color/grey)
+		return
 	if (CONFIG_GET(flag/grey_assistants))
 		if(H.jumpsuit_style == PREF_SUIT)
 			uniform = /obj/item/clothing/under/color/grey

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -464,14 +464,19 @@
 		var/list/dept_dat = list()
 		for(var/job in GLOB.position_categories[category]["jobs"])
 			var/datum/job/job_datum = SSjob.name_occupations[job]
+			// TFN EDIT START: alt job titles
 			if(job_datum && IsJobUnavailable(job_datum.title, TRUE) == JOB_AVAILABLE)
+				var/altjobline = ""
 				var/command_bold = ""
+				if(client && client.prefs && client.prefs.alt_titles_preferences[job_datum.title])//tegu edit - alt job titles
+					altjobline = "(as [client.prefs.alt_titles_preferences[job_datum.title]])"//tegu edit - alt job titles
 				if(job in GLOB.leader_positions)
 					command_bold = " command"
 				if(job_datum in SSjob.prioritized_jobs)
-					dept_dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'><span class='priority'>[job_datum.title] ([job_datum.current_positions])</span></a>"
+					dept_dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'><span class='priority'>[job_datum.title] [altjobline] ([job_datum.current_positions])</span></a>"
 				else
-					dept_dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[job_datum.title] ([job_datum.current_positions])</a>"
+					dept_dat += "<a class='job[command_bold]' href='byond://?src=[REF(src)];SelectedJob=[job_datum.title]'>[job_datum.title] [altjobline] ([job_datum.current_positions])</a>"
+			// TFN EDIT END
 		if(!dept_dat.len)
 			dept_dat += "<span class='nopositions'>No positions open.</span>"
 		dat += jointext(dept_dat, "")

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -285,7 +285,7 @@
 	sec_hud_set_security_status()
 	..()
 
-/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE)
+/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE, client/preference_source = null) // TFN EDIT: alt job titles
 	var/datum/outfit/O = null
 
 	if(ispath(outfit))
@@ -297,8 +297,7 @@
 	if(!O)
 		return 0
 
-	return O.equip(src, visualsOnly)
-
+	return O.equip(src, visualsOnly, preference_source) // TFN EDIT: alt job titles
 
 //delete all equipment without dropping anything
 /mob/living/carbon/human/proc/delete_equipment()

--- a/modular_tfn/modules/alt_job_titles/alt_job_titles.dm
+++ b/modular_tfn/modules/alt_job_titles/alt_job_titles.dm
@@ -1,0 +1,17 @@
+/datum/job
+	var/list/alt_titles = list()
+
+/datum/job/vamp/citizen
+	alt_titles = list(
+		"Private Investigator",
+		"Private Security",
+		"Tourist",
+		"Visitor",
+		"Entertainer",
+		"Entrepreneur",
+		"Contractor",
+		"Fixer",
+		"Lawyer",
+		"Attorney",
+		"Paralegal",
+	)

--- a/modular_tfn/modules/alt_job_titles/outfits.dm
+++ b/modular_tfn/modules/alt_job_titles/outfits.dm
@@ -1,0 +1,1 @@
+// TO BE ADDED

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3582,6 +3582,8 @@
 #include "interface\skin.dmf"
 #include "modular_tfn\code\modules\client\preferences.dm"
 #include "modular_tfn\code\modules\mob\living\carbon\human\human_defines.dm"
+#include "modular_tfn\modules\alt_job_titles\alt_job_titles.dm"
+#include "modular_tfn\modules\alt_job_titles\outfits.dm"
 #include "modular_tfn\modules\auspex_auras\auspex_auras.dm"
 #include "modular_tfn\modules\discord\account_link.dm"
 #include "modular_tfn\modules\discord\discord_embed.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Alt job titles from Tegu(which was ported from White Sands)

Allows the player to select an alternative job title in the Occupations menu when applicable. Occupations with alternative job titles have their names buttonified.

Alternative job titles can spawn with different outfits, if one is made for them.

## Why It's Good For The Game

RP good. More options good. Less role bloat good.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added alternative job titles
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
