### PR TITLE
Increases Tenebrous Form's walk speed

### DIFF
--- a/code/modules/spells/spell_types/shadow_walk.dm
+++ b/code/modules/spells/spell_types/shadow_walk.dm
@@ -70,7 +70,7 @@
 
 
 /obj/effect/dummy/phased_mob/shadow/relaymove(mob/living/user, direction)
-	if(last_go+5 > world.time)
+	if(last_go+2 > world.time)
 		return
 	last_go = world.time
 	var/turf/oldloc = loc


### PR DESCRIPTION
## About The Pull Request
WOE, BALANCE PR 🫶
* Increases Tenebrous Form's walk speed. Now roughly the same as ordinary walk speed.

https://github.com/user-attachments/assets/c35c7e50-6660-45c3-9f35-4c949369ff73

## Why It's Good For The Game
Tenebrous Form is underwhelming & uncomfortable to use for the level it is at. You're about as fast as your grandma's stair lift which makes dodging flashlights practically impossible. As it stands, Obfuscate is nearly a better version of it because you keep your speed, the average player's as blind as a bat and very little breaks your cloak unless it's from the player's end.

## Changelog
:cl:
balance: Tenebrous Form's walk speed is increased.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
