### PR TITLE
Removes a buggy proc rellated to item lists

### DIFF
--- a/code/modules/wod13/onyxcombat.dm
+++ b/code/modules/wod13/onyxcombat.dm
@@ -474,38 +474,6 @@
 	else
 		harm_focus = dir
 
-/atom/Click(location,control,params)
-	if(ishuman(usr))
-		if(isopenturf(src.loc) || isopenturf(src))
-			var/list/modifiers = params2list(params)
-			var/mob/living/carbon/human/HUY = usr
-			if(!HUY.get_active_held_item() && Adjacent(usr))
-				if(LAZYACCESS(modifiers, "right"))
-					var/list/shit = list()
-					var/obj/item/item_to_pick
-					var/turf/T
-					if(isturf(src))
-						T = src
-					else
-						T = src.loc
-					for(var/obj/item/I in T)
-						if(I)
-							if(!I.anchored)
-								shit[I.name] = I
-						if(length(shit) == 1)
-							item_to_pick = I
-					if(length(shit) >= 2)
-						var/result = input(usr, "Select the item you want to pick up.", "Pick up") as null|anything in shit
-						if(result)
-							item_to_pick = shit[result]
-						else
-							return
-					if(item_to_pick)
-						if(HUY.CanReach(item_to_pick))
-							HUY.put_in_active_hand(item_to_pick)
-						return
-	..()
-
 /mob/living/carbon/werewolf/Life()
 	. = ..()
 	update_blood_hud()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Removes a proc that ran whenever people would right click on a pile of items and it'd show a list. This was INCREDIBLY buggy and unnecessary, since we just have the examine menu.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

Removing buggy code good

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

https://github.com/user-attachments/assets/199af996-80eb-4956-a5ba-5aca836cd63b




</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl: XeonMations
del: Removed an uncessesary list proc from the game, fixing a bug,
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
