### PR TITLE
Rebalances Bloodpack prices from Supply/Warehouse

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -33,14 +33,14 @@
 /datum/supply_pack/vampire/bloodpack
 	name = "Blood Pack"
 	desc = "Contains 5 default blood packs."
-	cost = 100
+	cost = 750
 	contains = list(/obj/item/drinkable_bloodpack = 5)
 	crate_name = "blood crate"
 
 /datum/supply_pack/vampire/bloodpack_elite
 	name = "Elite Blood Pack"
 	desc = "Contains 5 elite blood packs."
-	cost = 300
+	cost = 1250
 	contains = list(/obj/item/drinkable_bloodpack/elite = 5)
 	crate_name = "blood crate"
 

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -40,7 +40,7 @@
 /datum/supply_pack/vampire/bloodpack_elite
 	name = "Elite Blood Pack"
 	desc = "Contains 5 elite blood packs."
-	cost = 1250
+	cost = 1750
 	contains = list(/obj/item/drinkable_bloodpack/elite = 5)
 	crate_name = "blood crate"
 


### PR DESCRIPTION
## About The Pull Request

Changes the value of bloodpacks from 100/5 bags to 750/5 bags, and 300/5 elite bags to 1750/5 elite bags

## Why It's Good For The Game

Previously bloodbags were _really cheap_, this made it hard to act as an alternative source of bloodbags as the dealer sold normals for 20/bag, and elite for 60/bag.

Now, bags are _expensive_, but unlike the alternative PR, (#62), the dealer is still a possible source of bloodbags.

The market floor's now 150 and 350 each, that's plenty of wiggle room to undercut the dealer. More importantly, desperate moralist vampires aren't simply out of luck if the clinic's understaffed or busy.

Notes: Obviously this PR will be closed if #62 passes, given it'd be redundant.

## Changelog
:cl:
balance: Nerfed the accessibility of warehouse bloodbags to give more wiggle room to alternative means.
/:cl: