### PR TITLE
Renames W*ndigos To Gale Stalkers On Tzula's Request

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -214,7 +214,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/archetype = /datum/archetype/average
 
 	var/breed = "Homid"
-	var/tribe = "Wendigo"
+	var/tribe = "Gale Stalkers"
 	var/datum/auspice/auspice = new /datum/auspice/ahroun()
 	var/werewolf_color = "black"
 	var/werewolf_scar = 0
@@ -541,8 +541,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					switch (tribe)
 						if ("Glasswalkers")
 							zalupa = auspice.glasswalker[i]
-						if ("Wendigo")
-							zalupa = auspice.wendigo[i]
+						if ("Gale Stalkers")
+							zalupa = auspice.galestalker[i]
 						if ("Black Spiral Dancers")
 							zalupa = auspice.spiral[i]
 					var/datum/action/T = new zalupa()
@@ -2289,7 +2289,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					if(slotlocked || !(pref_species.id == "garou"))
 						return
 
-					var/new_tribe = tgui_input_list(user, "Choose your Tribe:", "Tribe", sortList(list("Wendigo", "Glasswalkers", "Black Spiral Dancers")))
+					var/new_tribe = tgui_input_list(user, "Choose your Tribe:", "Tribe", sortList(list("Gale Stalkers", "Glasswalkers", "Black Spiral Dancers")))
 					if (new_tribe)
 						tribe = new_tribe
 
@@ -3226,7 +3226,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		character.maxHealth = round((initial(character.maxHealth)+(initial(character.maxHealth)/4)*(character.physique + character.additional_physique)))
 		character.health = character.maxHealth
 		switch(tribe)
-			if("Wendigo")
+			if("Gale Stalkers")
 				character.yin_chi = 1
 				character.max_yin_chi = 1
 				character.yang_chi = 5 + (auspice_level * 2)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -572,7 +572,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	archetype 		= sanitize_inlist(archetype, subtypesof(/datum/archetype))
 
 	breed			= sanitize_inlist(breed, list("Homid", "Lupus", "Metis"))
-	tribe			= sanitize_inlist(tribe, list("Wendigo", "Glasswalkers", "Black Spiral Dancers"))
+	tribe			= sanitize_inlist(tribe, list("Gale Stalkers", "Glasswalkers", "Black Spiral Dancers"))
 	werewolf_color	= sanitize_inlist(werewolf_color, list("black", "gray", "red", "white", "ginger", "brown"))
 	werewolf_scar	= sanitize_integer(werewolf_scar, 0, 7, initial(werewolf_scar))
 	werewolf_hair	= sanitize_integer(werewolf_hair, 0, 4, initial(werewolf_hair))

--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -160,7 +160,7 @@
 				var/mob/living/carbon/wolf = src
 
 				switch(wolf.auspice.tribe)
-					if ("Wendigo")
+					if ("Gale Stalkers")
 						wyld_taint++
 					if ("Glasswalkers")
 						weaver_taint++

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -458,7 +458,7 @@
 				var/mob/living/carbon/wolf = src
 				msg += "<span class='purple'><i>You recognize their scent as Garou.</i></span><br>"
 				switch(wolf.auspice.tribe)
-					if ("Wendigo")
+					if ("Gale Stalkers")
 						wyld_taint++
 					if ("Glasswalkers")
 						weaver_taint++

--- a/code/modules/mob/living/carbon/werewolf/life.dm
+++ b/code/modules/mob/living/carbon/werewolf/life.dm
@@ -65,7 +65,7 @@
 					last_veil_restore = world.time
 
 			switch(auspice.tribe)
-				if("Wendigo")
+				if("Gale Stalkers")
 					if(istype(get_area(src), /area/vtm/forest))
 						if((last_veil_restore + 50 SECONDS) <= world.time)
 							adjust_veil(1, src, TRUE)

--- a/code/modules/mob/living/carbon/werewolf/werewolf_update_icons.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf_update_icons.dm
@@ -40,7 +40,7 @@
 
 	if(sprite_apparel)
 		switch(auspice.tribe)
-			if("Wendigo")
+			if("Gale Stalkers")
 				var/mutable_appearance/clothing_overlay = mutable_appearance(icon, "wendigo[sprite_apparel][laid_down ? "_rest" : ""]")
 				add_overlay(clothing_overlay)
 			if("Glasswalkers")

--- a/code/modules/stock_market/industries.dm
+++ b/code/modules/stock_market/industries.dm
@@ -202,7 +202,7 @@
 	)
 
 /datum/industry/consumer/generateProductName(var/company)
-	var/list/meat = list("chicken", "lizard", "corgi", "monkey", "goat", "fly", "xenomorph", "human", "walrus", "wendigo", "bear", "clown", "turkey", "pork", "carp", "crab", "mimic", "mystery")
+	var/list/meat = list("chicken", "lizard", "corgi", "monkey", "goat", "fly", "xenomorph", "human", "walrus", "bear", "clown", "turkey", "pork", "carp", "crab", "mimic", "mystery")
 	var/list/qualifier = list("synthetic", "organic", "bio", "diet", "sugar-free", "paleolithic", "homeopathic", "recycled", "reclaimed", "vat-grown")
 	return "the [pick(qualifier)] [pick(meat)] meat product line"
 

--- a/code/modules/vtmb/werewolf/auspice.dm
+++ b/code/modules/vtmb/werewolf/auspice.dm
@@ -7,11 +7,11 @@
 	var/start_gnosis = 1
 	var/gnosis = 1
 	var/base_breed = "Homid"
-	var/tribe = "Wendigo"
+	var/tribe = "Gale Stalkers"
 	var/list/gifts = list()
 	var/force_abomination = FALSE
 
-	var/list/wendigo = list(
+	var/list/galestalker = list(
 		/datum/action/gift/stoic_pose = 1,
 		/datum/action/gift/freezing_wind = 2,
 		/datum/action/gift/bloody_feast = 3
@@ -55,9 +55,9 @@
 				A1.Grant(C.transformator.lupus_form)
 				var/datum/action/A2 = new zalupa()
 				A2.Grant(C.transformator.crinos_form)
-		if("Wendigo")
+		if("Gale Stalkers")
 			for(var/i in 1 to level)
-				var/zalupa = wendigo[i]
+				var/zalupa = galestalker[i]
 				var/datum/action/A = new zalupa()
 				A.Grant(C)
 				var/datum/action/A1 = new zalupa()

--- a/code/modules/vtmb/werewolf/totems.dm
+++ b/code/modules/vtmb/werewolf/totems.dm
@@ -91,10 +91,10 @@
 				overlays |= totem_light_overlay
 
 /obj/structure/werewolf_totem/wendigo
-	name = "Wendigo Totem"
+	name = "Gale Stalker Totem"
 	desc = "Gives power to all Garou of that tribe and steals it from others."
 	icon_state = "wendigo"
-	tribe = "Wendigo"
+	tribe = "Gale Stalkers"
 	totem_overlay_color = "#81ff4f"
 
 /obj/structure/werewolf_totem/children_of_gaia

--- a/code/modules/vtmb/werewolf/tribes.dm
+++ b/code/modules/vtmb/werewolf/tribes.dm
@@ -34,7 +34,7 @@
 
 /datum/action/gift/freezing_wind
 	name = "Freezing Wind"
-	desc = "Garou of Wendigo Tribe can create a stream of cold, freezing wind, and strike her foes with it."
+	desc = "Garou of Gale Stalkers Tribe can create a stream of cold, freezing wind, and strike her foes with it."
 	button_icon_state = "freezing_wind"
 	rage_req = 1
 


### PR DESCRIPTION
## About The Pull Request

What it says on the tin. This renames a culturally insensitive tribe to the more modernized name for them. Note that this does not adjust the code side of things, as refactoring it would be annoying and risks breaking things. This purely affects the player facing side of things.

### **IMPORTANT NOTICE:**
Due to how SS13 prefs saving code works, the null entry of W*ndigo no longer existing defaults to alphabetical primacy. This means that it will default all existing cases of such to Black Spiral Dancer. This is known and an announcement shall be required so as to ensure gale stalker players know to spend 3xp to change their tribe back to Gale Stalker properly.

## Why It's Good For The Game

Removing a deeply uncomfortable bit of cultural terminology and replacing it with the modernized tribe name is not only desirable, but was directly requested by one of the head staffers.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2025-04-04 200543](https://github.com/user-attachments/assets/3978d110-eb5a-4d96-b1b3-d2bed84ac555)
![Screenshot 2025-04-04 200611](https://github.com/user-attachments/assets/0317a3d7-b1d3-4b27-bb96-40a17843e62d)
![Screenshot 2025-04-04 201401](https://github.com/user-attachments/assets/3814dc0b-1bad-4379-bd5a-2c6b8634b01f)

</details>

## Changelog

:cl:
fix: Renames W*endigo to Gale Stalkers
/:cl:
