### PR TITLE
Small Garou nerfs + the best thing since sliced bread

### DIFF
--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -543,7 +543,6 @@ GLOBAL_LIST_EMPTY(station_turfs)
 /turf/handle_fall(mob/faller)
 	if(has_gravity(src))
 		playsound(src, "bodyfall", 50, TRUE)
-	faller.drop_all_held_items()
 
 /turf/proc/photograph(limit=20)
 	var/image/I = new()

--- a/code/modules/mob/living/carbon/werewolf/damage_procs.dm
+++ b/code/modules/mob/living/carbon/werewolf/damage_procs.dm
@@ -6,9 +6,9 @@
 //	return FALSE
 
 ///aliens are immune to stamina damage.
-/mob/living/carbon/werewolf/adjustStaminaLoss(amount, updating_health = 1, forced = FALSE)
-	return FALSE
+///mob/living/carbon/werewolf/adjustStaminaLoss(amount, updating_health = 1, forced = FALSE)
+//	return FALSE
 
 ///aliens are immune to stamina damage.
-/mob/living/carbon/werewolf/setStaminaLoss(amount, updating_health = 1)
-	return FALSE
+//mob/living/carbon/werewolf/setStaminaLoss(amount, updating_health = 1)
+//	return FALSE

--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -28,7 +28,7 @@
 	var/hispo = FALSE
 
 /datum/movespeed_modifier/lupusform
-	multiplicative_slowdown = -0.75
+	multiplicative_slowdown = -0.5
 
 /mob/living/carbon/werewolf/lupus/update_icons()
 	cut_overlays()

--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -28,7 +28,7 @@
 	var/hispo = FALSE
 
 /datum/movespeed_modifier/lupusform
-	multiplicative_slowdown = -0.80
+	multiplicative_slowdown = -0.60
 
 /mob/living/carbon/werewolf/lupus/update_icons()
 	cut_overlays()

--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -28,7 +28,7 @@
 	var/hispo = FALSE
 
 /datum/movespeed_modifier/lupusform
-	multiplicative_slowdown = -0.60
+	multiplicative_slowdown = -0.75
 
 /mob/living/carbon/werewolf/lupus/update_icons()
 	cut_overlays()

--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -28,7 +28,7 @@
 	var/hispo = FALSE
 
 /datum/movespeed_modifier/lupusform
-	multiplicative_slowdown = -0.5
+	multiplicative_slowdown = -0.7
 
 /mob/living/carbon/werewolf/lupus/update_icons()
 	cut_overlays()

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -100,6 +100,7 @@
 	for(var/mob/living/carbon/C in range(5, src))
 		if(apply_stun_others)
 			C.Knockdown(20)
+			C.Stun(10)
 		shake_camera(C, (6-get_dist(C, src))+1, (6-get_dist(C, src)))
 	if(apply_stun_self)
 		Knockdown(20)

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -99,10 +99,10 @@
 	new /obj/effect/temp_visual/dir_setting/fall_effect(get_turf(src))
 	for(var/mob/living/carbon/C in range(5, src))
 		if(apply_stun_others)
-			C.Stun(30)
+			C.Knockdown(20)
 		shake_camera(C, (6-get_dist(C, src))+1, (6-get_dist(C, src)))
 	if(apply_stun_self)
-		Stun(20)
+		Knockdown(20)
 	shake_camera(src, 5, 4)
 
 /mob/living/carbon/werewolf/Initialize()

--- a/code/modules/mob/living/carbon/werewolf/werewolf_defense.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf_defense.dm
@@ -1,10 +1,4 @@
 
-/mob/living/carbon/werewolf/get_eye_protection()
-	return ..() + 2 //potential cyber implants + natural eye protection
-
-/mob/living/carbon/werewolf/get_ear_protection()
-	return 2 //no ears
-
 /mob/living/carbon/werewolf/hitby(atom/movable/AM, skipcatch, hitpush, blocked, datum/thrownthing/throwingdatum)
 	..(AM, skipcatch = TRUE, hitpush = FALSE)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I was originally working on more comprehensive Garou nerfs, but since there is another PR up for that and I wish to avoid conflicts, I backtracked any that would conflict and kept just a few small ones.

This removes the immunity to flashbangs, flashes of light and stamina damage that werewolves inherited from xenomorphs (yes), and sets Lupus speed to be the same as Celerity 3. EDIT: Turns out there is a second layer of stamina damage immunity in their damage coeffs, so this doesn't remove that immunity. That is fine, for now this is just removing one layer of redundant code.

Much, much more importantly: Knockdowns no longer force you to drop in-hand items. This means you can actually consistently keep your weapon in hand during a fight, without immediately getting disarmed by punches. This also makes the strategy of jumping into people as a werewolf to force a knockdown less powerful.

## Why It's Good For The Game
Werewolves are oppressive in large part due to being non-human, carbon mobs that don't care about 80% of the game's rules. This helps bring them a bit more in line with the other splats.

Knockdowns not disarming just helps bring the tone of the game more in line with the intended tone of the setting. An Elder vampire should not be disarmed because a human punched him in the chest, or jumped into him. De-tgfies the combat significantly.
