### PR TITLE
fix Armor of Terra immortality

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/visceratika.dm
+++ b/code/modules/wod13/datums/powers/discipline/visceratika.dm
@@ -115,7 +115,7 @@
 	REMOVE_TRAIT(owner, TRAIT_HANDS_BLOCKED, MAGIC_TRAIT)
 
 	owner.name_override = null
-	owner.status_flags &= GODMODE
+	owner.status_flags &= ~GODMODE
 	owner.remove_atom_colour(FIXED_COLOUR_PRIORITY)
 
 	for(var/obj/item/stuff in owner.contents)


### PR DESCRIPTION
## About The Pull Request

Fixes #146  , there was a syntax error that stopped the godmode from being stripped after statue form expires, making gargoyles immortal even after Armor of Terra expires. 

## Why It's Good For The Game

Armor of Terra / Visceratika 4 is meant to lose its immortality once statue form expires. 

## Testing Photographs and Procedure
<details>
<summary>Testing Photographs and Procedure</summary>

![testterra](https://github.com/user-attachments/assets/eab676ce-fb72-4385-b8cd-17dbf6e17a84)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Armor of Terra no longer makes you permanently immortal 
/:cl:
