### PR TITLE
Garou Overhaul PR

### DIFF
--- a/code/modules/mob/living/carbon/werewolf/life.dm
+++ b/code/modules/mob/living/carbon/werewolf/life.dm
@@ -87,7 +87,7 @@
 /mob/living/carbon/werewolf/crinos/Life()
 	. = ..()
 	if(CheckEyewitness(src, src, 5, FALSE))
-		adjust_veil(-1)
+		adjust_veil(-3)
 
 /mob/living/carbon/werewolf/check_breath(datum/gas_mixture/breath)
 	return

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -210,10 +210,10 @@
 	werewolf_armor = 25
 
 /datum/movespeed_modifier/crinosform
-	multiplicative_slowdown = -0.2
+	multiplicative_slowdown = -0.3
 
 /datum/movespeed_modifier/silver_slowdown
-	multiplicative_slowdown = 0.3
+	multiplicative_slowdown = 0.6
 
 /mob/living/carbon/werewolf/crinos/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -210,10 +210,10 @@
 	werewolf_armor = 25
 
 /datum/movespeed_modifier/crinosform
-	multiplicative_slowdown = -0.3
+	multiplicative_slowdown = -0.2
 
 /datum/movespeed_modifier/silver_slowdown
-	multiplicative_slowdown = 0.6
+	multiplicative_slowdown = 0.7
 
 /mob/living/carbon/werewolf/crinos/Initialize()
 	. = ..()

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -106,9 +106,10 @@
 	shake_camera(src, 5, 4)
 
 /mob/living/carbon/werewolf/Initialize()
-	var/datum/action/gift/minor_rage_heal/GH = new()
-	var/datum/action/gift/major_rage_heal/GH = new()
-	GH.Grant(src)
+	var/datum/action/gift/minor_rage_heal/MRH = new()
+	var/datum/action/gift/major_rage_heal/GRH = new()
+	MRH.Grant(src)
+	GRH.Grant(src)
 	add_verb(src, /mob/living/proc/mob_sleep)
 	add_verb(src, /mob/living/proc/toggle_resting)
 

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -187,15 +187,15 @@
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	limb_destroyer = 1
 	hud_type = /datum/hud/werewolf
-	melee_damage_lower = 35
-	melee_damage_upper = 65
+	melee_damage_lower = 40
+	melee_damage_upper = 45
 	health = 250
 	maxHealth = 250
 //	speed = -1  doesn't work on carbons
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null
 	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 30
+	var/pounce_cooldown_time = 60
 	pixel_w = -8
 //	deathsound = 'sound/voice/hiss6.ogg'
 	bodyparts = list(
@@ -207,7 +207,7 @@
 		/obj/item/bodypart/l_leg,
 		)
 
-	werewolf_armor = 30
+	werewolf_armor = 25
 
 /datum/movespeed_modifier/crinosform
 	multiplicative_slowdown = -0.2

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -195,7 +195,7 @@
 	var/obj/item/r_store = null
 	var/obj/item/l_store = null
 	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 60
+	var/pounce_cooldown_time = 35
 	pixel_w = -8
 //	deathsound = 'sound/voice/hiss6.ogg'
 	bodyparts = list(
@@ -207,7 +207,7 @@
 		/obj/item/bodypart/l_leg,
 		)
 
-	werewolf_armor = 25
+	werewolf_armor = 35
 
 /datum/movespeed_modifier/crinosform
 	multiplicative_slowdown = -0.2

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -106,7 +106,8 @@
 	shake_camera(src, 5, 4)
 
 /mob/living/carbon/werewolf/Initialize()
-	var/datum/action/gift/rage_heal/GH = new()
+	var/datum/action/gift/minor_rage_heal/GH = new()
+	var/datum/action/gift/major_rage_heal/GH = new()
 	GH.Grant(src)
 	add_verb(src, /mob/living/proc/mob_sleep)
 	add_verb(src, /mob/living/proc/toggle_resting)

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -104,7 +104,7 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/razor_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.dna.species.attack_verb = "slash"
+			H.dna.species.attack_verb = "slash"f
 			H.dna.species.attack_sound = 'sound/weapons/slash.ogg'
 			H.dna.species.miss_sound = 'sound/weapons/slashmiss.ogg'
 			H.dna.species.punchdamagelow = 20

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -96,7 +96,7 @@
 	name = "Razor Claws"
 	desc = "By raking his claws over stone, steel, or another hard surface, the Ahroun hones them to razor sharpness."
 	button_icon_state = "razor_claws"
-	rage_req = 1
+	rage_req = 3
 
 /datum/action/gift/razor_claws/Trigger()
 	. = ..()
@@ -104,7 +104,7 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/razor_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.dna.species.attack_verb = "slash"f
+			H.dna.species.attack_verb = "slash"
 			H.dna.species.attack_sound = 'sound/weapons/slash.ogg'
 			H.dna.species.miss_sound = 'sound/weapons/slashmiss.ogg'
 			H.dna.species.punchdamagelow = 20

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -346,21 +346,59 @@
 				L.emote("laugh")
 				L.Stun(20)
 
-/datum/action/gift/rage_heal
-	name = "Rage Heal"
+/datum/action/gift/minor_rage_heal
+	name = "Minor Rage Heal"
 	desc = "This Gift allows the Garou to heal severe injuries with rage."
 	button_icon_state = "rage_heal"
-	rage_req = 1
+	rage_req = 3
 	check_flags = null
 
-/datum/action/gift/rage_heal/Trigger()
+/datum/action/gift/minor_rage_heal/Trigger()
+	. = ..()
+	if(allowed_to_proceed)
+		var/mob/living/carbon/C = owner
+		if(C.stat != DEAD)
+			SEND_SOUND(owner, sound('code/modules/wod13/sounds/rage_heal.ogg', 0, 0, 75))
+			C.adjustBruteLoss(-20*C.auspice.level, TRUE)
+			C.adjustFireLoss(-10*C.auspice.level, TRUE) // fire is agg damage for werewolves
+			C.adjustCloneLoss(-10*C.auspice.level, TRUE)
+			C.adjustToxLoss(-20*C.auspice.level, TRUE)
+			C.adjustOxyLoss(-20*C.auspice.level, TRUE)
+			C.bloodpool = min(C.bloodpool + C.auspice.level, C.maxbloodpool)
+			C.blood_volume = min(C.blood_volume + 56 * C.auspice.level, BLOOD_VOLUME_NORMAL)
+			if(ishuman(owner))
+				var/mob/living/carbon/human/BD = owner
+				if(length(BD.all_wounds))
+					var/datum/wound/W = pick(BD.all_wounds)
+					W.remove_wound()
+				if(length(BD.all_wounds))
+					var/datum/wound/W = pick(BD.all_wounds)
+					W.remove_wound()
+				if(length(BD.all_wounds))
+					var/datum/wound/W = pick(BD.all_wounds)
+					W.remove_wound()
+				if(length(BD.all_wounds))
+					var/datum/wound/W = pick(BD.all_wounds)
+					W.remove_wound()
+				if(length(BD.all_wounds))
+					var/datum/wound/W = pick(BD.all_wounds)
+					W.remove_wound()
+
+/datum/action/gift/major_rage_heal
+	name = "Major Rage Heal"
+	desc = "This Gift allows the Garou to heal severe injuries with rage."
+	button_icon_state = "rage_heal"
+	rage_req = 5
+	check_flags = null
+
+/datum/action/gift/major_rage_heal/Trigger()
 	. = ..()
 	if(allowed_to_proceed)
 		var/mob/living/carbon/C = owner
 		if(C.stat != DEAD)
 			SEND_SOUND(owner, sound('code/modules/wod13/sounds/rage_heal.ogg', 0, 0, 75))
 			C.adjustBruteLoss(-40*C.auspice.level, TRUE)
-			C.adjustFireLoss(-30*C.auspice.level, TRUE)
+			C.adjustFireLoss(-10*C.auspice.level, TRUE) // fire is agg damage on pnp without a gift
 			C.adjustCloneLoss(-10*C.auspice.level, TRUE)
 			C.adjustToxLoss(-10*C.auspice.level, TRUE)
 			C.adjustOxyLoss(-20*C.auspice.level, TRUE)

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -350,7 +350,7 @@
 	name = "Minor Rage Heal"
 	desc = "This Gift allows the Garou to heal severe injuries with rage."
 	button_icon_state = "rage_heal"
-	rage_req = 3
+	rage_req = 2
 	check_flags = null
 
 /datum/action/gift/minor_rage_heal/Trigger()
@@ -388,7 +388,7 @@
 	name = "Major Rage Heal"
 	desc = "This Gift allows the Garou to heal severe injuries with rage."
 	button_icon_state = "rage_heal"
-	rage_req = 5
+	rage_req = 3
 	check_flags = null
 
 /datum/action/gift/major_rage_heal/Trigger()

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -91,7 +91,7 @@
 	name = "Venom Claws"
 	desc = "While this ability is active, strikes with claws poison foes of garou."
 	button_icon_state = "venom_claws"
-	rage_req = 1
+	rage_req = 3
 
 /datum/action/gift/venom_claws/Trigger()
 	. = ..()
@@ -100,7 +100,7 @@
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/venom_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
 			H.melee_damage_lower = initial(H.melee_damage_lower)+5
-			H.melee_damage_upper = initial(H.melee_damage_upper)+5
+			H.melee_damage_upper = initial(H.melee_damage_upper)+5 // so you are gonna be hitting 50 here, and vamps take half that
 			H.tox_damage_plus = 5
 			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
 			spawn(12 SECONDS)

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -99,9 +99,9 @@
 		if(ishuman(owner))
 			playsound(get_turf(owner), 'code/modules/wod13/sounds/venom_claws.ogg', 75, FALSE)
 			var/mob/living/carbon/human/H = owner
-			H.melee_damage_lower = initial(H.melee_damage_lower)+15
-			H.melee_damage_upper = initial(H.melee_damage_upper)+15
-			H.tox_damage_plus = 15
+			H.melee_damage_lower = initial(H.melee_damage_lower)+5
+			H.melee_damage_upper = initial(H.melee_damage_upper)+5
+			H.tox_damage_plus = 5
 			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
 			spawn(12 SECONDS)
 				H.tox_damage_plus = 0
@@ -113,7 +113,7 @@
 			var/mob/living/carbon/H = owner
 			H.melee_damage_lower = initial(H.melee_damage_lower)+10
 			H.melee_damage_upper = initial(H.melee_damage_upper)+10
-			H.tox_damage_plus = 10
+			H.tox_damage_plus = 5
 			to_chat(owner, "<span class='notice'>You feel your claws filling with pure venom...</span>")
 			spawn(12 SECONDS)
 				H.tox_damage_plus = 0
@@ -133,12 +133,12 @@
 	if(allowed_to_proceed)
 		owner.visible_message("<span class='danger'>[owner.name] crackles with heat!</span>", "<span class='danger'>You crackle with heat, charging up your Gift!</span>")
 		if(do_after(owner, 3 SECONDS))
-			for(var/mob/living/L in orange(5, owner))
+			for(var/mob/living/L in orange(2, owner))
 				if(L)
 					L.adjustFireLoss(40)
-			for(var/turf/T in orange(4, get_turf(owner)))
+			for(var/turf/T in orange(2, get_turf(owner)))
 				var/obj/effect/fire/F = new(T)
-				spawn(5)
+				spawn(2)
 					qdel(F)
 
 /datum/action/gift/smooth_move
@@ -174,7 +174,7 @@
 		if(do_after(owner, 3 SECONDS))
 			playsound(owner, 'sound/magic/lightningshock.ogg', 100, TRUE, extrarange = 5)
 			tesla_zap(owner, 3, 30, ZAP_MOB_DAMAGE | ZAP_OBJ_DAMAGE | ZAP_MOB_STUN | ZAP_ALLOW_DUPLICATES)
-			for(var/mob/living/L in orange(6, owner))
+			for(var/mob/living/L in orange(4, owner))
 				if(L)
 					L.electrocute_act(30, owner, siemens_coeff = 1, flags = NONE)
 

--- a/code/modules/vtmb/werewolf_species.dm
+++ b/code/modules/vtmb/werewolf_species.dm
@@ -111,9 +111,10 @@
 	infor.Grant(C)
 	var/datum/action/gift/glabro/glabro = new()
 	glabro.Grant(C)
-	var/datum/action/gift/minor_rage_heal/GH = new()
-	var/datum/action/gift/major_rage_heal/GH = new()
-	GH.Grant(C)
+	var/datum/action/gift/minor_rage_heal/MRH = new()
+	var/datum/action/gift/major_rage_heal/GRH = new()
+	MRH.Grant(C)
+	GRH.Grant(C)
 	C.transformator = new(C)
 	C.transformator.human_form = C
 

--- a/code/modules/vtmb/werewolf_species.dm
+++ b/code/modules/vtmb/werewolf_species.dm
@@ -111,7 +111,8 @@
 	infor.Grant(C)
 	var/datum/action/gift/glabro/glabro = new()
 	glabro.Grant(C)
-	var/datum/action/gift/rage_heal/GH = new()
+	var/datum/action/gift/minor_rage_heal/GH = new()
+	var/datum/action/gift/major_rage_heal/GH = new()
 	GH.Grant(C)
 	C.transformator = new(C)
 	C.transformator.human_form = C

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -309,28 +309,28 @@
 /datum/supply_pack/vampire/ammo9/silver
 	name = "Ammo (9mm, silver)"
 	desc = "Contains a box of silver 9mm ammunition."
-	cost = 2000
+	cost = 1500
 	contains = list(/obj/item/ammo_box/vampire/c9mm/silver)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo44/silver
 	name = "Ammo (.44, silver)"
 	desc = "Contains a box of silver .44 ammunition."
-	cost = 2000
+	cost = 1500
 	contains = list(/obj/item/ammo_box/vampire/c44/silver)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo45/silver
 	name = "Ammo (.45, silver)"
 	desc = "Contains a box of silver .45 ammunition."
-	cost = 2000
+	cost = 1500
 	contains = list(/obj/item/ammo_box/vampire/c45acp/silver)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo556/silver
 	name = "Ammo (5.56, silver)"
 	desc = "Contains a box of silver 5.56 ammunition."
-	cost = 3000
+	cost = 1500
 	contains = list(/obj/item/ammo_box/vampire/c556/silver)
 
 /datum/supply_pack/vampire/ammo50

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -309,28 +309,28 @@
 /datum/supply_pack/vampire/ammo9/silver
 	name = "Ammo (9mm, silver)"
 	desc = "Contains a box of silver 9mm ammunition."
-	cost = 1500
+	cost = 6500
 	contains = list(/obj/item/ammo_box/vampire/c9mm/silver)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo44/silver
 	name = "Ammo (.44, silver)"
 	desc = "Contains a box of silver .44 ammunition."
-	cost = 1500
+	cost = 6500
 	contains = list(/obj/item/ammo_box/vampire/c44/silver)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo45/silver
 	name = "Ammo (.45, silver)"
 	desc = "Contains a box of silver .45 ammunition."
-	cost = 1500
+	cost = 6500
 	contains = list(/obj/item/ammo_box/vampire/c45acp/silver)
 	crate_name = "ammo crate"
 
 /datum/supply_pack/vampire/ammo556/silver
 	name = "Ammo (5.56, silver)"
 	desc = "Contains a box of silver 5.56 ammunition."
-	cost = 1500
+	cost = 7000
 	contains = list(/obj/item/ammo_box/vampire/c556/silver)
 
 /datum/supply_pack/vampire/ammo50

--- a/code/modules/wod13/status_effects/debuffs.dm
+++ b/code/modules/wod13/status_effects/debuffs.dm
@@ -970,7 +970,7 @@
 /datum/status_effect/silver_slowdown
 	id = "slowdown"
 	status_type = STATUS_EFFECT_REPLACE
-	duration = 5 SECONDS
+	duration = 15 SECONDS
 
 /datum/status_effect/silver_slowdown/on_apply()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

This PR works on implementing roles for the three tribes of Garou as well as an objective-less Ronin for said Garou.  The PR also implements a "greater" and lesser rage heal gift for Garou so that they can be balanced the same way cainites were by the generation pr.

## Why It's Good For The Game

Better balance, gives a sense of direction for players to be considered part of a tribe. Etc.

## Testing Photographs and Procedure
When we get there.

## Changelog

:cl:
add: wendigo/pentex first team/glasswalker tribe roles
add: ronin role
adjust: split rage heal into greater and lesser. 3 and 5 rage respectfully.
adjust: Garou run faster in **crinos** but are MUCH slower when hit by silver.
adjust: Max damage you can get with garou claws is 50, with vamps taking 25 per hit. This might need a change.
nerf: pounce is now 60 seconds, can go lower
nerf: fire damage is less soakable (healable)
nerf: claws can no longer stack exponential damage

/:cl:

