### PR TITLE
Re-adds the Diablerist trait so people can have the aura.

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -566,6 +566,16 @@ Dancer
 	lose_text = "<span class='notice'>You don't feel charismatic anymore.</span>"
 	allowed_species = list("Vampire", "Kuei-Jin")
 
+/datum/quirk/diablerist
+	name = "Diablerist"
+	desc = "For one reason or another, you have committed Diablerie in your past, a great crime within Kindred society. <b>This is not a license to Diablerize without proper reason!</b>"
+	value = 0
+	allowed_species = list("Vampire")
+
+/datum/quirk/diablerist/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	H.diablerist = TRUE
+
 /datum/quirk/tower
 	name = "Tower"
 	desc = "You are tall."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

re-adds the diablerist aura trait so that people can roleplay having committed diablerie in the past

## Why It's Good For The Game

people being able to rp the kind of character they want is good
makes it 0 points so people are not inclined to take it for free trait points, and re-words it to be more explicit as to it being a severe crime + changes the name from 'Black Secret' as well so it's more obvious

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

tested on local, everything worked fine - i reworded what the quirk said since i felt it was a bit wordy but otherwise nothing else was changed

![image](https://github.com/user-attachments/assets/37c28243-8830-4fdf-9695-f9959c5efcae)
![image](https://github.com/user-attachments/assets/178d0dc8-ec45-4cbf-8c35-cf5873fda61d)
![image](https://github.com/user-attachments/assets/b9a6bba4-d7ab-47dd-8aea-b5d5f7cc95d5)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Rewords and re-enables 'Black Secret' quirk to be more explicit about what it does, allowing people to have the Diablerist aura without adminhelping.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
