### PR TITLE
Adds Keui-Jin to Clinic Director species

### DIFF
--- a/code/modules/vtmb/jobs/doctor.dm
+++ b/code/modules/vtmb/jobs/doctor.dm
@@ -74,7 +74,7 @@
 
 	liver_traits = list(TRAIT_MEDICAL_METABOLISM)
 
-	allowed_species = list("Vampire", "Ghoul", "Human", "Werewolf")
+	allowed_species = list("Vampire", "Ghoul", "Human", "Werewolf", "Kuei-Jin")
 	display_order = JOB_DISPLAY_ORDER_CLINICS_DIRECTOR
 	bounty_types = CIV_JOB_MED
 


### PR DESCRIPTION

## About The Pull Request

Title

## Why It's Good For The Game

Clinic director could currently be played by all species _but_ Keui-Jin. This seems like an oversight, as doctor roles have no such restriction. 

Given that even staff currently play Keui-Jin clinic directors, there seems to be interest in allowing this.