### PR TITLE
More DeObfuscate triggers

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/obfuscate.dm
+++ b/code/modules/wod13/datums/powers/discipline/obfuscate.dm
@@ -154,7 +154,7 @@
 /datum/discipline_power/obfuscate/unseen_presence/activate()
 	. = ..()
 	RegisterSignal(owner, aggressive_signals, PROC_REF(on_combat_signal), override = TRUE)
-	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(handle_move))
+	RegisterSignal(owner, COMSIG_MOVABLE_MOVED, PROC_REF(handle_walk))
 	RegisterSignal(owner, COMSIG_MOVABLE_BUMP, PROC_REF(handle_bump))
 	RegisterSignal(owner, COMSIG_MOVABLE_CROSSED, PROC_REF(handle_bump))
 
@@ -172,6 +172,17 @@
 	UnregisterSignal(owner, COMSIG_MOVABLE_CROSSED, PROC_REF(handle_bump))
 
 	REMOVE_TRAIT(owner, TRAIT_OBFUSCATED, OBFUSCATE_TRAIT)
+
+//remove this when Mask of a Thousand Faces is made tabletop accurate
+/datum/discipline_power/obfuscate/unseen_presence/proc/handle_walk(datum/source, atom/moving_thing, dir)
+	SIGNAL_HANDLER
+
+	if (owner.m_intent != MOVE_INTENT_WALK)
+		to_chat(owner, span_danger("Your [src] falls away as you move too quickly!"))
+		try_deactivate(direct = TRUE)
+
+		deltimer(cooldown_timer)
+		cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), REVEAL_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
 //MASK OF A THOUSAND FACES
 /datum/discipline_power/obfuscate/mask_of_a_thousand_faces

--- a/code/modules/wod13/datums/powers/discipline/obfuscate.dm
+++ b/code/modules/wod13/datums/powers/discipline/obfuscate.dm
@@ -60,6 +60,16 @@
 	deltimer(cooldown_timer)
 	cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), REVEAL_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
+/datum/discipline_power/obfuscate/proc/handle_walk(datum/source, atom/moving_thing, dir)
+	SIGNAL_HANDLER
+
+	if (owner.m_intent != MOVE_INTENT_WALK)
+		to_chat(owner, span_danger("Your [src] falls away as you move too quickly!"))
+		try_deactivate(direct = TRUE)
+
+		deltimer(cooldown_timer)
+		cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), REVEAL_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
+
 /datum/discipline_power/obfuscate/proc/handle_bump(datum/source, atom/moving_thing, dir)
 	SIGNAL_HANDLER
 
@@ -172,17 +182,6 @@
 	UnregisterSignal(owner, COMSIG_MOVABLE_CROSSED, PROC_REF(handle_bump))
 
 	REMOVE_TRAIT(owner, TRAIT_OBFUSCATED, OBFUSCATE_TRAIT)
-
-//remove this when Mask of a Thousand Faces is made tabletop accurate
-/datum/discipline_power/obfuscate/unseen_presence/proc/handle_walk(datum/source, atom/moving_thing, dir)
-	SIGNAL_HANDLER
-
-	if (owner.m_intent != MOVE_INTENT_WALK)
-		to_chat(owner, span_danger("Your [src] falls away as you move too quickly!"))
-		try_deactivate(direct = TRUE)
-
-		deltimer(cooldown_timer)
-		cooldown_timer = addtimer(CALLBACK(src, PROC_REF(cooldown_expire)), REVEAL_COOLDOWN_LENGTH, TIMER_STOPPABLE | TIMER_DELETE_ME)
 
 //MASK OF A THOUSAND FACES
 /datum/discipline_power/obfuscate/mask_of_a_thousand_faces

--- a/code/modules/wod13/datums/powers/discipline/obfuscate.dm
+++ b/code/modules/wod13/datums/powers/discipline/obfuscate.dm
@@ -180,7 +180,7 @@
 
 	level = 3
 	check_flags = DISC_CHECK_CAPABLE
-	vitae_cost = 0
+	vitae_cost = 1
 
 	toggled = TRUE
 
@@ -222,7 +222,7 @@
 
 	level = 4
 	check_flags = DISC_CHECK_CAPABLE
-	vitae_cost = 0
+	vitae_cost = 2
 
 	toggled = TRUE
 
@@ -260,7 +260,7 @@
 
 	level = 5
 	check_flags = DISC_CHECK_CAPABLE
-	vitae_cost = 0
+	vitae_cost = 2
 
 	toggled = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a bunch of signal triggers to triggering obfuscation drop - getting shot, using Disciplines in general, bumping into things/people or being walked over, switching your rest state, grabbing or being grabbed, talking and emoting.
Adds new bump proc for that, renames the walk-fuscate proc, bunches them together a bit up the hierarchy.

I couldn't get picking up/dropping items and messing with storage containers work as triggers for deobfuscation. Same with doors and lockpicking, since there's no signals for it period there. Equipping/taking items from slots and pockets somehow DID drop obfuscate, but I omitted that because it's incredibly specific without the full package. If someone can figure this out for me, I can mess with it again.

## Why It's Good For The Game

Obfuscate stocks propelled into the stratosphere now that it makes you actually undetectable, and cannot be countered by anything but Auspex or liberal bat-swinging through the entire map. Being able to tank bullets and suck blood gave people waaaay too much bravery when it came to looting faction areas, and way too many get-out-of-fight-free cards.
This doesn't take away its main power, but adds a skill floor in managing your movement. It lets people relatively easily find Obfuscate users in enclosed spaces by running around until they bump them. Should encourage users to play smarter, and move more carefully without enforcing something artificial like mandatory slowdowns.

tl;dr salt pr after having my spray cans stolen by sabbat malkavians for the 50th time

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="294" alt="obfus5" src="https://github.com/user-attachments/assets/f8ebf526-ee7e-44b4-9e97-e84281d7cdee" />
<img width="273" alt="obfus4" src="https://github.com/user-attachments/assets/129ec588-8cad-419d-8be7-2e52a7bda769" />

trust me on being shot at dropping obfuscate, i cant be bothered to record videos on my craptop and you cant really communicate it with screenshots. All the triggers mentioned tested, they work!!!

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Obfuscate now drops on getting shot, using Disciplines, bumping, crossing, resting, grabs, talking, emotes.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
