### PR TITLE
makes broken tzimisce floor uncraftable (BUGFIX)

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/vicissitude.dm
+++ b/code/modules/wod13/datums/powers/discipline/vicissitude.dm
@@ -220,10 +220,10 @@
 	owner.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_wall)
 	owner.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_stool)
 	owner.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_floor)
-	owner.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_floor_living)
 	owner.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_eyes)
 	owner.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_implant)
 
+	// owner.mind.teach_crafting_recipe(/datum/crafting_recipe/tzi_floor_living) (Commented out because crafting it resulted in the crafting icon in tgui to go infinitely and stop the crafting menu from working)
 
 
 //BONECRAFTING


### PR DESCRIPTION
I swear I tested it



## About The Pull Request
comments out the tzimisce crafting recipe for the necropolis floor
## Why It's Good For The Game

Upon being crafted the tzimisce floor would be created but the "Crafting..." text would still show on the crafting menu along with the turning gear icon. This will be replaced by a structure in a future update.

## Testing Photographs and Procedure

No testing image provided because it is just commenting out a single line.

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

Make the tzimisce necropolis floor uncraftable 
del: Removed old things

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
