### PR TITLE
Vision Team Balance: Discipline Sharing Costs

### DIFF
--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -739,7 +739,7 @@
 	if (student.stat >= SOFT_CRIT)
 		to_chat(teacher, span_warning("Your student needs to be conscious!"))
 		return
-	if (teacher_prefs.true_experience < 10)
+	if (teacher_prefs.true_experience < 100)
 		to_chat(teacher, span_warning("You don't have enough experience to teach them this Discipline!"))
 		return
 	//checks that the teacher has blood bonded the student, this is something that needs to be reworked when blood bonds are made better
@@ -795,7 +795,7 @@
 
 		visible_message(span_notice("[teacher] begins mentoring [student] in [giving_discipline]."))
 		if (do_after(teacher, 30 SECONDS, student))
-			teacher_prefs.true_experience -= 10
+			teacher_prefs.true_experience -= 100
 
 			student_prefs.discipline_types += teaching_discipline
 			student_prefs.discipline_levels += 0


### PR DESCRIPTION
### **Vision Team Balance: Discipline Sharing Costs**
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

With increased XP gaining values, 10 is barely a cost. Teaching another a Discipline now costs the teacher 100 XP, more balancing to occur eventually.

## Why It's Good For The Game

XP Cost balanced around our higher gains, short and simple.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Rebalance Discipline Teaching, to match our XP gain rates.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
