### PR TITLE
Re-Enables Diablerie, Fixes Burn Healing On Feeding

### DIFF
--- a/code/__DEFINES/wod13/status_effects_debuffs.dm
+++ b/code/__DEFINES/wod13/status_effects_debuffs.dm
@@ -2,3 +2,4 @@
 
 #define STATUS_EFFECT_SILVER_SLOWDOWN /datum/status_effect/silver_slowdown //slows down any mobs with a bane to silver.
 #define STATUS_EFFECT_AWE /datum/status_effect/awe
+#define STATUS_EFFECT_DIABLERIE_HIGH /datum/status_effect/diablerie_high

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -42,48 +42,15 @@
 	if(mob.bloodpool <= 1 && mob.maxbloodpool > 1)
 		to_chat(src, "<span class='warning'>You feel small amount of <b>BLOOD</b> in your victim.</span>")
 		if(iskindred(mob) && iskindred(src))
-			if(!mob.client)
+			if(!mob.client || !mob.key)
 				to_chat(src, "<span class='warning'>You need [mob]'s attention to do that...</span>")
 				return
 			message_admins("[ADMIN_LOOKUPFLW(src)] is attempting to Diablerize [ADMIN_LOOKUPFLW(mob)]")
 			log_attack("[key_name(src)] is attempting to Diablerize [key_name(mob)].")
-			if(mob.key)
-				var/vse_taki = FALSE
-				if(clane)
-					var/salubri_allowed = FALSE
-					var/mob/living/carbon/human/H = mob
-					if(H.clane)
-						if(H.clane.name == "Salubri")
-							salubri_allowed = TRUE
-					if(clane.name != "Banu Haqim" && clane.name != "Caitiff")
-						if(!salubri_allowed)
-							if(!mind.special_role)
-								to_chat(src, "<span class='warning'>You find the idea of drinking your own <b>KIND's</b> blood disgusting!</span>")
-								last_drinkblood_use = 0
-								if(client)
-									client.images -= suckbar
-								qdel(suckbar)
-								stop_sound_channel(CHANNEL_BLOOD)
-								return
-							else
-								vse_taki = TRUE
-						else
-							vse_taki = TRUE
-					else
-						vse_taki = TRUE
-
-				if(!GLOB.canon_event)
-					to_chat(src, "<span class='warning'>It's not a canon event!</span>")
-					return
-
-				if(vse_taki)
-					to_chat(src, "<span class='userdanger'><b>YOU TRY TO COMMIT DIABLERIE ON [mob].</b></span>")
-				else
-					to_chat(src, "<span class='warning'>You find the idea of drinking your own <b>KIND</b> disgusting!</span>")
-					return
-			else
-				to_chat(src, "<span class='warning'>You need [mob]'s attention to do that...</span>")
+			if(!GLOB.canon_event)
+				to_chat(src, "<span class='warning'>It's not a canon event!</span>")
 				return
+			to_chat(src, "<span class='userdanger'><b>YOU TRY TO COMMIT DIABLERIE ON [mob].</b></span>")
 
 	if(!HAS_TRAIT(src, TRAIT_BLOODY_LOVER))
 		if(CheckEyewitness(src, src, 7, FALSE))
@@ -134,7 +101,7 @@
 		if(iskindred(mob))
 			to_chat(src, "<span class='userlove'>[mob]'s blood tastes HEAVENLY...</span>")
 			adjustBruteLoss(-25, TRUE)
-			adjustFireLoss(-25, TRUE)
+			adjustFireLoss(-6, TRUE)
 		else
 			to_chat(src, "<span class='warning'>You sip some <b>BLOOD</b> from your victim. It feels good.</span>")
 		if(HAS_TRAIT(src, TRAIT_MESSY_EATER))
@@ -149,7 +116,6 @@
 		else
 			bloodpool = min(maxbloodpool, bloodpool+bloodgain)
 			adjustBruteLoss(-10, TRUE)
-			adjustFireLoss(-10, TRUE)
 			update_damage_overlays()
 			update_health_hud()
 			update_blood_hud()
@@ -178,8 +144,6 @@
 							diablerist = 1
 					else
 						var/start_prob = 10
-						if(HAS_TRAIT(src, TRAIT_DIABLERIE))
-							start_prob = 30
 						if(prob(min(99, start_prob+((generation-K.generation)*10))))
 							to_chat(src, "<span class='userdanger'><b>[K]'s SOUL OVERCOMES YOURS AND GAIN CONTROL OF YOUR BODY.</b></span>")
 							message_admins("[ADMIN_LOOKUPFLW(src)] tried to Diablerize [ADMIN_LOOKUPFLW(mob)] and was overtaken.")
@@ -199,8 +163,6 @@
 									P.generation = max(P.generation - 1, 7)
 								generation = P.generation
 							diablerist = 1
