### PR TITLE
Necromancy Ghost Sight is Free Like Auspex Now

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/necromancy.dm
+++ b/code/modules/wod13/datums/powers/discipline/necromancy.dm
@@ -118,10 +118,11 @@
 	button_icon_state = "ghost"
 	check_flags = AB_CHECK_CONSCIOUS
 	vampiric = TRUE
+	var/ghosts_visible = FALSE
 
 /datum/action/ghost_hear/Trigger()
 	. = ..()
-	if(owner.see_invisible == SEE_INVISIBLE_OBSERVER)
+	if(ghosts_visible == TRUE)
 		deactivate()
 	else
 		activate()
@@ -129,6 +130,7 @@
 /datum/action/ghost_hear/proc/activate()
 	if(!isliving(owner))
 		return
+	ghosts_visible = TRUE
 	var/mob/living/user = owner
 	user.see_invisible = SEE_INVISIBLE_OBSERVER
 	to_chat(owner, span_notice("You peek beyond the Shroud to see ghosts."))
@@ -136,6 +138,7 @@
 /datum/action/ghost_hear/proc/deactivate()
 	if(!isliving(owner))
 		return
+	ghosts_visible = FALSE
 	var/mob/living/user = owner
 	user.see_invisible = initial(owner.see_invisible)
 	to_chat(owner, span_warning("Your vision returns to the mortal realm."))

--- a/code/modules/wod13/datums/powers/discipline/necromancy.dm
+++ b/code/modules/wod13/datums/powers/discipline/necromancy.dm
@@ -121,13 +121,15 @@
 
 /datum/action/ghost_hear/Trigger()
 	. = ..()
-	activate()
+	if(user.see_invisible == SEE_INVISIBLE_OBSERVER)
+		deactivate()
+	else
+		activate()
 
 /datum/action/ghost_hear/proc/activate()
 	if(!isliving(owner))
 		return
 	var/mob/living/user = owner
-
 	user.see_invisible = SEE_INVISIBLE_OBSERVER
 	to_chat(owner, span_notice("You peek beyond the Shroud to see ghosts."))
 

--- a/code/modules/wod13/datums/powers/discipline/necromancy.dm
+++ b/code/modules/wod13/datums/powers/discipline/necromancy.dm
@@ -132,10 +132,6 @@
 	if(!isliving(owner))
 		return
 	var/mob/living/user = owner
-	if (user.bloodpool < 1)
-		to_chat(owner, span_warning("You don't have enough blood to peek into the Shadowlands!"))
-		return
-	user.bloodpool = max(user.bloodpool - 1, 0)
 
 	loop_timer = addtimer(CALLBACK(src, PROC_REF(refresh)), duration_length, TIMER_STOPPABLE | TIMER_DELETE_ME)
 	user.see_invisible = SEE_INVISIBLE_OBSERVER
@@ -156,9 +152,7 @@
 		return
 	var/mob/living/user = owner
 
-	if (user.bloodpool >= 1)
-		user.bloodpool = max(user.bloodpool - 1, 0)
-		to_chat(owner, span_warning("Your ghost sight consumes blood to stay active..."))
+	if (TRUE)
 		loop_timer = addtimer(CALLBACK(src, PROC_REF(refresh)), duration_length, TIMER_STOPPABLE | TIMER_DELETE_ME)
 	else
 		deactivate()

--- a/code/modules/wod13/datums/powers/discipline/necromancy.dm
+++ b/code/modules/wod13/datums/powers/discipline/necromancy.dm
@@ -116,24 +116,18 @@
 	name = "See Ghosts"
 	desc = "Allows you to see ghosts."
 	button_icon_state = "ghost"
-	check_flags = AB_CHECK_HANDS_BLOCKED | AB_CHECK_IMMOBILE | AB_CHECK_LYING | AB_CHECK_CONSCIOUS
+	check_flags = AB_CHECK_CONSCIOUS
 	vampiric = TRUE
-	var/datum/timedevent/loop_timer
-	var/duration_length = 15 SECONDS
 
 /datum/action/ghost_hear/Trigger()
 	. = ..()
-	if (loop_timer)
-		deactivate()
-	else
-		activate()
+	activate()
 
 /datum/action/ghost_hear/proc/activate()
 	if(!isliving(owner))
 		return
 	var/mob/living/user = owner
 
-	loop_timer = addtimer(CALLBACK(src, PROC_REF(refresh)), duration_length, TIMER_STOPPABLE | TIMER_DELETE_ME)
 	user.see_invisible = SEE_INVISIBLE_OBSERVER
 	to_chat(owner, span_notice("You peek beyond the Shroud to see ghosts."))
 
@@ -141,21 +135,8 @@
 	if(!isliving(owner))
 		return
 	var/mob/living/user = owner
-
-	deltimer(loop_timer)
-	loop_timer = null
 	user.see_invisible = initial(owner.see_invisible)
 	to_chat(owner, span_warning("Your vision returns to the mortal realm."))
-
-/datum/action/ghost_hear/proc/refresh()
-	if(!isliving(owner))
-		return
-	var/mob/living/user = owner
-
-	if (TRUE)
-		loop_timer = addtimer(CALLBACK(src, PROC_REF(refresh)), duration_length, TIMER_STOPPABLE | TIMER_DELETE_ME)
-	else
-		deactivate()
 
 //SHAMBLING HORDES
 /datum/discipline_power/necromancy/shambling_hordes

--- a/code/modules/wod13/datums/powers/discipline/necromancy.dm
+++ b/code/modules/wod13/datums/powers/discipline/necromancy.dm
@@ -121,7 +121,7 @@
 
 /datum/action/ghost_hear/Trigger()
 	. = ..()
-	if(user.see_invisible == SEE_INVISIBLE_OBSERVER)
+	if(owner.see_invisible == SEE_INVISIBLE_OBSERVER)
 		deactivate()
 	else
 		activate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes ghost sight free like auspex. It's balanced because auspex gets to be free.


Also made me realize that we really do need some kind of refactor for abilities gained from disciplines gained at certain thresholds and aren't activated the usual way. Ghost sight seems to be a vanilla tgstation ability or something, it's weird.


## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Ghost sight's timer just lasts too short and uses up too much blood for what it is. This will make necromancy users happy.

## Testing Photographs and Procedure

It's a one or two line edit to make the ability work like all the other free cantrips.

</details>

## Testing


https://github.com/user-attachments/assets/7eb4ab9d-d8e9-4256-b12c-7f5a08d620c8



## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Necromancy's Ghost sight is free now.
:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
