### PR TITLE
Voice of Domination QoL: Halo Effect

### DIFF
--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -219,15 +219,13 @@
 
 	for(var/V in listeners)
 		if(ishuman(V))
-			var/mob/living/carbon/human/TRGT = V
-			TRGT.remove_overlay(MUTATIONS_LAYER)
+			var/mob/living/carbon/human/dominate_target = V
+			dominate_target.remove_overlay(MUTATIONS_LAYER)
 			var/mutable_appearance/dominate_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "dominate", -MUTATIONS_LAYER)
 			dominate_overlay.pixel_z = 2
-			TRGT.overlays_standing[MUTATIONS_LAYER] = dominate_overlay
-			TRGT.apply_overlay(MUTATIONS_LAYER)
-			spawn(2 SECONDS)
-				if(TRGT)
-					TRGT.remove_overlay(MUTATIONS_LAYER)
+			dominate_target.overlays_standing[MUTATIONS_LAYER] = dominate_overlay
+			dominate_target.apply_overlay(MUTATIONS_LAYER)
+			addtimer(CALLBACK(dominate_target, TYPE_PROC_REF(/mob/living/carbon/human, post_dominate_checks), dominate_target), 2 SECONDS)
 
 	//removed some keywords as they don't fit mental domination
 	var/static/regex/stun_words = regex("stop|wait|stand still|hold on|halt|cease")
@@ -248,7 +246,6 @@
 	var/static/regex/whoareyou_words = regex("who are you|say your name|state your name|identify")
 	var/static/regex/saymyname_words = regex("say my name|who am i|whoami")
 	var/static/regex/knockknock_words = regex("knock knock")
-	//var/static/regex/statelaws_words = regex("state laws|state your laws")
 	var/static/regex/move_words = regex("move|walk")
 	var/static/regex/left_words = regex("left|west|port")
 	var/static/regex/right_words = regex("right|east|starboard")
@@ -271,7 +268,6 @@
 	var/static/regex/salute_words = regex("salute")
 	var/static/regex/deathgasp_words = regex("play dead")
 	var/static/regex/clap_words = regex("clap|applaud")
-//	var/static/regex/honk_words = regex("ho+nk") //hooooooonk
 	var/static/regex/multispin_words = regex("like a record baby|right round")
 
 	var/i = 0
@@ -419,14 +415,6 @@
 			var/mob/living/L = V
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/atom/movable, say), "Who's there?"), 5 * i)
 			i++
-
-	//STATE LAWS
-	/*
-	else if((findtext(message, statelaws_words)))
-		cooldown = COOLDOWN_STUN
-		for(var/mob/living/silicon/S in listeners)
-			S.statelaws(force = 1)
-	*/
 
 	//MOVE
 	else if((findtext(message, move_words)))
@@ -581,15 +569,6 @@
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob/living/, emote), "clap"), 5 * i)
 			i++
 
-/*	//HONK
-	else if((findtext(message, honk_words)))
-		cooldown = COOLDOWN_MEME
-		addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(playsound), get_turf(user), 'sound/items/bikehorn.ogg', 300, 1), 25)
-		if(user.mind && user.mind.assigned_role == "Clown")
-			for(var/mob/living/carbon/C in listeners)
-				C.slip(140 * power_multiplier)
-			cooldown = COOLDOWN_MEME
-*/
 	//RIGHT ROUND
 	else if((findtext(message, multispin_words)))
 		cooldown = COOLDOWN_MEME

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -217,6 +217,18 @@
 		power_multiplier *= (1 + (1/specific_listeners.len)) //2x on a single guy, 1.5x on two and so on
 		message = copytext(message, length(found_string) + 1)
 
+	for(var/V in listeners)
+		if(ishuman(V))
+			var/mob/living/carbon/human/TRGT = V
+			TRGT.remove_overlay(MUTATIONS_LAYER)
+			var/mutable_appearance/dominate_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "dominate", -MUTATIONS_LAYER)
+			dominate_overlay.pixel_z = 2
+			TRGT.overlays_standing[MUTATIONS_LAYER] = dominate_overlay
+			TRGT.apply_overlay(MUTATIONS_LAYER)
+			spawn(2 SECONDS)
+				if(TRGT)
+					TRGT.remove_overlay(MUTATIONS_LAYER)
+
 	//removed some keywords as they don't fit mental domination
 	var/static/regex/stun_words = regex("stop|wait|stand still|hold on|halt|cease")
 	var/static/regex/knockdown_words = regex("drop|fall|trip|knockdown")
