### PR TITLE
Masks now conceal voice

### DIFF
--- a/code/modules/mob/living/carbon/human/human_say.dm
+++ b/code/modules/mob/living/carbon/human/human_say.dm
@@ -25,6 +25,13 @@
 			return ("Unknown")
 		else
 			return real_name
+	if((wear_mask && (wear_mask.flags_inv & HIDEFACE)) || (head && (head.flags_inv & HIDEFACE)))
+		if(gender == FEMALE)
+			return "Unknown woman"
+		else if(gender == MALE)
+			return "Unknown man"
+		else
+			return "Unknown person"
 	if(mind)
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling?.mimicing )


### PR DESCRIPTION
when a character speaks while wearing a mask (or headgear) that hides their face, instead of showing their name in chat, it will display unknown wo/man.
