### PR TITLE
Kuei-Jin Awaken out of Crit Fix

### DIFF
--- a/code/modules/vtmb/kuei_jin.dm
+++ b/code/modules/vtmb/kuei_jin.dm
@@ -51,7 +51,7 @@
 	disliked_food = GROSS | RAW
 	liked_food = JUNKFOOD | FRIED
 	species_traits = list(EYECOLOR, HAIR, FACEHAIR, LIPS, HAS_FLESH, HAS_BONE)
-	inherent_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_VIRUSIMMUNE, TRAIT_PERFECT_ATTACKER, TRAIT_NOBREATH)
+	inherent_traits = list(TRAIT_ADVANCEDTOOLUSER, TRAIT_VIRUSIMMUNE, TRAIT_PERFECT_ATTACKER, TRAIT_NOBREATH, TRAIT_NOCRITDAMAGE)
 	use_skintones = TRUE
 	limbs_id = "human"
 	wings_icon = "None"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Getting Little Death'd/Torpored as KJ would still stack damage on you because of not having a trait preventing that. This resulted in you perma-dying before you can Awaken if your Yin is 5 or higher. This grants them the trait to prevent passive damage while in crit, letting them safely Awaken after fights so long as nothing finishes them off.

Tested, works, doesn't break anything.

## Why It's Good For The Game

KJ experience a Torpor equivalent in the tabletop, named Little Death, already. Players shouldn't be punished by a bug they don't know to play around.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/7d88d8ed-000c-4a6c-8016-d1d3777402ca)
![image](https://github.com/user-attachments/assets/2b451762-168e-4469-9076-9967fc678cc5)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: KJs now have no crit damage trait, preventing them from passively dying of oxyloss before they can Awaken out of Little Death
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
