### PR TITLE
Removes generation checks from disciplines

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/dominate.dm
+++ b/code/modules/wod13/datums/powers/discipline/dominate.dm
@@ -56,7 +56,7 @@
 		if(human_target.clane?.name == "Gargoyle")
 			return TRUE
 
-	if((theirpower >= mypower) || (owner.generation > target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to dominate!"))
 		return FALSE
 
@@ -95,7 +95,7 @@
 		if(human_target.clane?.name == "Gargoyle")
 			return TRUE
 
-	if((theirpower >= mypower) || (owner.generation > target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to dominate!"))
 		return FALSE
 
@@ -136,7 +136,7 @@
 		if(human_target.clane?.name == "Gargoyle")
 			return TRUE
 
-	if((theirpower >= mypower) || (owner.generation > target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to dominate!"))
 		return FALSE
 
@@ -176,7 +176,7 @@
 		if(human_target.clane?.name == "Gargoyle")
 			return TRUE
 
-	if((theirpower >= mypower) || (owner.generation > target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to dominate!"))
 		return FALSE
 
@@ -215,7 +215,7 @@
 		if(human_target.clane?.name == "Gargoyle")
 			return TRUE
 
-	if((theirpower >= mypower) || (owner.generation > target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to dominate!"))
 		return FALSE
 

--- a/code/modules/wod13/datums/powers/discipline/presence.dm
+++ b/code/modules/wod13/datums/powers/discipline/presence.dm
@@ -30,7 +30,7 @@
 /datum/discipline_power/presence/awe/pre_activation_checks(mob/living/target)
 	var/mypower = owner.get_total_social()
 	var/theirpower = target.get_total_mentality()
-	if((theirpower >= mypower) || ((owner.generation - 3) >= target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to sway!"))
 		return FALSE
 
@@ -79,7 +79,7 @@
 /datum/discipline_power/presence/dread_gaze/pre_activation_checks(mob/living/target)
 	var/mypower = owner.get_total_social()
 	var/theirpower = target.get_total_mentality()
-	if((theirpower >= mypower) || ((owner.generation - 3) >= target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to sway!"))
 		return FALSE
 
@@ -121,7 +121,7 @@
 /datum/discipline_power/presence/entrancement/pre_activation_checks(mob/living/target)
 	var/mypower = owner.get_total_social()
 	var/theirpower = target.get_total_mentality()
-	if((theirpower >= mypower) || ((owner.generation - 3) >= target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to sway!"))
 		return FALSE
 
@@ -170,7 +170,7 @@
 /datum/discipline_power/presence/summon/pre_activation_checks(mob/living/target)
 	var/mypower = owner.get_total_social()
 	var/theirpower = target.get_total_mentality()
-	if((theirpower >= mypower) || ((owner.generation - 3) >= target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to sway!"))
 		return FALSE
 
@@ -220,7 +220,7 @@
 /datum/discipline_power/presence/majesty/pre_activation_checks(mob/living/target)
 	var/mypower = owner.get_total_social()
 	var/theirpower = target.get_total_mentality()
-	if((theirpower >= mypower) || ((owner.generation - 3) >= target.generation))
+	if(theirpower >= mypower)
 		to_chat(owner, span_warning("[target]'s mind is too powerful to sway!"))
 		return FALSE
 


### PR DESCRIPTION
Currently, white-listed players are simply immune to domination by those who are not white-listed. This is likely an oversight, as I can't imagine that domination/presence immunity was ever intended to be a benefit of being whitelisted when the white-list was introduced for quality control.