### PR TITLE
Discipline Buffs And Changes

### DIFF
--- a/code/__DEFINES/wod13/discipline.dm
+++ b/code/__DEFINES/wod13/discipline.dm
@@ -1,8 +1,8 @@
 //normal duration defines
-///Duration of one "turn", which is 6 seconds according to us
-#define DURATION_TURN 6 SECONDS
-///Duration of one "scene", which is 5 minutes according to us
-#define DURATION_SCENE 5 MINUTES
+///Duration of one "turn", which is 5 seconds according to us
+#define TURNS * 5 SECONDS
+///Duration of one "scene", which is 3 minutes according to us
+#define SCENES * 3 MINUTES
 
 //targeting bitflags, NONE or 0 if targeting self exclusively
 ///Allows for self to also be selected in ranged targeting, SET TO 0 IF NOT TARGETED OR RANGED

--- a/code/modules/wod13/datums/powers/discipline/__discipline_power.dm
+++ b/code/modules/wod13/datums/powers/discipline/__discipline_power.dm
@@ -500,7 +500,9 @@
 	if (toggled && (duration_length == 0))
 		return
 
-	duration_timers.Add(addtimer(CALLBACK(src, PROC_REF(duration_expire), target), duration_length, TIMER_STOPPABLE | TIMER_DELETE_ME))
+	//REFACTOR ME
+	var/full_duration_length = duration_length + owner.discipline_time_plus
+	duration_timers.Add(addtimer(CALLBACK(src, PROC_REF(duration_expire), target), full_duration_length, TIMER_STOPPABLE | TIMER_DELETE_ME))
 
 /**
  * Overridable proc handling the power's cooldown, which is a timer that triggers the cooldown_expire

--- a/code/modules/wod13/datums/powers/discipline/auspex.dm
+++ b/code/modules/wod13/datums/powers/discipline/auspex.dm
@@ -16,12 +16,11 @@
 	name = "Heightened Senses"
 	desc = "Enhances your senses far past human limitations."
 
-	check_flags = DISC_CHECK_CONSCIOUS
-
 	level = 1
+	check_flags = DISC_CHECK_CONSCIOUS
+	vitae_cost = 0
 
 	toggled = TRUE
-	duration_length = 30 SECONDS
 
 /datum/discipline_power/auspex/heightened_senses/activate()
 	. = ..()
@@ -44,12 +43,11 @@
 	name = "Aura Perception"
 	desc = "Allows you to perceive the auras of those near you."
 
-	check_flags = DISC_CHECK_CONSCIOUS
-
 	level = 2
+	check_flags = DISC_CHECK_CONSCIOUS
+	vitae_cost = 0
 
 	toggled = TRUE
-	duration_length = 30 SECONDS
 
 /datum/discipline_power/auspex/aura_perception/activate()
 	. = ..()
@@ -70,12 +68,11 @@
 	name = "The Spirit's Touch"
 	desc = "Allows you to feel the physical wellbeing of those near you."
 
-	check_flags = DISC_CHECK_CONSCIOUS
-
 	level = 3
+	check_flags = DISC_CHECK_CONSCIOUS
+	vitae_cost = 0
 
 	toggled = TRUE
-	duration_length = 30 SECONDS
 
 /datum/discipline_power/auspex/the_spirits_touch/activate()
 	. = ..()
@@ -98,12 +95,11 @@
 	name = "Telepathy"
 	desc = "Feel the psychic resonances left on objects you can touch."
 
-	check_flags = DISC_CHECK_CONSCIOUS
-
 	level = 4
+	check_flags = DISC_CHECK_CONSCIOUS
+	vitae_cost = 0
 
 	toggled = TRUE
-	duration_length = 30 SECONDS
 
 /datum/discipline_power/auspex/telepathy/activate()
 	. = ..()
@@ -218,9 +214,9 @@
 	name = "Psychic Projection"
 	desc = "Leave your body behind and fly across the land."
 
-	check_flags = DISC_CHECK_CONSCIOUS
-
 	level = 5
+	check_flags = DISC_CHECK_CONSCIOUS
+	vitae_cost = 1
 
 /datum/discipline_power/auspex/psychic_projection/activate()
 	. = ..()

--- a/code/modules/wod13/datums/powers/discipline/bloodheal.dm
+++ b/code/modules/wod13/datums/powers/discipline/bloodheal.dm
@@ -20,7 +20,7 @@
 
 	violates_masquerade = FALSE
 
-	cooldown_length = 1 * DURATION_TURN
+	cooldown_length = 1 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/bloodheal/one,

--- a/code/modules/wod13/datums/powers/discipline/celerity.dm
+++ b/code/modules/wod13/datums/powers/discipline/celerity.dm
@@ -56,7 +56,7 @@
 	check_flags = DISC_CHECK_LYING | DISC_CHECK_IMMOBILE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/celerity/two,
@@ -93,7 +93,7 @@
 	check_flags = DISC_CHECK_LYING | DISC_CHECK_IMMOBILE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/celerity/one,
@@ -129,7 +129,7 @@
 	check_flags = DISC_CHECK_LYING | DISC_CHECK_IMMOBILE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/celerity/one,
@@ -165,7 +165,7 @@
 	check_flags = DISC_CHECK_LYING | DISC_CHECK_IMMOBILE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/celerity/one,
@@ -201,7 +201,7 @@
 	check_flags = DISC_CHECK_LYING | DISC_CHECK_IMMOBILE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/celerity/one,

--- a/code/modules/wod13/datums/powers/discipline/fortitude.dm
+++ b/code/modules/wod13/datums/powers/discipline/fortitude.dm
@@ -21,7 +21,7 @@
 	check_flags = DISC_CHECK_CONSCIOUS
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/fortitude/two,
@@ -52,7 +52,7 @@
 	check_flags = DISC_CHECK_CONSCIOUS
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/fortitude/one,
@@ -83,7 +83,7 @@
 	check_flags = DISC_CHECK_CONSCIOUS
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/fortitude/one,
@@ -114,7 +114,7 @@
 	check_flags = DISC_CHECK_CONSCIOUS
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/fortitude/one,
@@ -145,7 +145,7 @@
 	check_flags = DISC_CHECK_CONSCIOUS
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	grouped_powers = list(
 		/datum/discipline_power/fortitude/one,

--- a/code/modules/wod13/datums/powers/discipline/obfuscate.dm
+++ b/code/modules/wod13/datums/powers/discipline/obfuscate.dm
@@ -1,4 +1,5 @@
 #define COMBAT_COOLDOWN_LENGTH 45 SECONDS
+#define REVEAL_COOLDOWN_LENGTH 15 SECONDS
 
 /datum/discipline/obfuscate
 	name = "Obfuscate"
@@ -32,16 +33,29 @@
 	deltimer(cooldown_timer)
 	cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), COMBAT_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
+/datum/discipline_power/obfuscate/proc/is_seen_check()
+	for (var/mob/living/viewer in oviewers(7, owner))
+		//cats cannot stop you from Obfuscating
+		if (!istype(viewer, /mob/living/carbon) && !viewer.client)
+			continue
+
+		//the corpses are not watching you
+		if (HAS_TRAIT(viewer, TRAIT_BLIND) || viewer.stat >= UNCONSCIOUS)
+			continue
+
+		to_chat(owner, span_warning("You cannot use [src] while you're being observed!"))
+		return FALSE
+
+	return TRUE
+
 //CLOAK OF SHADOWS
 /datum/discipline_power/obfuscate/cloak_of_shadows
 	name = "Cloak of Shadows"
 	desc = "Meld into the shadows and stay unnoticed so long as you draw no attention."
 
 	level = 1
-
 	check_flags = DISC_CHECK_CAPABLE
-
-	duration_length = 10 SECONDS
+	vitae_cost = 0
 
 	toggled = TRUE
 
@@ -52,6 +66,10 @@
 		/datum/discipline_power/obfuscate/vanish_from_the_minds_eye,
 		/datum/discipline_power/obfuscate/cloak_the_gathering
 	)
+
+/datum/discipline_power/obfuscate/cloak_of_shadows/pre_activation_checks()
+	. = ..()
+	return is_seen_check()
 
 /datum/discipline_power/obfuscate/cloak_of_shadows/activate()
 	. = ..()
@@ -73,7 +91,11 @@
 /datum/discipline_power/obfuscate/cloak_of_shadows/proc/handle_move(datum/source, atom/moving_thing, dir)
 	SIGNAL_HANDLER
 
+	to_chat(owner, span_danger("Your [src] falls away as you move from your position!"))
 	try_deactivate(direct = TRUE)
+
+	deltimer(cooldown_timer)
+	cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), REVEAL_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
 //UNSEEN PRESENCE
 /datum/discipline_power/obfuscate/unseen_presence
@@ -81,10 +103,8 @@
 	desc = "Move among the crowds without ever being noticed. Achieve invisibility."
 
 	level = 2
-
 	check_flags = DISC_CHECK_CAPABLE
-
-	duration_length = 20 SECONDS
+	vitae_cost = 0
 
 	toggled = TRUE
 
@@ -95,6 +115,10 @@
 		/datum/discipline_power/obfuscate/vanish_from_the_minds_eye,
 		/datum/discipline_power/obfuscate/cloak_the_gathering
 	)
+
+/datum/discipline_power/obfuscate/unseen_presence/pre_activation_checks()
+	. = ..()
+	return is_seen_check()
 
 /datum/discipline_power/obfuscate/unseen_presence/activate()
 	. = ..()
@@ -104,6 +128,7 @@
 	for(var/mob/living/carbon/human/npc/NPC in GLOB.npc_list)
 		if (NPC.danger_source == owner)
 			NPC.danger_source = null
+
 	owner.alpha = 10
 
 /datum/discipline_power/obfuscate/unseen_presence/deactivate()
@@ -113,11 +138,16 @@
 
 	owner.alpha = 255
 
+//remove this when Mask of a Thousand Faces is made tabletop accurate
 /datum/discipline_power/obfuscate/unseen_presence/proc/handle_move(datum/source, atom/moving_thing, dir)
 	SIGNAL_HANDLER
 
 	if (owner.m_intent != MOVE_INTENT_WALK)
+		to_chat(owner, span_danger("Your [src] falls away as you move too quickly!"))
 		try_deactivate(direct = TRUE)
+
+		deltimer(cooldown_timer)
+		cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), REVEAL_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
 //MASK OF A THOUSAND FACES
 /datum/discipline_power/obfuscate/mask_of_a_thousand_faces
@@ -125,10 +155,7 @@
 	desc = "Be noticed, but incorrectly. Hide your identity but nothing else."
 
 	level = 3
-
 	check_flags = DISC_CHECK_CAPABLE
-
-	duration_length = 30 SECONDS
 
 	toggled = TRUE
 
@@ -139,6 +166,10 @@
 		/datum/discipline_power/obfuscate/vanish_from_the_minds_eye,
 		/datum/discipline_power/obfuscate/cloak_the_gathering
 	)
+
+/datum/discipline_power/obfuscate/mask_of_a_thousand_faces/pre_activation_checks()
+	. = ..()
+	return is_seen_check()
 
 /datum/discipline_power/obfuscate/mask_of_a_thousand_faces/activate()
 	. = ..()
@@ -161,10 +192,7 @@
 	desc = "Disappear from plain view, and possibly wipe your past presence from recollection."
 
 	level = 4
-
 	check_flags = DISC_CHECK_CAPABLE
-
-	duration_length = 40 SECONDS
 
 	toggled = TRUE
 
@@ -197,10 +225,8 @@
 	desc = "Hide yourself and others, scheme in peace."
 
 	level = 5
-
 	check_flags = DISC_CHECK_CAPABLE
-
-	duration_length = 50 SECONDS
+	vitae_cost = 0
 
 	toggled = TRUE
 
@@ -228,3 +254,4 @@
 	owner.alpha = 255
 
 #undef COMBAT_COOLDOWN_LENGTH
+#undef REVEAL_COOLDOWN_LENGTH

--- a/code/modules/wod13/datums/powers/discipline/potence.dm
+++ b/code/modules/wod13/datums/powers/discipline/potence.dm
@@ -21,7 +21,7 @@
 	check_flags = DISC_CHECK_CAPABLE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	var/datum/component/tackler
 
@@ -61,7 +61,7 @@
 	check_flags = DISC_CHECK_CAPABLE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	var/datum/component/tackler
 
@@ -101,7 +101,7 @@
 	check_flags = DISC_CHECK_CAPABLE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	var/datum/component/tackler
 
@@ -141,7 +141,7 @@
 	check_flags = DISC_CHECK_CAPABLE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	var/datum/component/tackler
 
@@ -181,7 +181,7 @@
 	check_flags = DISC_CHECK_CAPABLE
 
 	toggled = TRUE
-	duration_length = DURATION_TURN
+	duration_length = 2 TURNS
 
 	var/datum/component/tackler
 

--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -77,17 +77,49 @@
 	desc = "Solidify into stone and become invulnerable."
 
 	level = 4
-	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_IMMOBILE | DISC_CHECK_LYING
+	check_flags = DISC_CHECK_CONSCIOUS | DISC_CHECK_CAPABLE | DISC_CHECK_LYING
 
 	violates_masquerade = TRUE
 
-	duration_length = 15 SECONDS
-	cooldown_length = 10 SECONDS
+	toggled = TRUE
+	cooldown_length = 1 MINUTES
+	duration_length = 1 MINUTES
 
 /datum/discipline_power/visceratika/armor_of_terra/activate()
 	. = ..()
-	owner.Stun(duration_length)
-	owner.petrify(duration_length, "Visceratika")
+	addtimer(CALLBACK(src, PROC_REF(try_deactivate), null, TRUE), duration_length * 2) //failsafe (no, you can't stay in statue mode forever, 2 mins is enough)
+	to_chat(owner, span_warning("You harden your skin far more than you're able to take for long!"))
+	ADD_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
+	ADD_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
+	ADD_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
+	ADD_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
+	ADD_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
+	ADD_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
+
+	owner.name_override = "Statue of [owner.real_name]"
+	owner.status_flags |= GODMODE
+	var/newcolor = list(rgb(77,77,77), rgb(150,150,150), rgb(28,28,28), rgb(0,0,0))
+	owner.add_atom_colour(newcolor, FIXED_COLOUR_PRIORITY)
+
+	for(var/obj/stuff in owner.contents) //no stealing
+		ADD_TRAIT(stuff, TRAIT_NODROP, MAGIC)
+
+/datum/discipline_power/visceratika/armor_of_terra/deactivate()
+	. = ..()
+	to_chat(owner, span_warning("You soften your skin, to your normal hardness."))
+	REMOVE_TRAIT(owner, TRAIT_STUNIMMUNE, MAGIC)
+	REMOVE_TRAIT(owner, TRAIT_PUSHIMMUNE, MAGIC)
+	REMOVE_TRAIT(owner, TRAIT_NOBLEED, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_MUTE, STATUE_MUTE)
+	REMOVE_TRAIT(owner, TRAIT_IMMOBILIZED, MAGIC_TRAIT)
+	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
+
+	owner.name_override = null
+	owner.status_flags &= GODMODE
+	owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
+
+	for(var/obj/item/stuff in owner.contents)
+		REMOVE_TRAIT(stuff, TRAIT_NODROP, MAGIC)
 
 //FLOW WITHIN THE MOUNTAIN
 /datum/discipline_power/visceratika/flow_within_the_mountain


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR ports [#944](https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/944) and [#941](https://github.com/WorldOfDarknessXIII/World-of-Darkness-13/pull/941) from the upstream. Credit to @Singul0 for the Visceratika changes.

Changes from my PR are as follows:
- Potence, Fortitude, and Celerity now last 10 seconds (2 turns) rather than 6 seconds.
- Bloodheal now has a cooldown of 5 seconds from 6 again.
- Obfuscate and Auspex no longer cost vitae and last indefinitely (in the case of Auspex, only the 5th rank does)
- Obfuscate levels 1-3 can no longer be casted while you're being directly observed by a human or a player. (This is to make rank 4 more worthwhile and closer to tabletop.)
- Obfuscate now goes on a 15 second cooldown if you do anything except combat to reveal yourself, to counterbalance it being free.
- Renames DURATION_TURN and DURATION_SCENE to TURNS and SCENES to make them easier to use, like the SECONDS and whatnot defines.
- Fixes Galdjum having no effect.

Changes from @Singul0 's PR are as follows:
- Visceratika 4 now turns your mob into a statue rather than stuffing you into an object statue, letting you keep your sprite.
- Visceratika 4 is now toggled, and can last a maximum of 2 minutes until it forcefully deactivates itself for a full minute.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Lots of quality of life stuff, some improvements to make it closer to tabletop, all that good stuff!
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
- Potence, Fortitude, and Celerity now last 10 seconds (2 turns) rather than 6 seconds.
- Bloodheal now has a cooldown of 5 seconds from 6 again.
- Obfuscate and Auspex no longer cost vitae and last indefinitely (in the case of Auspex, only the 5th rank does)
- Obfuscate levels 1-3 can no longer be casted while you're being directly observed by a human or a player. (This is to make rank 4 more worthwhile and closer to tabletop.)
- Obfuscate now goes on a 15 second cooldown if you do anything except combat to reveal yourself, to counterbalance it being free.
- Visceratika 4 now turns your mob into a statue rather than stuffing you into an object statue, letting you keep your sprite.
- Visceratika 4 is now toggled, and can last a maximum of 2 minutes until it forcefully deactivates itself for a full minute.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
