### PR TITLE
Fixes Limb Health

### DIFF
--- a/code/modules/mob/living/carbon/werewolf/transformation.dm
+++ b/code/modules/mob/living/carbon/werewolf/transformation.dm
@@ -28,6 +28,8 @@ INITIALIZE_IMMEDIATE(/obj/werewolf_holder/transformation)
 	second.adjustCloneLoss(round((first.getCloneLoss()/100)*percentage)-second.getCloneLoss())
 
 /obj/werewolf_holder/transformation/proc/trans_gender(mob/living/carbon/trans, form)
+	if(trans.stat == 4)
+		return
 	if(!given_quirks)
 		given_quirks = TRUE
 		if(HAS_TRAIT(trans, TRAIT_DANCER))

--- a/code/modules/mob/living/carbon/werewolf/transformation.dm
+++ b/code/modules/mob/living/carbon/werewolf/transformation.dm
@@ -28,7 +28,7 @@ INITIALIZE_IMMEDIATE(/obj/werewolf_holder/transformation)
 	second.adjustCloneLoss(round((first.getCloneLoss()/100)*percentage)-second.getCloneLoss())
 
 /obj/werewolf_holder/transformation/proc/trans_gender(mob/living/carbon/trans, form)
-	if(trans.stat == 4)
+	if(trans.stat == DEAD)
 		return
 	if(!given_quirks)
 		given_quirks = TRUE

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -198,12 +198,12 @@
 	pixel_w = -8
 //	deathsound = 'sound/voice/hiss6.ogg'
 	bodyparts = list(
-		/obj/item/bodypart/chest/alien,
-		/obj/item/bodypart/head/alien,
-		/obj/item/bodypart/l_arm/alien,
-		/obj/item/bodypart/r_arm/alien,
-		/obj/item/bodypart/r_leg/alien,
-		/obj/item/bodypart/l_leg/alien,
+		/obj/item/bodypart/chest/crinos,
+		/obj/item/bodypart/head/crinos,
+		/obj/item/bodypart/l_arm/crinos,
+		/obj/item/bodypart/r_arm/crinos,
+		/obj/item/bodypart/r_leg/crinos,
+		/obj/item/bodypart/l_leg/crinos,
 		)
 
 	werewolf_armor = 30

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -198,12 +198,12 @@
 	pixel_w = -8
 //	deathsound = 'sound/voice/hiss6.ogg'
 	bodyparts = list(
-		/obj/item/bodypart/chest,
-		/obj/item/bodypart/head,
-		/obj/item/bodypart/l_arm,
-		/obj/item/bodypart/r_arm,
-		/obj/item/bodypart/r_leg,
-		/obj/item/bodypart/l_leg,
+		/obj/item/bodypart/chest/alien,
+		/obj/item/bodypart/head/alien,
+		/obj/item/bodypart/l_arm/alien,
+		/obj/item/bodypart/r_arm/alien,
+		/obj/item/bodypart/r_leg/alien,
+		/obj/item/bodypart/l_leg/alien,
 		)
 
 	werewolf_armor = 30

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -38,7 +38,7 @@
 	if(prob(probability))
 		zone = check_zone(zone)
 	else
-		zone = pickweight(list(BODY_ZONE_HEAD = 1, BODY_ZONE_CHEST = 1, BODY_ZONE_L_ARM = 4, BODY_ZONE_R_ARM = 4, BODY_ZONE_L_LEG = 4, BODY_ZONE_R_LEG = 4))
+		zone = pickweight(list(BODY_ZONE_HEAD = 1, BODY_ZONE_CHEST = 4, BODY_ZONE_L_ARM = 1, BODY_ZONE_R_ARM = 1, BODY_ZONE_L_LEG = 1, BODY_ZONE_R_LEG = 1))
 	return zone
 
 ///Would this zone be above the neck

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -3,7 +3,7 @@
 	desc = "Didn't make sense not to live for fun, your brain gets smart but your head gets dumb."
 	icon = 'icons/mob/human_parts.dmi'
 	icon_state = "default_human_head"
-	max_damage = 200
+	max_damage = 500
 	body_zone = BODY_ZONE_HEAD
 	body_part = HEAD
 	w_class = WEIGHT_CLASS_BULKY //Quite a hefty load

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -279,8 +279,11 @@
 	px_x = 0
 	px_y = 0
 	dismemberable = 0
-	max_damage = 600
+	max_damage = 500
 	animal_origin = ALIEN_BODYPART
+
+/obj/item/bodypart/head/crinos
+	max_damage = 600
 
 /obj/item/bodypart/head/larva
 	icon = 'icons/mob/animal_parts.dmi'

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -3,7 +3,7 @@
 	desc = "Didn't make sense not to live for fun, your brain gets smart but your head gets dumb."
 	icon = 'icons/mob/human_parts.dmi'
 	icon_state = "default_human_head"
-	max_damage = 500
+	max_damage = 300
 	body_zone = BODY_ZONE_HEAD
 	body_part = HEAD
 	w_class = WEIGHT_CLASS_BULKY //Quite a hefty load
@@ -279,7 +279,7 @@
 	px_x = 0
 	px_y = 0
 	dismemberable = 0
-	max_damage = 500
+	max_damage = 600
 	animal_origin = ALIEN_BODYPART
 
 /obj/item/bodypart/head/larva

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -38,8 +38,11 @@
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_chest"
 	dismemberable = 0
-	max_damage = 600
+	max_damage = 500
 	animal_origin = ALIEN_BODYPART
+
+/obj/item/bodypart/chest/crinos
+	max_damage = 600
 
 /obj/item/bodypart/chest/larva
 	icon = 'icons/mob/animal_parts.dmi'
@@ -142,8 +145,11 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 125
+	max_damage = 100
 	animal_origin = ALIEN_BODYPART
+
+/obj/item/bodypart/l_arm/crinos
+	max_damage = 125
 
 /obj/item/bodypart/r_arm
 	name = "right arm"
@@ -237,8 +243,11 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 125
+	max_damage = 100
 	animal_origin = ALIEN_BODYPART
+
+/obj/item/bodypart/r_arm/crinos
+	max_damage = 125
 
 /obj/item/bodypart/l_leg
 	name = "left leg"
@@ -326,8 +335,11 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 125
+	max_damage = 100
 	animal_origin = ALIEN_BODYPART
+
+/obj/item/bodypart/l_leg/crinos
+	max_damage = 125
 
 /obj/item/bodypart/r_leg
 	name = "right leg"
@@ -417,5 +429,8 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 125
+	max_damage = 100
 	animal_origin = ALIEN_BODYPART
+
+/obj/item/bodypart/r_leg/crinos
+	max_damage = 125

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -3,7 +3,7 @@
 	name = BODY_ZONE_CHEST
 	desc = "It's impolite to stare at a person's chest."
 	icon_state = "default_human_chest"
-	max_damage = 200
+	max_damage = 600 //Enough to account for Crinos (500 health), otherwise damage can get voided which is not what we want.
 	body_zone = BODY_ZONE_CHEST
 	body_part = CHEST
 	px_x = 0
@@ -57,7 +57,7 @@
 	icon_state = "default_human_l_arm"
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	max_damage = 50
+	max_damage = 100
 	max_stamina_damage = 50
 	body_zone = BODY_ZONE_L_ARM
 	body_part = ARM_LEFT
@@ -152,7 +152,7 @@
 	icon_state = "default_human_r_arm"
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	max_damage = 50
+	max_damage = 100
 	body_zone = BODY_ZONE_R_ARM
 	body_part = ARM_RIGHT
 	aux_zone = BODY_ZONE_PRECISE_R_HAND
@@ -247,7 +247,7 @@
 	icon_state = "default_human_l_leg"
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	max_damage = 50
+	max_damage = 100
 	body_zone = BODY_ZONE_L_LEG
 	body_part = LEG_LEFT
 	body_damage_coeff = 0.75
@@ -338,7 +338,7 @@
 	icon_state = "default_human_r_leg"
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	max_damage = 50
+	max_damage = 100
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT
 	body_damage_coeff = 0.75

--- a/code/modules/surgery/bodyparts/parts.dm
+++ b/code/modules/surgery/bodyparts/parts.dm
@@ -3,7 +3,7 @@
 	name = BODY_ZONE_CHEST
 	desc = "It's impolite to stare at a person's chest."
 	icon_state = "default_human_chest"
-	max_damage = 600 //Enough to account for Crinos (500 health), otherwise damage can get voided which is not what we want.
+	max_damage = 300
 	body_zone = BODY_ZONE_CHEST
 	body_part = CHEST
 	px_x = 0
@@ -38,7 +38,7 @@
 	icon = 'icons/mob/animal_parts.dmi'
 	icon_state = "alien_chest"
 	dismemberable = 0
-	max_damage = 500
+	max_damage = 600
 	animal_origin = ALIEN_BODYPART
 
 /obj/item/bodypart/chest/larva
@@ -57,7 +57,7 @@
 	icon_state = "default_human_l_arm"
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	max_damage = 100
+	max_damage = 75
 	max_stamina_damage = 50
 	body_zone = BODY_ZONE_L_ARM
 	body_part = ARM_LEFT
@@ -142,7 +142,7 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 100
+	max_damage = 125
 	animal_origin = ALIEN_BODYPART
 
 /obj/item/bodypart/r_arm
@@ -152,7 +152,7 @@
 	icon_state = "default_human_r_arm"
 	attack_verb_continuous = list("slaps", "punches")
 	attack_verb_simple = list("slap", "punch")
-	max_damage = 100
+	max_damage = 75
 	body_zone = BODY_ZONE_R_ARM
 	body_part = ARM_RIGHT
 	aux_zone = BODY_ZONE_PRECISE_R_HAND
@@ -237,7 +237,7 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 100
+	max_damage = 125
 	animal_origin = ALIEN_BODYPART
 
 /obj/item/bodypart/l_leg
@@ -247,7 +247,7 @@
 	icon_state = "default_human_l_leg"
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	max_damage = 100
+	max_damage = 75
 	body_zone = BODY_ZONE_L_LEG
 	body_part = LEG_LEFT
 	body_damage_coeff = 0.75
@@ -326,7 +326,7 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 100
+	max_damage = 125
 	animal_origin = ALIEN_BODYPART
 
 /obj/item/bodypart/r_leg
@@ -338,7 +338,7 @@
 	icon_state = "default_human_r_leg"
 	attack_verb_continuous = list("kicks", "stomps")
 	attack_verb_simple = list("kick", "stomp")
-	max_damage = 100
+	max_damage = 75
 	body_zone = BODY_ZONE_R_LEG
 	body_part = LEG_RIGHT
 	body_damage_coeff = 0.75
@@ -417,5 +417,5 @@
 	px_y = 0
 	dismemberable = FALSE
 	can_be_disabled = FALSE
-	max_damage = 100
+	max_damage = 125
 	animal_origin = ALIEN_BODYPART


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjusts the max health of limbs to account for the codebase's increased healthpools.

Because limbs capped out at 200 max damage, you'd end up with situations where you'd continue hitting a limb after it reached its max damage, causing no damage at all. 200 max limb health is fine for a normal SS13 server where people die after taking 200 damage total, but not for servers where people can reach upwards of 600 max health.

Also makes it so random misses are more likely to hit chest instead of limbs, reducing RNG in actually downing someone, since limbs have little max health and hitting them is often a wasted hit as the excess damage does not transfer elsewhere.

Also adds a status check on the transformation proc to maybe, potentially fix the Lupus revival bug.

## Why It's Good For The Game

This fixes the issue where Crinos werewolves could tank unreasonable amounts of damage. After live testing, I am convinced this is enough to fix the issue and other nerfs might not be necessary.