@@ -259,7 +271,7 @@
 	var/static/regex/salute_words = regex("salute")
 	var/static/regex/deathgasp_words = regex("play dead")
 	var/static/regex/clap_words = regex("clap|applaud")
-	var/static/regex/honk_words = regex("ho+nk") //hooooooonk
+//	var/static/regex/honk_words = regex("ho+nk") //hooooooonk
 	var/static/regex/multispin_words = regex("like a record baby|right round")
 
 	var/i = 0
@@ -569,7 +581,7 @@
 			addtimer(CALLBACK(L, TYPE_PROC_REF(/mob/living/, emote), "clap"), 5 * i)
 			i++
 
-	//HONK
+/*	//HONK
 	else if((findtext(message, honk_words)))
 		cooldown = COOLDOWN_MEME
 		addtimer(CALLBACK(GLOBAL_PROC, PROC_REF(playsound), get_turf(user), 'sound/items/bikehorn.ogg', 300, 1), 25)
@@ -577,7 +589,7 @@
 			for(var/mob/living/carbon/C in listeners)
 				C.slip(140 * power_multiplier)
 			cooldown = COOLDOWN_MEME
-
+*/
 	//RIGHT ROUND
 	else if((findtext(message, multispin_words)))
 		cooldown = COOLDOWN_MEME

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -217,9 +217,9 @@
 		power_multiplier *= (1 + (1/specific_listeners.len)) //2x on a single guy, 1.5x on two and so on
 		message = copytext(message, length(found_string) + 1)
 
-	for(var/V in listeners)
-		if(ishuman(V))
-			var/mob/living/carbon/human/dominate_target = V
+	for(var/affected in listeners)
+		if(ishuman(affected))
+			var/mob/living/carbon/human/dominate_target = affected
 			dominate_target.remove_overlay(MUTATIONS_LAYER)
 			var/mutable_appearance/dominate_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "dominate", -MUTATIONS_LAYER)
 			dominate_overlay.pixel_z = 2

--- a/code/modules/wod13/datums/powers/discipline/dominate.dm
+++ b/code/modules/wod13/datums/powers/discipline/dominate.dm
@@ -18,17 +18,15 @@
 
 /datum/discipline_power/dominate/activate(mob/living/target)
 	. = ..()
-	var/mob/living/carbon/human/TRGT
+	var/mob/living/carbon/human/dominate_target
 	if(ishuman(target))
-		TRGT = target
-		TRGT.remove_overlay(MUTATIONS_LAYER)
+		dominate_target = target
+		dominate_target.remove_overlay(MUTATIONS_LAYER)
 		var/mutable_appearance/dominate_overlay = mutable_appearance('code/modules/wod13/icons.dmi', "dominate", -MUTATIONS_LAYER)
 		dominate_overlay.pixel_z = 2
-		TRGT.overlays_standing[MUTATIONS_LAYER] = dominate_overlay
-		TRGT.apply_overlay(MUTATIONS_LAYER)
-		spawn(2 SECONDS)
-			if(TRGT)
-				TRGT.remove_overlay(MUTATIONS_LAYER)
+		dominate_target.overlays_standing[MUTATIONS_LAYER] = dominate_overlay
+		dominate_target.apply_overlay(MUTATIONS_LAYER)
+		addtimer(CALLBACK(dominate_target, TYPE_PROC_REF(/mob/living/carbon/human, post_dominate_checks), dominate_target), 2 SECONDS)
 	return TRUE
 
 /datum/movespeed_modifier/dominate
@@ -243,3 +241,7 @@
 				ClickOn(src)
 		else
 			ClickOn(src)
+
+/mob/living/carbon/human/proc/post_dominate_checks(mob/living/carbon/human/dominate_target)
+	if(dominate_target)
+		dominate_target.remove_overlay(MUTATIONS_LAYER)


### PR DESCRIPTION
Two hours of this to make it work.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Voice of Domination now uses the dominate "halo" effect on succesful use, for any of its command and even freeform usage. If you lose the social v mental contest, you get it.

## Why It's Good For The Game

Proper feedback to players of when it should work and when it shouldnt, without the mechanical 5 dot discipline powers, and instead the freeform variants.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
![image](https://github.com/user-attachments/assets/5bca2b4b-4a67-4bc2-932c-484e2bc7f7e1)

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Dominate´s effect halo now shows up, in Voice of Domination.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
