### PR TITLE
Malk headrole characters have control over their speech

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -19,6 +19,10 @@
 			if(iskindred(src))
 				if(clane)
 					if(clane.name == "Malkavian")
+						if (job in GLOB.command_positions)
+							return
+						if (job in GLOB.camarilla_council_positions)
+							return
 						for(var/mob/living/carbon/human/H in GLOB.malkavian_list)
 							if(H)
 //							if(H != src)


### PR DESCRIPTION
## About The Pull Request

Malkavian head characters won't randomly speak in madness to every other Malkavian (Particularly- Prince, Seneschal, Sheriff, Hound, Primogen).

## Why It's Good For The Game

It's good for the game as it promotes people in higher positions having self control to not dox conversations they're actively happening, and promotes those people to have self-control instead of being batshit.


## Changelog

:cl: DasFox
code: Malk headroles don't randomly speak madly.
/:cl: