### PR TITLE
adds two new abyss mysticism runes, one to break lights in a radius, one to heal

### DIFF
--- a/code/modules/vtmb/magic/mysticism.dm
+++ b/code/modules/vtmb/magic/mysticism.dm
@@ -137,7 +137,7 @@
 
 /obj/abyssrune/identification
 	name = "Occult Items Identification"
-	desc = "Identificates single occult item"
+	desc = "Identifies a single occult item"
 	icon_state = "rune4"
 	word = "WUS'ZAT"
 
@@ -148,3 +148,46 @@
 			playsound(loc, 'sound/magic/voidblink.ogg', 50, FALSE)
 			qdel(src)
 			return
+
+/obj/abyssrune/blackout //not canon wod material, seemed a cool idea.
+	name = "Blackout"
+	desc = "Destroys every wall light in range of the rune."
+	icon_state = "rune7"
+	word = "FYU'SES BLO'OUN"
+	mystlevel = 2
+
+//actual function of the rune
+/obj/abyssrune/blackout/complete()
+	for(var/obj/machinery/light/i in range(7, src)) //for every light in a range of 7 (called i)
+		if(i != LIGHT_BROKEN) //if it aint broke
+			i.break_light_tube(0) //break it
+	playsound(loc, 'sound/magic/voidblink.ogg', 50, FALSE) //make the funny void sound
+	qdel(src) //delete the rune
+
+/obj/abyssrune/comforting_darkness
+	name = "Comforting Darkness"
+	desc = "Use the power of the abyss to mend the wounds of yourself and others."
+	icon_state = "rune8"
+	word = "KEYUR AGA"
+	mystlevel = 2
+
+/obj/abyssrune/comforting_darkness/complete()
+	for(var/mob/living/victim in src.loc) //for every living mob in the same space as the rune
+		victim.adjustBruteLoss(-30)
+		victim.adjustFireLoss(-10)
+		victim.adjustToxLoss(-20)
+		victim.adjustCloneLoss(-5)
+		victim.SetSleeping(60)
+		playsound(loc, 'sound/magic/voidblink.ogg', 50, FALSE)
+		qdel(src)
+		return //shit uhhhhh do i need this???
+
+	//after the loop is exited (due to failure to find) it resorts to working on the caster
+	src.last_activator.adjustBruteLoss(-30) //not a lot, less than a good sword hit's worth, better to heal someone else with
+	src.last_activator.adjustFireLoss(-10) //better have burn heal!
+	src.last_activator.adjustToxLoss(-20) //shit, how do kindred deal with tox?
+	src.last_activator.adjustCloneLoss(-5) //heals clone damage at a VERY small rate
+	src.last_activator.SetSleeping(60) //sleeping is for balance to stop you from just selfspamming these. MIGHT be exploitable for offense too, but hey, creativity! its runes!
+	playsound(loc, 'sound/magic/voidblink.ogg', 50, FALSE)
+	qdel(src)
+	//godawful, sorry, could be worse though.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds two new Abyss Mysticism runes to Obtenebration.
Blackout - (non-canonical) Breaks all electronic lights in a radius of 7 tiles.
Comforting Darkness - Heals either the mob on the rune or the caster. Puts them to sleep also.
Also fixes a grammatical error in the identification rune.

I should add, these are my first proper additions, so do tell me if they are ABSOLUTE GARBAGE <3

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As it was, Abyss Mysticism was very bare-bones, an afterthought and took a lot of its abilities from Thaumaturgy anyway.
This provides some unique runes that are flavourful, fleshing out this mechanic, without stealing Thaumaturgy's thunder.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>

<summary>Screenshots&Videos</summary>

please excuse the unserious nature of some of this

![image](https://github.com/user-attachments/assets/a457ddd6-b1a9-491b-a922-5f67efe87227)
appears in rune menu for mysticism.

![image](https://github.com/user-attachments/assets/f17e9696-e423-4944-833e-07da4ec5c3f9)
blackout rune drawn

![image](https://github.com/user-attachments/assets/74ec0d8c-d4d9-43ea-b2c9-574d0f77ddf8)
breaks lights in radius, but doesnt break those outside the radius

rune 2

![image](https://github.com/user-attachments/assets/60cc860a-d990-4ae1-8efd-0ef182fe76ae)
boy i sure am feeling hurt ouch oof my bones! (only testing brute damage, but should work fine for other types as specified)

![image](https://github.com/user-attachments/assets/941c3ed2-89ef-43d1-836f-20a1ea10d1d4)
used off of the rune, puts to sleep
![image](https://github.com/user-attachments/assets/169dbb97-bb09-4b55-9867-16068b395b9a)
boom, thats 30 less brute. maybe tweak the value if need be. i undertuned it because i wasnt too sure.
also runes are very spammy en masse so yknow.

![image](https://github.com/user-attachments/assets/c27b4e46-587d-4eca-8966-2fd455818d34)
somebody's killed that kine! oh no!
![image](https://github.com/user-attachments/assets/0d4594a0-e001-4dac-89bf-e33caced7ea1)

![image](https://github.com/user-attachments/assets/be0da857-9cc5-40a8-8b67-b7bf5cbe45db)
after healing with the rune. (would sleep them if they were still alive)
doesnt heal anything other than the actual damageloss though

![image](https://github.com/user-attachments/assets/92e4969e-3dcc-41c5-933b-0b450ad6c7b0)
also just works when you are on the rune.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: two new obtenebration abyss mysticism runes and their function
spellcheck: fixed grammatical error on abyss identification rune
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
