### PR TITLE
Removes Bloodpacks from Supply/Warehouse

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -30,20 +30,6 @@
 	)
 	crate_name = "weapon crate"
 
-/datum/supply_pack/vampire/bloodpack
-	name = "Blood Pack"
-	desc = "Contains 5 default blood packs."
-	cost = 100
-	contains = list(/obj/item/drinkable_bloodpack = 5)
-	crate_name = "blood crate"
-
-/datum/supply_pack/vampire/bloodpack_elite
-	name = "Elite Blood Pack"
-	desc = "Contains 5 elite blood packs."
-	cost = 300
-	contains = list(/obj/item/drinkable_bloodpack/elite = 5)
-	crate_name = "blood crate"
-
 /datum/supply_pack/vampire/weaponstake
 	name = "Weapon (stake)"
 	desc = "Contains 3 usable wooden stakes."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title says, removes bloodpacks from the supply warehouse purchase

## Why It's Good For The Game

You could purchase bloodpacks in sets of 5 very cheaply compared to the clinic. The clinic was originally the only place to obtain bloodpacks.

Supply offered 5 Bloodpacks for the price of one, with 5 Elite bloodpacks for the price of 1.5 of one. This made purchasing from medical a net loss, as they price bloodpacks at 100 Dollar and 250 Dollar respectivaly.

All this does is give the clinic something more to do than wait for mass casualty events.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
del: Removed Bloodpacks from Warehouse/Supply
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