-							maxHealth = initial(maxHealth)+max(0, 50*(13-generation))
-							health = initial(health)+max(0, 50*(13-generation))
 							if(K.client)
 								var/datum/brain_trauma/special/imaginary_friend/trauma = gain_trauma(/datum/brain_trauma/special/imaginary_friend)
 								trauma.friend.key = K.key

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -46,8 +46,8 @@
 				to_chat(src, "<span class='warning'>You need [mob]'s attention to do that...</span>")
 				last_drinkblood_use = 0
 				if(client)
-				client.images -= suckbar
-				qdel(suckbar)
+					client.images -= suckbar
+					qdel(suckbar)
 				stop_sound_channel(CHANNEL_BLOOD)
 				return
 			message_admins("[ADMIN_LOOKUPFLW(src)] is attempting to Diablerize [ADMIN_LOOKUPFLW(mob)]")
@@ -134,7 +134,7 @@
 					if(confirmation == "Yes")
 						SEND_SIGNAL(src, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 0)
 						AdjustMasquerade(-1)
-						if(do_mob(src, mob, 600))
+						if(do_mob(src, mob, 60 SECONDS))
 							if(K.generation >= generation)
 								message_admins("[ADMIN_LOOKUPFLW(src)] successfully Diablerized [ADMIN_LOOKUPFLW(mob)]")
 								log_attack("[key_name(src)] successfully Diablerized [key_name(mob)].")
@@ -144,6 +144,7 @@
 								mob.death()
 								if(P2)
 									P2.reason_of_death =  "Diablerized by [true_real_name ? true_real_name : real_name] ([time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")])."
+								apply_status_effect(STATUS_EFFECT_DIABLERIE_HIGH)
 								adjustBruteLoss(-50, TRUE)
 								adjustFireLoss(-50, TRUE)
 								if(key)

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -130,11 +130,11 @@
 				if(iskindred(mob) && iskindred(src))
 					var/datum/preferences/P = GLOB.preferences_datums[ckey(key)]
 					var/datum/preferences/P2 = GLOB.preferences_datums[ckey(mob.key)]
-					var/confirmation = input(src, "ATTEMPT TO DIABLERIZE [mob]?") in list("No", "Yes")
+					var/confirmation = tgui_alert(src, "Attempt to diablerize [mob]?", "Diablerize", buttons = list("Yes", "No"))
 					if(confirmation == "Yes")
 						SEND_SIGNAL(src, COMSIG_PATH_HIT, PATH_SCORE_DOWN, 0)
 						AdjustMasquerade(-1)
-						if(do_mob(src, mob, 60 SECONDS))
+						if(do_after(src, 60 SECONDS, mob))
 							if(K.generation >= generation)
 								message_admins("[ADMIN_LOOKUPFLW(src)] successfully Diablerized [ADMIN_LOOKUPFLW(mob)]")
 								log_attack("[key_name(src)] successfully Diablerized [key_name(mob)].")

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -154,7 +154,7 @@
 							else
 								var/start_prob = 10
 								if(prob(min(99, start_prob+((generation-K.generation)*10))))
-									to_chat(src, "<span class='userdanger'><b>[K]'s SOUL OVERCOMES YOURS AND GAIN CONTROL OF YOUR BODY.</b></span>")
+									to_chat(src, span_userdanger("[K]'s SOUL OVERCOMES YOURS AND GAIN CONTROL OF YOUR BODY."))
 									message_admins("[ADMIN_LOOKUPFLW(src)] tried to Diablerize [ADMIN_LOOKUPFLW(mob)] and was overtaken.")
 									log_attack("[key_name(src)] tried to Diablerize [key_name(mob)] and was overtaken.")
 									generation = min(13, P.generation+1)

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -53,7 +53,7 @@
 			message_admins("[ADMIN_LOOKUPFLW(src)] is attempting to Diablerize [ADMIN_LOOKUPFLW(mob)]")
 			log_attack("[key_name(src)] is attempting to Diablerize [key_name(mob)].")
 			if(!GLOB.canon_event)
-				to_chat(src, "<span class='warning'>It's not a canon event!</span>")
+				to_chat(src, span_warning("It's not a canon event!"))
 				return
 			to_chat(src, span_userdanger("YOU TRY TO COMMIT DIABLERIE ON [mob]."))
 

--- a/code/modules/wod13/bloodsucking.dm
+++ b/code/modules/wod13/bloodsucking.dm
@@ -40,7 +40,7 @@
 		mob.Stun(40) //NPCs don't get to resist
 
 	if(mob.bloodpool <= 1 && mob.maxbloodpool > 1)
-		to_chat(src, "<span class='warning'>You feel only a sliver of <b>BLOOD</b> in your victim.</span>")
+		to_chat(src, span_warning("You feel only a sliver of <b>BLOOD</b> in your victim."))
 		if(iskindred(mob) && iskindred(src))
 			if(!mob.client || !mob.key)
 				to_chat(src, "<span class='warning'>You need [mob]'s attention to do that...</span>")
@@ -55,7 +55,7 @@
 			if(!GLOB.canon_event)
 				to_chat(src, "<span class='warning'>It's not a canon event!</span>")
 				return
-			to_chat(src, "<span class='userdanger'><b>YOU TRY TO COMMIT DIABLERIE ON [mob].</b></span>")
+			to_chat(src, span_userdanger("YOU TRY TO COMMIT DIABLERIE ON [mob]."))
 
 	if(!HAS_TRAIT(src, TRAIT_BLOODY_LOVER))
 		if(CheckEyewitness(src, src, 7, FALSE))

--- a/code/modules/wod13/status_effects/debuffs.dm
+++ b/code/modules/wod13/status_effects/debuffs.dm
@@ -1005,3 +1005,41 @@
 /datum/status_effect/awe/Destroy()
 	source = null
 	return ..()
+
+/datum/status_effect/diablerie_high //Used for powers that force a target to walk to you.
+	id = "diablerie"
+	status_type = STATUS_EFFECT_REPLACE
+	duration = 15 MINUTES
+	tick_interval = 2 SECONDS
+	alert_type = /atom/movable/screen/alert/status_effect/diablerie_high
+
+/atom/movable/screen/alert/status_effect/diablerie_high
+	name = "Amaranth"
+	desc = "That felt amazing... I am zooted out of my mind."
+	icon_state = "hypnosis"
+
+/datum/movespeed_modifier/diablerie_high
+	multiplicative_slowdown = 0.15
+
+/datum/status_effect/diablerie_high/tick()
+	var/mob/living/carbon/H = owner
+	H.set_drugginess(15)
+	if(prob(4))
+		var/high_message = pick("You feel in tune with your Beast.","You feel like fistfighting Hardestadt.","Some more Vitae would wash this down nicely..","You could use some more of that nectar.","You can feel your blood pulsing.","You feel relaxed.","Your Beast craves for more.","You notice you've been moving more slowly.")
+		to_chat(H, span_notice("[high_message]"))
+
+/datum/status_effect/diablerie_high/on_apply()
+	. = ..()
+	owner.add_movespeed_modifier(/datum/movespeed_modifier/diablerie_high)
+	if(!HAS_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN))
+		ADD_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, SPECIES_TRAIT)
+	owner.additional_dexterity -= 2
+	owner.additional_mentality -= 1
+
+/datum/status_effect/diablerie_high/on_remove()
+	. = ..()
+	owner.remove_movespeed_modifier(/datum/movespeed_modifier/diablerie_high)
+	owner.additional_dexterity += 2
+	owner.additional_mentality += 1
+	if(HAS_TRAIT(owner, TRAIT_IGNORESLOWDOWN))
+		REMOVE_TRAIT(owner, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)

--- a/code/modules/wod13/status_effects/debuffs.dm
+++ b/code/modules/wod13/status_effects/debuffs.dm
@@ -1041,5 +1041,5 @@
 	owner.remove_movespeed_modifier(/datum/movespeed_modifier/diablerie_high)
 	owner.additional_dexterity += 2
 	owner.additional_mentality += 1
-	if(HAS_TRAIT(owner, TRAIT_IGNORESLOWDOWN))
-		REMOVE_TRAIT(owner, TRAIT_IGNORESLOWDOWN, SPECIES_TRAIT)
+	if(HAS_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN))
+		REMOVE_TRAIT(owner, TRAIT_IGNOREDAMAGESLOWDOWN, SPECIES_TRAIT)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes it so Diablerie is no longer restricted to Salubri, Caitiff and Banu Haqim.
Adds a prompt to Diablerie, followed by a 60 second timer before it actually happens.
Removes the hike in chance of dying when diablerizing just for having the Diablerist trait.
Removes old code from back when Generation was tied to healthpool.

The high associated with Diablerizing another Kindred is now represented with a status effect.

Tones down/removes the burn damage healing from drinking blood.

## Why It's Good For The Game
Lore-accuracy. As for potential rulebreaking, The Final Nights is a more curated environment, and wanton Diablerie should be held to a higher standard of punishment rather than mechanically restricted - specially in its current iteration, where it does not in any way affect the Diablerized player's character sheet.

Drinking blood healing such a massive amount of burn damage was a leftover. As part of the server's launch, all sources of kindred fire damage healing were slashed down (from 30 per BP to 6), and whoever did it forgot to change it for blood drinking as well.


## Testing Photographs and Procedure
![1f3bc55eebf680ca59be56f7e4eb5250](https://github.com/user-attachments/assets/4205600b-019f-420b-9419-2ebc36c602d7)


</details>

## Changelog

:cl:
add: Vampires of all clans can now attempt Diablerie without getting mindcontrolled by Hardestadt and his 5G towers.
add: Diablerie now comes with its associated high.
/:cl: