### PR TITLE
Fixes flavortext & ooc notes getting needlessly encoded

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2482,16 +2482,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				// TODO: Completely revamp flavor text into a more expansive system - TFN
 				// TFN EDIT ADDITION START: character headshots & flavortext
 				if("ooc_notes")
-					var/new_ooc_notes = tgui_input_text(user, "Choose your character's OOC notes:", "Character Preference", ooc_notes, MAX_MESSAGE_LEN, multiline = TRUE)
+					var/new_ooc_notes = tgui_input_text(user, "Choose your character's OOC notes:", "Character Preference", ooc_notes, MAX_MESSAGE_LEN, multiline = TRUE, encode = FALSE)
 					if(!length(new_ooc_notes))
 						return
-					ooc_notes = new_ooc_notes
+					ooc_notes = STRIP_HTML_SIMPLE(new_ooc_notes, MAX_MESSAGE_LEN)
 
 				if("flavor_text")
-					var/new_flavor = tgui_input_text(user, "Choose your character's flavor text:", "Character Preference", flavor_text, MAX_FLAVOR_LEN, multiline = TRUE)
+					var/new_flavor = tgui_input_text(user, "Choose your character's flavor text:", "Character Preference", flavor_text, MAX_FLAVOR_LEN, multiline = TRUE, encode = FALSE)
 					if(!length(new_flavor))
 						return
-					flavor_text = new_flavor
+					flavor_text = STRIP_HTML_SIMPLE(new_flavor, MAX_FLAVOR_LEN)
 
 				if("view_flavortext")
 					var/datum/browser/popup = new(user, "[real_name]_flavortext", real_name, 500, 200)

--- a/code/modules/mob/living/examine_tgui.dm
+++ b/code/modules/mob/living/examine_tgui.dm
@@ -70,7 +70,7 @@
 
 	data["obscured"] = obscured ? TRUE : FALSE
 	data["character_name"] = name
-	data["flavor_text"] = html_decode(flavor_text)
-	data["ooc_notes"] = html_decode(ooc_notes)
+	data["flavor_text"] = flavor_text
+	data["ooc_notes"] = ooc_notes
 	data["headshot"] = headshot
 	return data

--- a/code/modules/mob/living/examine_tgui.dm
+++ b/code/modules/mob/living/examine_tgui.dm
@@ -70,7 +70,7 @@
 
 	data["obscured"] = obscured ? TRUE : FALSE
 	data["character_name"] = name
-	data["flavor_text"] = flavor_text
-	data["ooc_notes"] = ooc_notes
+	data["flavor_text"] = html_decode(flavor_text)
+	data["ooc_notes"] = html_decode(ooc_notes)
 	data["headshot"] = headshot
 	return data


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes weird unicode characters appearing in place of innocent characters like ' in flavortext & ooc note presentation

## Why It's Good For The Game

This is the same method upstream /tg/ used in their preferences rework, and it just works.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Fixed weird characters showing up in flavortext & ooc notes display.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
