### PR TITLE
Cappadocian Crypt Haven

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -4401,7 +4401,7 @@
 /obj/item/candle,
 /obj/item/trash/candle,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "blM" = (
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/plasteel/stairs{
@@ -5800,7 +5800,7 @@
 /obj/item/clothing/mask/vampire/venetian_mask,
 /obj/item/clothing/mask/vampire/venetian_mask,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "bHo" = (
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/vampgrass,
@@ -10734,7 +10734,7 @@
 /area/vtm/sewer/tzimisce_sanctum)
 "dbN" = (
 /turf/open/water,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "dbP" = (
 /obj/machinery/light{
 	dir = 4
@@ -13487,7 +13487,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "dUR" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -14380,7 +14380,7 @@
 "eig" = (
 /obj/structure/railing,
 /turf/open/floor/plating/vampwood,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "eir" = (
 /turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
@@ -15902,7 +15902,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "eIk" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry/old,
@@ -18007,7 +18007,7 @@
 /obj/item/card/id/hunter,
 /obj/item/clothing/neck/vampire/prayerbeads,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "fnG" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -19359,7 +19359,7 @@
 /obj/item/storage/fancy/candle_box,
 /obj/item/storage/box/matches,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "fFq" = (
 /turf/closed/wall/vampwall/painted,
 /area/vtm)
@@ -23448,7 +23448,7 @@
 /area/vtm/interior/wyrm_corrupted)
 "gOK" = (
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "gOM" = (
 /obj/item/vamp/phone/street{
 	pixel_z = 24
@@ -33688,7 +33688,7 @@
 /obj/structure/closet/crate/coffin,
 /obj/effect/mob_spawn/human/skeleton,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "jQW" = (
 /obj/structure/bed/maint,
 /obj/effect/turf_decal/weather/dirt{
@@ -45340,6 +45340,9 @@
 "noM" = (
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower)
+"noR" = (
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/cappadocian)
 "npf" = (
 /obj/effect/decal/bordur,
 /obj/effect/decal/trash,
@@ -45361,7 +45364,7 @@
 /area/vtm/hotel)
 "npk" = (
 /turf/closed/wall/vampwall/painted,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "npw" = (
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -46710,7 +46713,7 @@
 "nIR" = (
 /obj/structure/curtain/bounty,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "nIZ" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -50868,7 +50871,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "oSu" = (
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/rich,
@@ -54404,7 +54407,7 @@
 /area/vtm/financialdistrict/construction)
 "pRV" = (
 /turf/open/floor/plating/vampwood,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "pRX" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/white{
@@ -54436,7 +54439,7 @@
 /area/vtm/park)
 "pSE" = (
 /turf/open/openspace,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "pSV" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/structure/coclock,
@@ -54948,7 +54951,7 @@
 "qaY" = (
 /obj/structure/vampstatue/angel,
 /turf/open/water,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "qbh" = (
 /obj/structure/window/reinforced/indestructable{
 	alpha = 0
@@ -58327,7 +58330,7 @@
 "qWZ" = (
 /obj/structure/stairs/west,
 /turf/open/floor/plating/rough/cave,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "qXd" = (
 /obj/machinery/button/crematorium{
 	id = "cleanatorium";
@@ -59974,7 +59977,7 @@
 /obj/structure/closet/crate/coffin,
 /obj/effect/mob_spawn/human/corpse/ciz4,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "rtG" = (
 /turf/open/floor/plating/rust,
 /area/vtm/sewer)
@@ -62072,7 +62075,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "rXD" = (
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
@@ -62561,7 +62564,7 @@
 /obj/item/flashlight/lantern,
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "sdO" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -62896,7 +62899,7 @@
 "sjo" = (
 /obj/structure/vampdoor/wood/cappadocian,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "sjw" = (
 /obj/item/vamp/phone/street{
 	pixel_z = 24
@@ -65157,7 +65160,7 @@
 "sTw" = (
 /obj/structure/vampdoor/wood/cappadocian,
 /turf/open/floor/plating/rough/cave,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "sTy" = (
 /obj/machinery/light/prince{
 	pixel_y = 32
@@ -70337,6 +70340,9 @@
 /obj/item/candle/infinite,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/sewer/tzimisce_sanctum)
+"uww" = (
+/turf/closed/wall/vampwall/junk/alt,
+/area/vtm/sewer/cappadocian)
 "uwQ" = (
 /obj/structure/vampdoor{
 	dir = 4
@@ -74658,6 +74664,9 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f3)
+"vJS" = (
+/turf/closed/wall/vampwall/rich/old,
+/area/vtm/sewer/cappadocian)
 "vJY" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -78721,7 +78730,7 @@
 "wUY" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/plating/sidewalk,
-/area/space)
+/area/vtm/sewer/cappadocian)
 "wVf" = (
 /obj/structure/fluff/hedge{
 	pixel_y = 6
@@ -101090,9 +101099,9 @@ cSf
 cSf
 cSf
 cSf
-jjV
-jjV
-jjV
+uww
+uww
+uww
 cSf
 cSf
 cSf
@@ -101347,9 +101356,9 @@ cSf
 cSf
 cSf
 cSf
-jjV
+uww
 qWZ
-jjV
+uww
 cSf
 cSf
 cSf
@@ -101604,9 +101613,9 @@ cSf
 cSf
 cSf
 cSf
-jjV
-wHf
-jjV
+uww
+noR
+uww
 eig
 cSf
 cSf
@@ -101861,8 +101870,8 @@ cSf
 cSf
 cSf
 cSf
-jjV
-wHf
+uww
+noR
 sTw
 pRV
 hdT
@@ -102118,9 +102127,9 @@ cSf
 cSf
 cSf
 cSf
-jjV
-wHf
-jjV
+uww
+noR
+uww
 eig
 cSf
 cSf
@@ -102368,20 +102377,20 @@ npk
 npk
 npk
 npk
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
 rXB
-jjV
-jjV
-jjV
-jjV
-jjV
+uww
+uww
+uww
+uww
+uww
 cSf
 cSf
 cSf
@@ -102625,20 +102634,20 @@ dbN
 dbN
 dbN
 npk
-jjV
+uww
 jQU
 gOK
 rtE
 gOK
-jjV
+uww
 sdK
 gOK
 gOK
-jjV
+uww
 wUY
 blL
 wUY
-jjV
+uww
 cSf
 cSf
 cSf
@@ -102883,7 +102892,7 @@ npk
 dbN
 dbN
 npk
-jjV
+uww
 gOK
 gOK
 gOK
@@ -102895,7 +102904,7 @@ nIR
 gOK
 gOK
 gOK
-jjV
+uww
 cSf
 cSf
 cSf
@@ -103140,19 +103149,19 @@ dbN
 dbN
 dbN
 dbN
-jjV
+uww
 nIR
-jjV
+uww
 nIR
-nIR
-gOK
-gOK
-gOK
 nIR
 gOK
 gOK
 gOK
-jjV
+nIR
+gOK
+gOK
+gOK
+uww
 cSf
 cSf
 cSf
@@ -103401,15 +103410,15 @@ gOK
 gOK
 gOK
 gOK
-jjV
+uww
 nIR
-jjV
+uww
 nIR
-jjV
+uww
 nIR
-jjV
+uww
 nIR
-jjV
+uww
 cSf
 cSf
 cSf
@@ -103654,9 +103663,9 @@ dbN
 dbN
 dbN
 dbN
-jjV
+uww
 nIR
-jjV
+uww
 nIR
 nIR
 oSs
@@ -103666,7 +103675,7 @@ nIR
 gOK
 gOK
 gOK
-jjV
+uww
 cSf
 cSf
 cSf
@@ -103911,7 +103920,7 @@ npk
 dbN
 dbN
 npk
-jjV
+uww
 gOK
 gOK
 gOK
@@ -103923,7 +103932,7 @@ nIR
 gOK
 gOK
 gOK
-jjV
+uww
 cSf
 cSf
 cSf
@@ -104167,20 +104176,20 @@ dbN
 dbN
 dbN
 npk
-jjV
+uww
 jQU
 gOK
 rtE
 gOK
-jjV
+uww
 fnE
 bHn
 fFl
-jjV
+uww
 wUY
 blL
 wUY
-jjV
+uww
 cSf
 cSf
 cSf
@@ -104424,20 +104433,20 @@ npk
 npk
 npk
 npk
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
-jjV
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
+uww
 cSf
 cSf
 cSf
@@ -166369,10 +166378,10 @@ hgv
 hgv
 hgv
 hgv
-icl
-icl
-icl
-icl
+vJS
+vJS
+vJS
+vJS
 rgV
 rgV
 rgV
@@ -166626,7 +166635,7 @@ tND
 tND
 tND
 tND
-icl
+vJS
 gOK
 gOK
 sjo
@@ -166883,7 +166892,7 @@ qHD
 qHD
 qHD
 tND
-icl
+vJS
 pSE
 gOK
 fYI

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -33684,11 +33684,6 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/setite/basement)
-"jQU" = (
-/obj/structure/closet/crate/coffin,
-/obj/effect/mob_spawn/human/corpse/charredskeleton,
-/turf/open/floor/plating/sidewalk,
-/area/vtm/sewer/cappadocian)
 "jQW" = (
 /obj/structure/bed/maint,
 /obj/effect/turf_decal/weather/dirt{
@@ -49769,8 +49764,7 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/sewer/nosferatu_town)
 "oDo" = (
-/obj/structure/stairs,
-/turf/open/floor/plating/sidewalk,
+/turf/open/floor/plasteel/stairs/medium,
 /area/vtm/sewer/cappadocian)
 "oDs" = (
 /obj/effect/decal/painting/third,
@@ -102639,7 +102633,7 @@ dbN
 dbN
 npk
 uww
-jQU
+rtE
 gOK
 rtE
 gOK
@@ -104181,7 +104175,7 @@ dbN
 dbN
 npk
 uww
-jQU
+rtE
 gOK
 rtE
 gOK

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -62067,6 +62067,12 @@
 	},
 /turf/open/floor/plating/vampplating/stone,
 /area/vtm/interior/bianchiBank)
+"rXB" = (
+/obj/structure/vampdoor/wood/cappadocian{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "rXD" = (
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
@@ -101605,7 +101611,7 @@ eig
 cSf
 cSf
 cSf
-cSf
+hdT
 cSf
 cSf
 cSf
@@ -101859,13 +101865,13 @@ jjV
 wHf
 sTw
 pRV
+hdT
 cSf
 cSf
 cSf
 cSf
 cSf
-cSf
-cSf
+hdT
 hns
 adH
 krV
@@ -102370,7 +102376,7 @@ jjV
 jjV
 jjV
 jjV
-gOK
+rXB
 jjV
 jjV
 jjV

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -4396,6 +4396,12 @@
 /obj/structure/chair/comfy/brown,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior)
+"blL" = (
+/obj/structure/table/wood,
+/obj/item/candle,
+/obj/item/trash/candle,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "blM" = (
 /obj/structure/curtain/cloth/fancy,
 /turf/open/floor/plasteel/stairs{
@@ -5785,6 +5791,16 @@
 	},
 /turf/open/floor/plating/vampwood,
 /area/vtm/hotel)
+"bHn" = (
+/obj/structure/table/wood,
+/obj/item/clothing/mask/vampire/venetian_mask/jester,
+/obj/item/clothing/mask/vampire/venetian_mask/fancy,
+/obj/item/clothing/mask/vampire/venetian_mask/fancy,
+/obj/item/clothing/mask/vampire/venetian_mask/fancy,
+/obj/item/clothing/mask/vampire/venetian_mask,
+/obj/item/clothing/mask/vampire/venetian_mask,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "bHo" = (
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/vampgrass,
@@ -10717,14 +10733,8 @@
 /turf/open/indestructible/necropolis/air,
 /area/vtm/sewer/tzimisce_sanctum)
 "dbN" = (
-/obj/effect/decal/coastline{
-	dir = 4
-	},
-/obj/effect/decal/coastline{
-	dir = 4
-	},
-/turf/open/floor/plating/vampbeach,
-/area/vtm/northbeach)
+/turf/open/water,
+/area/space)
 "dbP" = (
 /obj/machinery/light{
 	dir = 4
@@ -13472,6 +13482,12 @@
 	},
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/banu/haven)
+"dUF" = (
+/obj/structure/chair/pew/left{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "dUR" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -14361,6 +14377,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
+"eig" = (
+/obj/structure/railing,
+/turf/open/floor/plating/vampwood,
+/area/space)
 "eir" = (
 /turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
@@ -15877,6 +15897,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"eIh" = (
+/obj/structure/chair/pew{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "eIk" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry/old,
@@ -17975,6 +18001,13 @@
 /obj/structure/punching_bag,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f3)
+"fnE" = (
+/obj/structure/table/wood,
+/obj/item/storage/book/bible,
+/obj/item/card/id/hunter,
+/obj/item/clothing/neck/vampire/prayerbeads,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "fnG" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -19321,6 +19354,12 @@
 	},
 /turf/open/floor/plating/saint,
 /area/vtm/church/interior/staff)
+"fFl" = (
+/obj/structure/table/wood,
+/obj/item/storage/fancy/candle_box,
+/obj/item/storage/box/matches,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "fFq" = (
 /turf/closed/wall/vampwall/painted,
 /area/vtm)
@@ -23408,14 +23447,8 @@
 /turf/closed/wall/vampwall/metal,
 /area/vtm/interior/wyrm_corrupted)
 "gOK" = (
-/obj/effect/decal/coastline{
-	dir = 4
-	},
-/obj/effect/decal/coastline{
-	dir = 4
-	},
-/turf/closed/wall/vampwall/rich/old,
-/area/vtm/northbeach)
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "gOM" = (
 /obj/item/vamp/phone/street{
 	pixel_z = 24
@@ -33651,6 +33684,11 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/setite/basement)
+"jQU" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/mob_spawn/human/skeleton,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "jQW" = (
 /obj/structure/bed/maint,
 /obj/effect/turf_decal/weather/dirt{
@@ -45322,8 +45360,8 @@
 /turf/open/floor/carpet/green,
 /area/vtm/hotel)
 "npk" = (
-/turf/closed/wall/vampwall/rich/old,
-/area/vtm/northbeach)
+/turf/closed/wall/vampwall/painted,
+/area/space)
 "npw" = (
 /obj/item/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -46669,6 +46707,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights/community)
+"nIR" = (
+/obj/structure/curtain/bounty,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "nIZ" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -50821,6 +50863,12 @@
 	alpha = 0
 	},
 /area/vtm)
+"oSs" = (
+/obj/structure/chair/pew/right{
+	dir = 4
+	},
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "oSu" = (
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/rich,
@@ -54354,6 +54402,9 @@
 /obj/manholedown,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/construction)
+"pRV" = (
+/turf/open/floor/plating/vampwood,
+/area/space)
 "pRX" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/white{
@@ -54383,6 +54434,9 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampplating/stone,
 /area/vtm/park)
+"pSE" = (
+/turf/open/openspace,
+/area/space)
 "pSV" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/structure/coclock,
@@ -54887,6 +54941,10 @@
 /obj/item/storage/pill_bottle/mutadone,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"qaY" = (
+/obj/structure/vampstatue/angel,
+/turf/open/water,
+/area/space)
 "qbh" = (
 /obj/structure/window/reinforced/indestructable{
 	alpha = 0
@@ -58262,6 +58320,10 @@
 /obj/structure/big_vamprocks,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/old)
+"qWZ" = (
+/obj/structure/stairs/west,
+/turf/open/floor/plating/rough/cave,
+/area/space)
 "qXd" = (
 /obj/machinery/button/crematorium{
 	id = "cleanatorium";
@@ -59904,6 +59966,11 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"rtE" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/mob_spawn/human/corpse/ciz4,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "rtG" = (
 /turf/open/floor/plating/rust,
 /area/vtm/sewer)
@@ -62476,6 +62543,15 @@
 /obj/machinery/mineral/equipment_vendor/fastfood/smoking,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
+"sdK" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/obj/item/flashlight/lantern,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "sdO" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -78624,6 +78700,10 @@
 	},
 /turf/open/floor/plating/vampdirt,
 /area/vtm)
+"wUY" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "wVf" = (
 /obj/structure/fluff/hedge{
 	pixel_y = 6
@@ -100992,9 +101072,9 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-cSf
+jjV
+jjV
+jjV
 cSf
 cSf
 cSf
@@ -101249,9 +101329,9 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-cSf
+jjV
+qWZ
+jjV
 cSf
 cSf
 cSf
@@ -101506,10 +101586,10 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-cSf
-cSf
+jjV
+wHf
+jjV
+eig
 cSf
 cSf
 cSf
@@ -101763,10 +101843,10 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-cSf
-cSf
+jjV
+wHf
+wHf
+pRV
 cSf
 cSf
 cSf
@@ -102007,10 +102087,10 @@ dhc
 (74,1,1) = {"
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
 nYS
 nxc
 nxc
@@ -102020,10 +102100,10 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-cSf
-cSf
+jjV
+wHf
+jjV
+eig
 cSf
 cSf
 cSf
@@ -102263,27 +102343,27 @@ dhc
 "}
 (75,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+tiZ
 nYS
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+npk
+npk
+npk
+npk
+npk
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+gOK
+jjV
+jjV
+jjV
+jjV
+jjV
 cSf
 cSf
 cSf
@@ -102519,28 +102599,28 @@ dhc
 dhc
 "}
 (76,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+nYS
+npk
+npk
+dbN
+dbN
+dbN
+npk
+jjV
+jQU
+gOK
+rtE
+gOK
+jjV
+sdK
+gOK
+gOK
+jjV
+wUY
+blL
+wUY
+jjV
 cSf
 cSf
 cSf
@@ -102776,28 +102856,28 @@ dhc
 dhc
 "}
 (77,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-fZO
-fZO
-fZO
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+npk
+npk
+dbN
+dbN
+npk
+dbN
+dbN
+npk
+jjV
+gOK
+gOK
+gOK
+nIR
+gOK
+gOK
+gOK
+nIR
+gOK
+gOK
+gOK
+jjV
 cSf
 cSf
 cSf
@@ -103033,28 +103113,28 @@ dhc
 dhc
 "}
 (78,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-fZO
-fZO
-fZO
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+npk
+dbN
+dbN
+dbN
+dbN
+dbN
+dbN
+dbN
+jjV
+nIR
+jjV
+nIR
+nIR
+gOK
+gOK
+gOK
+nIR
+gOK
+gOK
+gOK
+jjV
 cSf
 cSf
 cSf
@@ -103290,28 +103370,28 @@ dhc
 dhc
 "}
 (79,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-fZO
-fZO
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+npk
+dbN
+qaY
+dbN
+dbN
+dbN
+dbN
+dbN
+gOK
+gOK
+gOK
+gOK
+jjV
+nIR
+jjV
+nIR
+jjV
+nIR
+jjV
+nIR
+jjV
 cSf
 cSf
 cSf
@@ -103547,28 +103627,28 @@ dhc
 dhc
 "}
 (80,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-hrG
-hYc
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+npk
+dbN
+dbN
+dbN
+dbN
+dbN
+dbN
+dbN
+jjV
+nIR
+jjV
+nIR
+nIR
+oSs
+eIh
+dUF
+nIR
+gOK
+gOK
+gOK
+jjV
 cSf
 cSf
 cSf
@@ -103804,28 +103884,28 @@ dhc
 dhc
 "}
 (81,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-lvu
-fZO
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+npk
+npk
+dbN
+dbN
+npk
+dbN
+dbN
+npk
+jjV
+gOK
+gOK
+gOK
+nIR
+gOK
+gOK
+gOK
+nIR
+gOK
+gOK
+gOK
+jjV
 cSf
 cSf
 cSf
@@ -104061,28 +104141,28 @@ dhc
 dhc
 "}
 (82,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-fZO
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+nYS
+npk
+npk
+dbN
+dbN
+dbN
+npk
+jjV
+jQU
+gOK
+rtE
+gOK
+jjV
+fnE
+bHn
+fFl
+jjV
+wUY
+blL
+wUY
+jjV
 cSf
 cSf
 cSf
@@ -104319,27 +104399,27 @@ dhc
 "}
 (83,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+tiZ
 nYS
-nxc
-fZO
-fZO
-jAq
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+npk
+npk
+npk
+npk
+npk
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
+jjV
 cSf
 cSf
 cSf
@@ -104577,14 +104657,14 @@ dhc
 (84,1,1) = {"
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
 nYS
 nxc
-fZO
-jAq
+cSf
+cSf
 cSf
 cSf
 cSf
@@ -107157,8 +107237,8 @@ nxc
 nxc
 nxc
 cSf
-cSf
-cSf
+fZO
+jAq
 cSf
 cSf
 cSf
@@ -107413,11 +107493,11 @@ nYS
 nYS
 nYS
 nxc
-cSf
-cSf
-cSf
-cSf
-cSf
+fZO
+fZO
+fZO
+fZO
+fZO
 cSf
 cSf
 cSf
@@ -107670,11 +107750,11 @@ nYS
 dhc
 nYS
 nxc
-cSf
-cSf
-cSf
-cSf
-cSf
+fZO
+fZO
+fZO
+fZO
+fZO
 cSf
 cSf
 cSf
@@ -107928,10 +108008,10 @@ dhc
 nYS
 nxc
 nxc
-cSf
-cSf
-cSf
-cSf
+fZO
+fZO
+fZO
+jAq
 cSf
 cSf
 cSf
@@ -108185,10 +108265,10 @@ dhc
 nYS
 nYS
 nxc
-cSf
-cSf
-cSf
-cSf
+hrG
+hYc
+fZO
+jAq
 cSf
 cSf
 cSf
@@ -108442,10 +108522,10 @@ dhc
 nYS
 nYS
 nxc
-cSf
-cSf
-cSf
-cSf
+lvu
+fZO
+fZO
+jAq
 cSf
 cSf
 cSf
@@ -108699,9 +108779,9 @@ dhc
 nYS
 nxc
 nxc
-cSf
-cSf
-cSf
+fZO
+fZO
+jAq
 cSf
 cSf
 cSf
@@ -108955,10 +109035,10 @@ dhc
 nYS
 nYS
 nxc
-cSf
-cSf
-cSf
-cSf
+fZO
+fZO
+fZO
+jAq
 cSf
 cSf
 cSf
@@ -109212,9 +109292,9 @@ dhc
 nYS
 nxc
 nxc
-cSf
-cSf
-cSf
+fZO
+fZO
+jAq
 cSf
 cSf
 cSf
@@ -166271,10 +166351,10 @@ hgv
 hgv
 hgv
 hgv
-gOK
-rgV
-dbN
-rgV
+icl
+icl
+icl
+icl
 rgV
 rgV
 rgV
@@ -166528,10 +166608,10 @@ tND
 tND
 tND
 tND
-npk
-qIX
-qIX
-qIX
+icl
+gOK
+gOK
+gOK
 qIX
 qIX
 qIX
@@ -166785,9 +166865,9 @@ qHD
 qHD
 qHD
 tND
-npk
-qIX
-qIX
+icl
+pSE
+gOK
 fYI
 fYI
 fYI

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -33686,7 +33686,7 @@
 /area/vtm/interior/setite/basement)
 "jQU" = (
 /obj/structure/closet/crate/coffin,
-/obj/effect/mob_spawn/human/skeleton,
+/obj/effect/mob_spawn/human/corpse/charredskeleton,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/sewer/cappadocian)
 "jQW" = (
@@ -49768,6 +49768,10 @@
 /obj/effect/landmark/latejoin_masquerade,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/sewer/nosferatu_town)
+"oDo" = (
+/obj/structure/stairs,
+/turf/open/floor/plating/sidewalk,
+/area/vtm/sewer/cappadocian)
 "oDs" = (
 /obj/effect/decal/painting/third,
 /obj/effect/decal/wallpaper/paper/stripe,
@@ -101619,8 +101623,8 @@ uww
 eig
 cSf
 cSf
-cSf
 hdT
+cSf
 cSf
 cSf
 cSf
@@ -103406,7 +103410,7 @@ dbN
 dbN
 dbN
 dbN
-gOK
+oDo
 gOK
 gOK
 gOK

--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -54906,6 +54906,10 @@
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/strip)
+"qam" = (
+/obj/structure/vampdoor/wood/giovanni,
+/turf/closed/wall/vampwall/rock,
+/area/vtm/sewer/nosferatu_town)
 "qau" = (
 /obj/structure/chair/pew/right{
 	dir = 4
@@ -62883,6 +62887,10 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/park)
+"sjo" = (
+/obj/structure/vampdoor/wood/cappadocian,
+/turf/open/floor/plating/sidewalk,
+/area/space)
 "sjw" = (
 /obj/item/vamp/phone/street{
 	pixel_z = 24
@@ -65140,6 +65148,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
+"sTw" = (
+/obj/structure/vampdoor/wood/cappadocian,
+/turf/open/floor/plating/rough/cave,
+/area/space)
 "sTy" = (
 /obj/machinery/light/prince{
 	pixel_y = 32
@@ -99524,7 +99536,7 @@ nxc
 cSf
 nxc
 nYS
-nxc
+qam
 cSf
 cSf
 cSf
@@ -101845,7 +101857,7 @@ cSf
 cSf
 jjV
 wHf
-wHf
+sTw
 pRV
 cSf
 cSf
@@ -166611,7 +166623,7 @@ tND
 icl
 gOK
 gOK
-gOK
+sjo
 qIX
 qIX
 qIX

--- a/code/modules/vtmb/vampire_clane/cappadocian.dm
+++ b/code/modules/vtmb/vampire_clane/cappadocian.dm
@@ -38,4 +38,4 @@
 
 	var/obj/item/clothing/mask/vampire/venetian_mask/fancy/new_mask = new(H.loc)
 	H.equip_to_appropriate_slot(new_mask, FALSE)
-
+	clan_keys = /obj/item/vamp/keys/cappadocian

--- a/code/modules/vtmb/vampire_clane/cappadocian.dm
+++ b/code/modules/vtmb/vampire_clane/cappadocian.dm
@@ -12,6 +12,7 @@
 	alt_sprite_greyscale = TRUE
 
 	whitelisted = FALSE
+	clan_keys = /obj/item/vamp/keys/cappadocian
 
 /datum/vampireclane/cappadocian/on_gain(mob/living/carbon/human/H)
 	var/years_undead = H.chronological_age - H.age
@@ -38,4 +39,3 @@
 
 	var/obj/item/clothing/mask/vampire/venetian_mask/fancy/new_mask = new(H.loc)
 	H.equip_to_appropriate_slot(new_mask, FALSE)
-	clan_keys = /obj/item/vamp/keys/cappadocian

--- a/code/modules/wod13/ambient.dm
+++ b/code/modules/wod13/ambient.dm
@@ -434,6 +434,16 @@
 	yin_chi = 2
 	wall_rating = HIGH_WALL_RATING
 
+	name = "Cappadocian Crypt"
+	icon_state = "graveyard"
+	ambience_index = AMBIENCE_INTERIOR
+	music = /datum/vampiremusic/hollywood
+	upper = FALSE
+	zone_type = "elysium"
+	yang_chi = 0
+	yin_chi = 2
+	wall_rating = LOW_WALL_RATING
+
 // GAROU CENTRIC AREAS
 /area/vtm/forest
 	name = "Forest"

--- a/code/modules/wod13/ambient.dm
+++ b/code/modules/wod13/ambient.dm
@@ -434,6 +434,7 @@
 	yin_chi = 2
 	wall_rating = HIGH_WALL_RATING
 
+/area/vtm/sewer/cappadocian
 	name = "Cappadocian Crypt"
 	icon_state = "graveyard"
 	ambience_index = AMBIENCE_INTERIOR

--- a/code/modules/wod13/items/keys/keys.dm
+++ b/code/modules/wod13/items/keys/keys.dm
@@ -320,6 +320,13 @@
 	)
 	color = "#e8ff29"
 
+/obj/item/vamp/keys/cappadocian
+	name = "Eroded keys"
+	accesslocks = list(
+		"cappadocian"
+	)
+		color = "#99620e"
+
 //===========================CLINIC KEYS===========================
 /obj/item/vamp/keys/clinic
 	name = "Clinic keys"

--- a/code/modules/wod13/items/keys/keys.dm
+++ b/code/modules/wod13/items/keys/keys.dm
@@ -325,7 +325,7 @@
 	accesslocks = list(
 		"cappadocian"
 	)
-		color = "#99620e"
+	color = "#99620e"
 
 //===========================CLINIC KEYS===========================
 /obj/item/vamp/keys/clinic

--- a/code/modules/wod13/structures/doors/vampdoor_wood.dm
+++ b/code/modules/wod13/structures/doors/vampdoor_wood.dm
@@ -38,3 +38,8 @@
 	name = "Jazz Club"
 	lock_id = "milleniumCommon"
 	lockpick_difficulty = 8
+
+/obj/structure/vampdoor/wood/cappadocian
+	locked = TRUE
+	lock_id = "cappadocian"
+	lockpick_difficulty = 8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Implements a Cappadocian Haven. A small, cramped space with few resources owing to their position in politics.

## Why It's Good For The Game

This gives the innately estranged and adrift Cappadocian clan with feet and fingers divided per-player across in-game factions and loyalties due to the nature of their clan a neutral ground to call their home. In-game RP has already been undertaken to legitimise it with various faction leads to back it as a neutral space also. Anastasios has spoken with the Anarchs, Fortunus with the Camarilla and so on. Having this neutral ground will give the Cappadocians a place as bargainers, peace brokers and scholars as Cappadocius intended as well as some much needed protection and space to organise against those hungry to diablerise them. Better yet, it gives a place where Harbingers, Premascine, Infitiores and more can actually discuss family matters without having to rely on opposition simply not strolling by.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Designated areas modified shown with and without Cappa area overlay.
![image](https://github.com/user-attachments/assets/d643a341-4b70-4621-97ee-2d5747fd080a)
![image](https://github.com/user-attachments/assets/0c1edf44-2c00-412a-808d-35e2ed608aae)
![image](https://github.com/user-attachments/assets/fff61a80-ad80-48f1-a4ff-0dff2bfb7d66)
![image](https://github.com/user-attachments/assets/e370bfee-5f63-49a6-8022-b4d00f070e8b)


Cappadocian Eroded Keys type properly spawned with.
![image](https://github.com/user-attachments/assets/f47e5e87-00c5-4afe-8656-b738b621f570)


Tested for no airless tiles, doors un/locking correctly.
![image](https://github.com/user-attachments/assets/0b49b507-345c-44a7-91e4-a3c70170a73e)

</details>

## Changelog

🆑MrSeaside
add: Cappadocian Haven in the Underground Town
add: Access next to pier church
add: Access from the underground canal
add: Cappadocian doors added
add: Eroded Keys type for Cappas added
add: Eroded Keys added to Cappas on spawn
add: Cappadocian Crypt area type added, borrowing the graveyard icon for now

map: moves the island of goodies where the Cappa Haven now is to the east.
map: tested area isn't airless

del: the water and stone under where the haven now is
/:cl:


## Bonus Lore Proposal
A cramped, damp little crypt. Featured is the surface entrance and (suspension of disbelief so it doesn't sit in the middle of the undertown) the lore that the old church was actually moved further south at one point, leading to the old crypt being sealed off in favour of usage of the graveyard. The template for the crypt when the foundation were being built was in fact a copy/paste of the above church limits, widened slightly (for an ounce of actual space) to match the old-old church site before the shore was worn away more these past two hundred or so years. To the north of the crypt, a flooded chamber has been maintained as it was found, (with white walls for contrast to match the source inspiration) in miraculously good condition by some saintly blessing. This naturally would be the preferred chamber to worship in peace, to meet as a group or for Venetian Premascine, known to favour the canals, to indulge the daysleep or idle away the nights. Due to being pumped and only vaguely restored, bookshelves were evaluated to be untenable in the damp conditions. Owing to (a need to be able to get past one another without compromising space or support pillars) the amount of efforts and funds being largely put towards pumping out the submerged vault of the dead, Anastasios has made do with curtains instead of doors also as means of privacy. Some simple items of worship and necessity have been stored too, such as traditional masks, religious items and lanterns due to the risk of electricity being used in such a recently de-submerged space.