### PR TITLE
Fortitude W's

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/fortitude.dm
+++ b/code/modules/wod13/datums/powers/discipline/fortitude.dm
@@ -32,15 +32,11 @@
 
 /datum/discipline_power/fortitude/one/activate()
 	. = ..()
-	owner.physiology.armor.melee += 15
-	owner.physiology.armor.bullet += 15
-	owner.physiology.armor.fire += 10
+	owner.physiology.damage_resistance = 15
 
 /datum/discipline_power/fortitude/one/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 15
-	owner.physiology.armor.bullet -= 15
-	owner.physiology.armor.fire -= 10
+	owner.physiology.damage_resistance = 0
 
 //FORTITUDE 2
 /datum/discipline_power/fortitude/two
@@ -63,15 +59,11 @@
 
 /datum/discipline_power/fortitude/two/activate()
 	. = ..()
-	owner.physiology.armor.melee += 30
-	owner.physiology.armor.bullet += 30
-	owner.physiology.armor.fire += 20
+	owner.physiology.damage_resistance = 30
 
 /datum/discipline_power/fortitude/two/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 30
-	owner.physiology.armor.bullet -= 30
-	owner.physiology.armor.fire -= 20
+	owner.physiology.damage_resistance = 0
 
 //FORTITUDE 3
 /datum/discipline_power/fortitude/three
@@ -94,15 +86,11 @@
 
 /datum/discipline_power/fortitude/three/activate()
 	. = ..()
-	owner.physiology.armor.melee += 45
-	owner.physiology.armor.bullet += 45
-	owner.physiology.armor.fire += 30
+	owner.physiology.damage_resistance = 45
 
 /datum/discipline_power/fortitude/three/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 45
-	owner.physiology.armor.bullet -= 45
-	owner.physiology.armor.fire -= 30
+	owner.physiology.damage_resistance = 0
 
 //FORTITUDE 4
 /datum/discipline_power/fortitude/four
@@ -125,15 +113,11 @@
 
 /datum/discipline_power/fortitude/four/activate()
 	. = ..()
-	owner.physiology.armor.melee += 60
-	owner.physiology.armor.bullet += 60
-	owner.physiology.armor.fire += 40
+	owner.physiology.damage_resistance = 60
 
 /datum/discipline_power/fortitude/four/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 60
-	owner.physiology.armor.bullet -= 60
-	owner.physiology.armor.fire -= 40
+	owner.physiology.damage_resistance = 0
 
 //FORTITUDE 5
 /datum/discipline_power/fortitude/five
@@ -156,12 +140,8 @@
 
 /datum/discipline_power/fortitude/five/activate()
 	. = ..()
-	owner.physiology.armor.melee += 75
-	owner.physiology.armor.bullet += 75
-	owner.physiology.armor.fire += 50
+	owner.physiology.damage_resistance = 75
 
 /datum/discipline_power/fortitude/five/deactivate()
 	. = ..()
-	owner.physiology.armor.melee -= 75
-	owner.physiology.armor.bullet -= 75
-	owner.physiology.armor.fire -= 50
+	owner.physiology.damage_resistance = 0

--- a/code/modules/wod13/datums/powers/discipline/obtenebration.dm
+++ b/code/modules/wod13/datums/powers/discipline/obtenebration.dm
@@ -100,13 +100,13 @@
 
 /datum/discipline_power/obtenebration/black_metamorphosis/activate()
 	. = ..()
-	owner.physiology.damage_resistance += 60
+	owner.physiology.damage_resistance = 60
 	animate(owner, color = "#000000", time = 1 SECONDS, loop = 1)
 
 /datum/discipline_power/obtenebration/black_metamorphosis/deactivate()
 	. = ..()
 	playsound(owner.loc, 'sound/magic/voidblink.ogg', 50, FALSE)
-	owner.physiology.damage_resistance -= 60
+	owner.physiology.damage_resistance = 0
 	animate(owner, color = initial(owner.color), time = 1 SECONDS, loop = 1)
 
 //TENEBROUS FORM

--- a/code/modules/wod13/datums/powers/discipline/potence.dm
+++ b/code/modules/wod13/datums/powers/discipline/potence.dm
@@ -120,7 +120,7 @@
 	owner.dna.species.attack_sound = 'code/modules/wod13/sounds/heavypunch.ogg'
 	tackler = owner.AddComponent(/datum/component/tackler, stamina_cost=0, base_knockdown = 1 SECONDS, range = 5, speed = 1, skill_mod = 0, min_distance = 0)
 	owner.potential = 3
-	ADD_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
+
 
 /datum/discipline_power/potence/three/deactivate()
 	. = ..()
@@ -131,7 +131,7 @@
 	owner.remove_overlay(POTENCE_LAYER)
 	owner.potential = 0
 	qdel(tackler)
-	REMOVE_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
+
 
 //POTENCE 4
 /datum/discipline_power/potence/four
@@ -162,7 +162,7 @@
 	owner.dna.species.attack_sound = 'code/modules/wod13/sounds/heavypunch.ogg'
 	tackler = owner.AddComponent(/datum/component/tackler, stamina_cost=0, base_knockdown = 1 SECONDS, range = 6, speed = 1, skill_mod = 0, min_distance = 0)
 	owner.potential = 4
-	ADD_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
+
 
 /datum/discipline_power/potence/four/deactivate()
 	. = ..()
@@ -173,7 +173,7 @@
 	owner.remove_overlay(POTENCE_LAYER)
 	owner.potential = 0
 	qdel(tackler)
-	REMOVE_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
+
 
 //POTENCE 5
 /datum/discipline_power/potence/five
@@ -204,7 +204,7 @@
 	owner.dna.species.attack_sound = 'code/modules/wod13/sounds/heavypunch.ogg'
 	tackler = owner.AddComponent(/datum/component/tackler, stamina_cost=0, base_knockdown = 1 SECONDS, range = 7, speed = 1, skill_mod = 0, min_distance = 0)
 	owner.potential = 5
-	ADD_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
+
 
 /datum/discipline_power/potence/five/deactivate()
 	. = ..()
@@ -215,4 +215,4 @@
 	owner.remove_overlay(POTENCE_LAYER)
 	owner.potential = 0
 	qdel(tackler)
-	REMOVE_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
+

--- a/code/modules/wod13/datums/powers/discipline/potence.dm
+++ b/code/modules/wod13/datums/powers/discipline/potence.dm
@@ -100,7 +100,6 @@
 
 	check_flags = DISC_CHECK_CAPABLE
 
-	violates_masquerade = TRUE
 	toggled = TRUE
 	duration_length = 2 TURNS
 
@@ -121,6 +120,7 @@
 	owner.dna.species.attack_sound = 'code/modules/wod13/sounds/heavypunch.ogg'
 	tackler = owner.AddComponent(/datum/component/tackler, stamina_cost=0, base_knockdown = 1 SECONDS, range = 5, speed = 1, skill_mod = 0, min_distance = 0)
 	owner.potential = 3
+	ADD_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
 
 /datum/discipline_power/potence/three/deactivate()
 	. = ..()
@@ -131,6 +131,7 @@
 	owner.remove_overlay(POTENCE_LAYER)
 	owner.potential = 0
 	qdel(tackler)
+	REMOVE_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
 
 //POTENCE 4
 /datum/discipline_power/potence/four
@@ -141,7 +142,6 @@
 
 	check_flags = DISC_CHECK_CAPABLE
 
-	violates_masquerade = TRUE
 	toggled = TRUE
 	duration_length = 2 TURNS
 
@@ -162,6 +162,7 @@
 	owner.dna.species.attack_sound = 'code/modules/wod13/sounds/heavypunch.ogg'
 	tackler = owner.AddComponent(/datum/component/tackler, stamina_cost=0, base_knockdown = 1 SECONDS, range = 6, speed = 1, skill_mod = 0, min_distance = 0)
 	owner.potential = 4
+	ADD_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
 
 /datum/discipline_power/potence/four/deactivate()
 	. = ..()
@@ -172,6 +173,7 @@
 	owner.remove_overlay(POTENCE_LAYER)
 	owner.potential = 0
 	qdel(tackler)
+	REMOVE_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
 
 //POTENCE 5
 /datum/discipline_power/potence/five
@@ -182,7 +184,6 @@
 
 	check_flags = DISC_CHECK_CAPABLE
 
-	violates_masquerade = TRUE
 	toggled = TRUE
 	duration_length = 2 TURNS
 
@@ -203,6 +204,7 @@
 	owner.dna.species.attack_sound = 'code/modules/wod13/sounds/heavypunch.ogg'
 	tackler = owner.AddComponent(/datum/component/tackler, stamina_cost=0, base_knockdown = 1 SECONDS, range = 7, speed = 1, skill_mod = 0, min_distance = 0)
 	owner.potential = 5
+	ADD_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)
 
 /datum/discipline_power/potence/five/deactivate()
 	. = ..()
@@ -213,3 +215,4 @@
 	owner.remove_overlay(POTENCE_LAYER)
 	owner.potential = 0
 	qdel(tackler)
+	REMOVE_TRAIT(owner, TRAIT_NONMASQUERADE, TRAUMA_TRAIT)

--- a/code/modules/wod13/datums/powers/discipline/potence.dm
+++ b/code/modules/wod13/datums/powers/discipline/potence.dm
@@ -100,6 +100,7 @@
 
 	check_flags = DISC_CHECK_CAPABLE
 
+	violates_masquerade = TRUE
 	toggled = TRUE
 	duration_length = 2 TURNS
 
@@ -140,6 +141,7 @@
 
 	check_flags = DISC_CHECK_CAPABLE
 
+	violates_masquerade = TRUE
 	toggled = TRUE
 	duration_length = 2 TURNS
 
@@ -180,6 +182,7 @@
 
 	check_flags = DISC_CHECK_CAPABLE
 
+	violates_masquerade = TRUE
 	toggled = TRUE
 	duration_length = 2 TURNS
 

--- a/code/modules/wod13/datums/powers/discipline/thaumaturgy.dm
+++ b/code/modules/wod13/datums/powers/discipline/thaumaturgy.dm
@@ -381,14 +381,14 @@
 	H.bloodpool = max(H.bloodpool - 2, 0)
 	playsound(H.loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
 	abuse_fix = world.time
-	H.physiology.damage_resistance += 60
+	H.physiology.damage_resistance = 60
 	animate(H, color = "#ff0000", time = 10, loop = 1)
 	if(H.CheckEyewitness(H, H, 7, FALSE))
 		H.AdjustMasquerade(-1)
 	spawn(15 SECONDS)
 		if(H)
 			playsound(H.loc, 'code/modules/wod13/sounds/thaum.ogg', 50, FALSE)
-			H.physiology.damage_resistance -= 60
+			H.physiology.damage_resistance = 0
 			H.color = initial(H.color)
 
 /*


### PR DESCRIPTION
## About The Pull Request

### THIS PR NO LONGER TOUCHES POTENCE. THAT HAS BEEN MOVED TO A SEPARATE PR

Makes fortitude work based off of damage_resistance instead of armor, same as obtenebration 4 and blood shield. Additionally codes all three in a way that prevents any possibility of stacking.

## Why It's Good For The Game

I'm ngl I just think it's weird that throwing someone through a wall isn't considered a masquerade breach but having a dog next to you causes every bystander to think you're a freak. This gives a little more thought to this discipline, as you can either go all out and start breaching or be more subdued with a lesser damage buff (but still substantial, 1.8x melee dmg is no joke).

As for the other bit, I just don't like that there are situations where fortitude is outdone by other, more versatile disciplines. Yeah fort isn't a masq breach but it also doesn't come with 4 additional decent powers + sorcereries. Making it damage resistance means lower levels of fortitude are more useful while fort 5 becomes the undisputed champion of durability.

As for the stacking thing, it's theoretically possible to become immortal if you have blood armor + obtenebration currently. I figure it best to clip that ahead of time, especially since fortitude is easier to obtain than either.

## Testing Photographs and Procedure

Non-fortitude hit

![image](https://github.com/user-attachments/assets/79f2bbee-661d-4e78-81f5-8abfcba5b5c8)

Fortitude hit

![image](https://github.com/user-attachments/assets/9199c99e-b590-4a59-80dc-c2055fc7dab3)


## Changelog

:cl:

balance: Potence 3, 4, and 5 are masquerade breaches.
balance: Fortitude is now damage_resistance, not armor, and is not subject to armor penetration.
balance: Fortitude, obtenebration 4, and blood armor can no longer stack.
/:cl:

