### PR TITLE
Less accident-prone Garou transformation

### DIFF
--- a/code/_onclick/hud/werewolf.dm
+++ b/code/_onclick/hud/werewolf.dm
@@ -18,8 +18,9 @@
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
-/atom/movable/screen/transform_homid/Click()
-	var/mob/living/carbon/C = usr
+/atom/movable/screen/transform_homid/CtrlClick(mob/user)
+	. = ..()
+	var/mob/living/carbon/C = user
 	if(C.stat >= SOFT_CRIT || C.IsSleeping() || C.IsUnconscious() || C.IsParalyzed() || C.IsKnockdown() || C.IsStun())
 		return
 	if(C.transformator)
@@ -32,8 +33,9 @@
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
-/atom/movable/screen/transform_crinos/Click()
-	var/mob/living/carbon/C = usr
+/atom/movable/screen/transform_crinos/CtrlClick(mob/user)
+	. = ..()
+	var/mob/living/carbon/C = user
 	if(C.stat >= SOFT_CRIT || C.IsSleeping() || C.IsUnconscious() || C.IsParalyzed() || C.IsKnockdown() || C.IsStun())
 		return
 	if(C.transformator)
@@ -46,8 +48,9 @@
 	layer = HUD_LAYER
 	plane = HUD_PLANE
 
-/atom/movable/screen/transform_lupus/Click()
-	var/mob/living/carbon/C = usr
+/atom/movable/screen/transform_lupus/CtrlClick(mob/user)
+	. = ..()
+	var/mob/living/carbon/C = user
 	if(C.stat >= SOFT_CRIT || C.IsSleeping() || C.IsUnconscious() || C.IsParalyzed() || C.IsKnockdown() || C.IsStun())
 		return
 	if(C.transformator)
@@ -75,7 +78,8 @@
 		C.transformator.lupus_form.last_moon_look = world.time
 		C.transformator.crinos_form.last_moon_look = world.time
 		C.transformator.human_form.last_moon_look = world.time
-		to_chat(C, "<span class='notice'>The Moon is [GLOB.moon_state].</span>")
+		to_chat(C, span_notice("The Moon is [GLOB.moon_state]."))
+		to_chat(C, span_notice("You can activate transformations using Ctrl-Click!"))
 //		icon_state = "[GLOB.moon_state]"
 		C.emote("howl")
 		playsound(get_turf(C), pick('code/modules/wod13/sounds/awo1.ogg', 'code/modules/wod13/sounds/awo2.ogg'), 100, FALSE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR makes Garou transformations trigger using Ctrl-Click instead of just Click.

## Why It's Good For The Game

Less prone to accidents, like new players transforming in public or tabbing back into the game and mis-clicking on a transformation (this totally didn't happen to me just the round before I wrote this PR tehee).

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Garou transformations trigger using Ctrl-Click instead of just Click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
