### PR TITLE
Makes Lasombra weakness less crippling, applies it properly to radios.

### DIFF
--- a/code/modules/vtmb/electronics/p25.dm
+++ b/code/modules/vtmb/electronics/p25.dm
@@ -624,7 +624,7 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 		var/mob/living/carbon/human/speaker_man = speaker
 		if(speaker_man.clane?.name == "Lasombra")
 			raw_message = scramble_lasombra_message(raw_message,speaker_man)
-			playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 30, FALSE)
+			playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 10, FALSE, ignore_walls = FALSE)
 
 	var/formatted = format_message(raw_message)
 	for(var/mob/M in get_hearers_in_view(1, get_turf(src)))

--- a/code/modules/vtmb/electronics/p25.dm
+++ b/code/modules/vtmb/electronics/p25.dm
@@ -195,6 +195,7 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 			to_chat(listener, message)
 			if(play_sound)
 				playsound(R, play_sound, sound_volume, FALSE)
+
 	return TRUE
 
 // ==============================
@@ -588,6 +589,13 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 
 	playsound(src, 'sound/effects/radioclick.ogg', 30, FALSE)
 
+	var/tmp/garble = FALSE
+	if(iskindred(speaker))
+		var/mob/living/carbon/human/speaker_man = speaker
+		if(speaker_man.clane?.name == "Lasombra")
+			message = scramble_lasombra_message(message,speaker_man)
+			garble = TRUE
+
 	var/formatted = format_message(message)
 	if(check_signal())
 		for(var/obj/item/p25radio/R in GLOB.p25_radios)
@@ -600,11 +608,12 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 
 			for(var/mob/listener in get_hearers_in_view(1, get_turf(R)))
 				to_chat(listener, formatted)
+			if(garble)
+				playsound(R, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 0.3, FALSE, ignore_walls = FALSE)
+			playsound(R, 'sound/effects/radioclick.ogg', 1, FALSE)
 
 		if(linked_transceiver)
 			linked_transceiver.broadcast_message(formatted)
-
-		playsound(src, 'sound/effects/radioclick.ogg', 30, FALSE)
 
 	return ITALICS | REDUCE_RANGE
 
@@ -619,12 +628,6 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 
 	if(!check_signal())
 		return
-
-	if(iskindred(speaker_mob))
-		var/mob/living/carbon/human/speaker_man = speaker
-		if(speaker_man.clane?.name == "Lasombra")
-			raw_message = scramble_lasombra_message(raw_message,speaker_man)
-			playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 10, FALSE, ignore_walls = FALSE)
 
 	var/formatted = format_message(raw_message)
 	for(var/mob/M in get_hearers_in_view(1, get_turf(src)))

--- a/code/modules/vtmb/electronics/p25.dm
+++ b/code/modules/vtmb/electronics/p25.dm
@@ -622,7 +622,7 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 
 	if(iskindred(speaker_mob))
 		var/mob/living/carbon/human/speaker_man = speaker
-		if(speaker_man.clane && speaker_man.clane.name == "Lasombra")
+		if(speaker_man.clane?.name == "Lasombra")
 			raw_message = scramble_lasombra_message(raw_message)
 			playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 30, FALSE)
 

--- a/code/modules/vtmb/electronics/p25.dm
+++ b/code/modules/vtmb/electronics/p25.dm
@@ -620,6 +620,12 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 	if(!check_signal())
 		return
 
+	if(iskindred(speaker_mob))
+		var/mob/living/carbon/human/speaker_man = speaker
+		if(speaker_man.clane && speaker_man.clane.name == "Lasombra")
+			raw_message = scramble_lasombra_message(raw_message)
+			playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 30, FALSE)
+
 	var/formatted = format_message(raw_message)
 	for(var/mob/M in get_hearers_in_view(1, get_turf(src)))
 		to_chat(M, formatted)

--- a/code/modules/vtmb/electronics/p25.dm
+++ b/code/modules/vtmb/electronics/p25.dm
@@ -623,7 +623,7 @@ GLOBAL_LIST_EMPTY(p25_tranceivers)
 	if(iskindred(speaker_mob))
 		var/mob/living/carbon/human/speaker_man = speaker
 		if(speaker_man.clane?.name == "Lasombra")
-			raw_message = scramble_lasombra_message(raw_message)
+			raw_message = scramble_lasombra_message(raw_message,speaker_man)
 			playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 30, FALSE)
 
 	var/formatted = format_message(raw_message)

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -759,7 +759,7 @@
 
 					if(SPK.clane?.name == "Lasombra")
 						message = scramble_lasombra_message(message,SPK)
-						playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 20, FALSE, ignore_walls = FALSE)
+						playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 5, FALSE, ignore_walls = FALSE)
 					else
 						playsound(online, 'code/modules/wod13/sounds/phonetalk.ogg', 50, FALSE)
 				var/obj/phonevoice/VOIC = new(online)

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -759,12 +759,9 @@
 
 					if(SPK.clane?.name == "Lasombra")
 						message = scramble_lasombra_message(message,SPK)
-						playsound(online, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 50, FALSE)
+						playsound(src, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 20, FALSE, ignore_walls = FALSE)
 					else
 						playsound(online, 'code/modules/wod13/sounds/phonetalk.ogg', 50, FALSE)
-//					if(SPK.clane)
-//						if(SPK.clane.name == "Lasombra")
-//							return
 				var/obj/phonevoice/VOIC = new(online)
 				VOIC.name = voice_saying
 				VOIC.speech_span = spchspn

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -757,8 +757,8 @@
 					var/mob/living/carbon/human/SPK = hearing_args[HEARING_SPEAKER]
 					voice_saying = "[age2agedescription(SPK.age)] [SPK.gender] voice ([SPK.phonevoicetag])"
 
-					if(SPK.clane && SPK.clane.name == "Lasombra")
-						message = scramble_lasombra_message(message)
+					if(SPK.clane?.name == "Lasombra")
+						message = scramble_lasombra_message(message,SPK)
 						playsound(online, 'code/modules/wod13/sounds/lasombra_whisper.ogg', 50, FALSE)
 					else
 						playsound(online, 'code/modules/wod13/sounds/phonetalk.ogg', 50, FALSE)

--- a/code/modules/vtmb/electronics/phones/phone_voice.dm
+++ b/code/modules/vtmb/electronics/phones/phone_voice.dm
@@ -27,11 +27,11 @@ var/list/zalgo_letters = list(
 	var/gibberish_message = ""
 	var/totalsocial = 0
 	if(lasombra)
-		totalsocial = (lasombra.social+lasombra.additional_social) * 5
+		totalsocial = (lasombra.social+lasombra.additional_social) * 3 // +3% chance per social. 15 max, 18 avg, 24 beauty.9
 	for(var/i = 1 to length(message))
 		var/char = message[i]
 		// Randomize or replace characters with gibberish
-		var/chance = 50 + totalsocial // 50% + 5% chance per point of social to keep intact.
+		var/chance = 70 + totalsocial // 70% + totalsocial chance per point of social to keep intact.
 		if(prob(chance))
 			gibberish_message += char
 		else

--- a/code/modules/vtmb/electronics/phones/phone_voice.dm
+++ b/code/modules/vtmb/electronics/phones/phone_voice.dm
@@ -23,12 +23,13 @@ var/list/zalgo_letters = list(
 	send_speech(message, 2, src, , spans, message_language=language)
 //	speech_span = initial(speech_span)
 
-/proc/scramble_lasombra_message(var/message)
+/proc/scramble_lasombra_message(var/message,var/mob/living/carbon/human/lasombra)
 	var/gibberish_message = ""
 	for(var/i = 1 to length(message))
 		var/char = message[i]
 		// Randomize or replace characters with gibberish
-		if(prob(30)) // 30% chance to keep the original character
+		var/chance = ((lasombra.social+lasombra.additional_social)*10) //10% chance per point of social to keep intact.
+		if(prob(chance))
 			gibberish_message += char
 		else
 			gibberish_message += pick(zalgo_letters) // Replace with random gibberish letters

--- a/code/modules/vtmb/electronics/phones/phone_voice.dm
+++ b/code/modules/vtmb/electronics/phones/phone_voice.dm
@@ -25,10 +25,13 @@ var/list/zalgo_letters = list(
 
 /proc/scramble_lasombra_message(var/message,var/mob/living/carbon/human/lasombra)
 	var/gibberish_message = ""
+	var/totalsocial = 0
+	if(lasombra)
+		totalsocial = (lasombra.social+lasombra.additional_social) * 5
 	for(var/i = 1 to length(message))
 		var/char = message[i]
 		// Randomize or replace characters with gibberish
-		var/chance = ((lasombra.social+lasombra.additional_social)*10) //10% chance per point of social to keep intact.
+		var/chance = 50 + totalsocial // 50% + 5% chance per point of social to keep intact.
 		if(prob(chance))
 			gibberish_message += char
 		else


### PR DESCRIPTION
## About The Pull Request

When a Lasombra speaks into a radio, it comes out as harble-garble just like phones, enforcing their weakness properly.
This also makes the Lasombra garble amount scale against their Social. (70%, +3% per dot of social for sentence integrity.) The Lasombra microphone volume has been downplayed, and respects walls now.

Also, solved radios double-buzzing, because they were supposed to buzz on the other end. Made it quiet.

## Why It's Good For The Game

Properly maintains immersive consistency, and assists.

## Screenshots/Testing
![image](https://github.com/user-attachments/assets/70b4256c-e2e5-4d19-9f15-5855ae6f0b85)
![image](https://github.com/user-attachments/assets/f978cbca-5e2c-4d07-be3a-7aacecc8102a)
![image](https://github.com/user-attachments/assets/50230fac-0f0f-4993-ba54-cd4ec11eeff8)
![image](https://github.com/user-attachments/assets/9eaf23fe-696d-4a57-927a-61abf8a58320)
![image](https://github.com/user-attachments/assets/b2e3960a-8270-4cb8-a146-a91c81ac27be)

## Changelog

:cl: Yinadele
balance: Lasombra radio speech no longer crystal clear.
balance: Lasombra garblespeech slightly less oppressive. Should still oppress, and remain very visible. Sound tuned down.
/:cl: