### PR TITLE
Minimum Generation in Savefile [HOTFIX]

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -629,7 +629,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	lover				= sanitize_integer(lover, 0, 1, initial(lover))
 	masquerade				= sanitize_integer(masquerade, 0, 5, initial(masquerade))
 	// TFN EDIT START: gen tweaks
-	generation				= sanitize_integer(generation, 8, 14, initial(generation))
+	generation				= sanitize_integer(generation, 7, 14, initial(generation))
 	generation_bonus				= sanitize_integer(generation_bonus, 0, 5, initial(generation_bonus))
 	// TFN EDIT END
 	hair_color			= sanitize_hexcolor(hair_color, 3, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR saves TFN.

Just kidding its a one digit change to let potential 7th gen characters exist and save properly by making the integer sanitation minimum be one lower.

May or may not be currently relevant. You never know.

## Why It's Good For The Game
[REDACTED]
