### PR TITLE
.50 Deagle and .50 Sniper Hotfix

### DIFF
--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -272,7 +272,7 @@
 /datum/supply_pack/vampire/weapondeagle50
 	name = "Weapon (desert eagle 50AE)"
 	desc = "Contains a .50 caliber desert eagle."
-	cost = 10000
+	cost = 5000
 	contains = list(
 		/obj/item/gun/ballistic/automatic/vampire/deagle/c50,
 		/obj/item/ammo_box/magazine/m50,

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -274,7 +274,7 @@
 	desc = "Contains a .50 caliber desert eagle."
 	cost = 10000
 	contains = list(
-		/obj/item/gun/ballistic/automatic/pistol/deagle/c50,
+		/obj/item/gun/ballistic/automatic/vampire/deagle/c50,
 		/obj/item/ammo_box/magazine/m50,
 	)
 

--- a/code/modules/wod13/cargo.dm
+++ b/code/modules/wod13/cargo.dm
@@ -272,9 +272,9 @@
 /datum/supply_pack/vampire/weapondeagle50
 	name = "Weapon (desert eagle 50AE)"
 	desc = "Contains a .50 caliber desert eagle."
-	cost = 2000
+	cost = 10000
 	contains = list(
-		/obj/item/gun/ballistic/automatic/pistol/deagle,
+		/obj/item/gun/ballistic/automatic/pistol/deagle/c50,
 		/obj/item/ammo_box/magazine/m50,
 	)
 

--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -180,6 +180,8 @@
 	icon_state = "deagle50"
 	inhand_icon_state = "deagle"
 	worn_icon_state = "deagle"
+	w_class = WEIGHT_CLASS_BULKY // No dual-wielding these, its a .50 cal with 0 fire delay
+	recoil = 5 // Big recoil
 	mag_type = /obj/item/ammo_box/magazine/m50
 	fire_sound_volume = 125 //MY EARS
 

--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -171,7 +171,7 @@
 	icon_state = "deagle"
 	ammo_type = /obj/item/ammo_casing/vampire/c50
 	caliber = CALIBER_50
-	max_ammo = 5 //5 .50 bullets in a pistol magazine is already pushing it
+	max_ammo = 7 //Can't touch this without breaking the sprite because its using .44 mag sprites.
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/gun/ballistic/automatic/vampire/deagle/c50

--- a/code/modules/wod13/guns.dm
+++ b/code/modules/wod13/guns.dm
@@ -171,7 +171,7 @@
 	icon_state = "deagle"
 	ammo_type = /obj/item/ammo_casing/vampire/c50
 	caliber = CALIBER_50
-	max_ammo = 7
+	max_ammo = 5 //5 .50 bullets in a pistol magazine is already pushing it
 	multiple_sprites = AMMO_BOX_FULL_EMPTY
 
 /obj/item/gun/ballistic/automatic/vampire/deagle/c50
@@ -180,8 +180,7 @@
 	icon_state = "deagle50"
 	inhand_icon_state = "deagle"
 	worn_icon_state = "deagle"
-	w_class = WEIGHT_CLASS_BULKY // No dual-wielding these, its a .50 cal with 0 fire delay
-	recoil = 5 // Big recoil
+	weapon_weight = WEAPON_HEAVY // No dual-wielding .50 cals.
 	mag_type = /obj/item/ammo_box/magazine/m50
 	fire_sound_volume = 125 //MY EARS
 
@@ -583,6 +582,7 @@
 	inhand_icon_state = "sniper"
 	worn_icon_state = "sniper"
 	w_class = WEIGHT_CLASS_BULKY
+	weapon_weight = WEAPON_HEAVY
 	mag_type = /obj/item/ammo_box/magazine/internal/vampire/sniper
 	bolt_wording = "bolt"
 	bolt_type = BOLT_TYPE_STANDARD
@@ -596,7 +596,6 @@
 	tac_reloads = FALSE
 	fire_delay = 40
 	burst_size = 1
-	w_class = WEIGHT_CLASS_NORMAL
 	zoomable = TRUE
 	zoom_amt = 10 //Long range, enough to see in front of you, but no tiles behind you.
 	zoom_out_amt = 5

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3473,8 +3473,8 @@
 #include "modular_tfn\modules\discord\tgs_commands.dm"
 #include "modular_tfn\modules\discord\toggle_notify.dm"
 #include "modular_tfn\modules\fomori\code\fomori.dm"
+#include "modular_tfn\modules\morality\morality.dm"
 #include "modular_tfn\modules\morality\morality_component.dm"
 #include "modular_tfn\modules\panicbunker\code\panicbunker.dm"
-#include "modular_tfn\modules\morality\morality.dm"
 #include "modular_tfn\modules\subtle\subtle.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request
Quick hotfix to prevent the .50 Deagle from being dual-wielded. Also increases its cost significantly per advice.

Sniper rifles can also no longer be dual-wielded, but that is less important.

## Why It's Good For The Game
Dual McLuskies with Gunfighter had 700 DPS, before Cruelty factored in. Compared to the sniper rifle's 70 DPS with Gunfighter, it's clear there was a problem.

## Testing Photographs and Procedure
![c5cefa1fb2a661c643a4099337a0c5d1](https://github.com/user-attachments/assets/48fd7e06-8a95-4464-8758-0ce9da798ee6)

</details>

## Changelog

:cl:
balance: Can no longer dual-wield .50 caliber guns.
balance: .50 Deagle price increased.
/:cl:
