### PR TITLE
Makes madness speech cd 5 seconds.

### DIFF
--- a/code/modules/vtmb/vampire_clane/malkavian.dm
+++ b/code/modules/vtmb/vampire_clane/malkavian.dm
@@ -64,7 +64,7 @@ GLOBAL_LIST_INIT(malkavian_character_replacements, list(
 	button_icon_state = "malk_speech"
 	check_flags = AB_CHECK_CONSCIOUS
 	vampiric = TRUE
-	cooldown_time = 5 MINUTES
+	cooldown_time = 5 SECONDS
 	///clane datum
 	var/datum/vampireclane/malkavian/clane_datum
 


### PR DESCRIPTION
## About The Pull Request

Madness speech is a 5 second cooldown, same as madness network hivemind.

## Why It's Good For The Game

Malk speech is a pretty fun representation of just how disconnected malks can be when they open their mouths, and locking it behind a 5 minutes cd is the silliest thing I've ever seen. I don't even understand how this could possibly be abused, and frankly, any possible abuse that talking funny can have pales in comparison to the abuse you can pull with a normal vampiric discipline.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog

:cl:

code: Channel Madness has a 5 second cooldown.

/:cl:


