### PR TITLE
[READY FOR MERGE] Raises Vampire Final Death Threshold, AHeal Fixes Torpor, Brain Damage Changes

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -76,7 +76,7 @@
 #define HEALTH_THRESHOLD_DEAD -100
 
 #define HEALTH_THRESHOLD_VAMPIRE_TORPOR -100
-#define HEALTH_THRESHOLD_VAMPIRE_DEAD -200
+#define HEALTH_THRESHOLD_VAMPIRE_DEAD -700
 
 #define HEALTH_THRESHOLD_NEARDEATH -90 //Not used mechanically, but to determine if someone is so close to death they hear the other side
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -228,9 +228,9 @@
 	return ..()
 
 /obj/item/organ/brain/on_life()
-	if(!(iskindred(src.owner) || iscathayan(src.owner)))
+	if(!(iskindred(owner) || iscathayan(owner)))
 		if(damage >= BRAIN_DAMAGE_DEATH) //rip
-			to_chat(owner, "<span class='userdanger'>The last spark of life in your brain fizzles out...</span>")
+			to_chat(owner, span_userdanger("The last spark of life in your brain fizzles out...</span>"))
 			owner.death()
 
 /obj/item/organ/brain/check_damage_thresholds(mob/M)

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -228,9 +228,10 @@
 	return ..()
 
 /obj/item/organ/brain/on_life()
-	if(damage >= BRAIN_DAMAGE_DEATH) //rip
-		to_chat(owner, "<span class='userdanger'>The last spark of life in your brain fizzles out...</span>")
-		owner.death()
+	if(!(iskindred(src.owner) || iscathayan(src.owner)))
+		if(damage >= BRAIN_DAMAGE_DEATH) //rip
+			to_chat(owner, "<span class='userdanger'>The last spark of life in your brain fizzles out...</span>")
+			owner.death()
 
 /obj/item/organ/brain/check_damage_thresholds(mob/M)
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -977,6 +977,8 @@
 	if(admin_revive)
 		suiciding = FALSE
 		regenerate_limbs()
+		if(HAS_TRAIT(src, TRAIT_TORPOR))
+			cure_torpor()
 		regenerate_organs()
 		set_handcuffed(null)
 		for(var/obj/item/restraints/R in contents) //actually remove cuffs from inventory

--- a/code/modules/vtmb/kuei_jin.dm
+++ b/code/modules/vtmb/kuei_jin.dm
@@ -537,6 +537,7 @@
 	var/obj/item/organ/brain/brain = kueijin.getorganslot(ORGAN_SLOT_BRAIN)
 	if(brain)
 		brain.applyOrganDamage(-100)
+		brain.cure_all_traumas(TRAUMA_RESILIENCE_WOUND)
 
 	var/heal_level = min(kueijin.mind.dharma.level, 4)
 	kueijin.heal_ordered_damage(20 * heal_level, list(OXY, STAMINA, BRUTE, TOX))
@@ -596,6 +597,7 @@
 	var/obj/item/organ/brain/brain = kueijin.getorganslot(ORGAN_SLOT_BRAIN)
 	if(brain)
 		brain.applyOrganDamage(-100)
+		brain.cure_all_traumas(TRAUMA_RESILIENCE_WOUND)
 
 	var/heal_level = min(kueijin.mind.dharma.level, 4)
 	kueijin.heal_ordered_damage(10 * heal_level, list(OXY, STAMINA, BRUTE, TOX))

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -348,6 +348,7 @@
 	. = ..()
 	if(allowed_to_proceed)
 		var/mob/living/carbon/C = owner
+		var/obj/item/organ/brain/brain = C.getorganslot(ORGAN_SLOT_BRAIN)
 		if(C.stat != DEAD)
 			SEND_SOUND(owner, sound('code/modules/wod13/sounds/rage_heal.ogg', 0, 0, 75))
 			C.adjustBruteLoss(-40*C.auspice.level, TRUE)
@@ -374,6 +375,9 @@
 				if(length(BD.all_wounds))
 					var/datum/wound/W = pick(BD.all_wounds)
 					W.remove_wound()
+			if (brain)
+				brain.applyOrganDamage(-30*C.auspice.level)
+				brain.cure_all_traumas(TRAUMA_RESILIENCE_WOUND)
 
 /datum/action/change_apparel
 	name = "Change Apparel"

--- a/code/modules/wod13/datums/powers/discipline/bloodheal.dm
+++ b/code/modules/wod13/datums/powers/discipline/bloodheal.dm
@@ -54,19 +54,19 @@
 	//brain damage and traumas healing
 	var/obj/item/organ/brain/brain = owner.getorganslot(ORGAN_SLOT_BRAIN)
 	if (brain)
-		brain.applyOrganDamage(-HEAL_BASHING_LETHAL * vitae_cost)
-
-		for (var/i in 1 to min(vitae_cost, length(brain.get_traumas_type())))
+		brain.applyOrganDamage(-HEAL_BASHING_LETHAL * (vitae_cost*5))
+		brain.cure_all_traumas(TRAUMA_RESILIENCE_WOUND)
+		/*for (var/i in 1 to min(vitae_cost*10, length(brain.get_traumas_type())))
 			var/datum/brain_trauma/healing_trauma = pick(brain.get_traumas_type())
-			brain.cure_trauma_type(healing_trauma, resilience = TRAUMA_RESILIENCE_WOUND)
+			brain.cure_trauma_type(healing_trauma, resilience = TRAUMA_RESILIENCE_WOUND)*/
 
 	//miscellaneous organ damage healing
 	var/obj/item/organ/eyes/eyes = owner.getorganslot(ORGAN_SLOT_EYES)
 	if (eyes)
 		eyes.applyOrganDamage(-HEAL_BASHING_LETHAL * vitae_cost)
 
-		owner.adjust_blindness(-HEAL_AGGRAVATED * vitae_cost)
-		owner.adjust_blurriness(-HEAL_AGGRAVATED * vitae_cost)
+		owner.adjust_blindness(-HEAL_BASHING_LETHAL * vitae_cost)
+		owner.adjust_blurriness(-HEAL_BASHING_LETHAL * vitae_cost)
 
 	//healing too quickly attracts attention
 	if (violates_masquerade)

--- a/code/modules/wod13/datums/powers/discipline/bloodheal.dm
+++ b/code/modules/wod13/datums/powers/discipline/bloodheal.dm
@@ -56,9 +56,6 @@
 	if (brain)
 		brain.applyOrganDamage(-HEAL_BASHING_LETHAL * (vitae_cost*5))
 		brain.cure_all_traumas(TRAUMA_RESILIENCE_WOUND)
-		/*for (var/i in 1 to min(vitae_cost*10, length(brain.get_traumas_type())))
-			var/datum/brain_trauma/healing_trauma = pick(brain.get_traumas_type())
-			brain.cure_trauma_type(healing_trauma, resilience = TRAUMA_RESILIENCE_WOUND)*/
 
 	//miscellaneous organ damage healing
 	var/obj/item/organ/eyes/eyes = owner.getorganslot(ORGAN_SLOT_EYES)

--- a/code/modules/wod13/onyxcombat.dm
+++ b/code/modules/wod13/onyxcombat.dm
@@ -36,9 +36,6 @@
 
 	if(iskindred(src) || iscathayan(src))
 		can_be_embraced = FALSE
-		//var/obj/item/organ/brain/brain = getorganslot(ORGAN_SLOT_BRAIN) //NO REVIVAL EVER
-		//if (brain)
-		//	brain.organ_flags |= ORGAN_FAILING
 
 		if(in_frenzy)
 			exit_frenzymod()

--- a/code/modules/wod13/onyxcombat.dm
+++ b/code/modules/wod13/onyxcombat.dm
@@ -36,9 +36,9 @@
 
 	if(iskindred(src) || iscathayan(src))
 		can_be_embraced = FALSE
-		var/obj/item/organ/brain/brain = getorganslot(ORGAN_SLOT_BRAIN) //NO REVIVAL EVER
-		if (brain)
-			brain.organ_flags |= ORGAN_FAILING
+		//var/obj/item/organ/brain/brain = getorganslot(ORGAN_SLOT_BRAIN) //NO REVIVAL EVER
+		//if (brain)
+		//	brain.organ_flags |= ORGAN_FAILING
 
 		if(in_frenzy)
 			exit_frenzymod()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Shifts the Final Death threshold all the way to -700 to make sure vampire deaths are intentional and not caused by someone tapping you like one single time after you torpor.
- Adds the cure torpor proc to adminheal.
- Makes several changes to make healing brain traumas and damage easier for Kindred. Also makes eye damage easier to heal since before it was treating it as aggravated.
- Vampires can no longer die from brain damage.
- Werewolves and KJ now heal brain damage and cure brain traumas on rage heal/chi reanimation.

## Why It's Good For The Game
Prevents accidental deaths. Right now Vampires torpor at -100 health and FD at -200. This is a gap of 100 health between safely downing someone and roundremoving them.

> Won't this make killing vampires too difficult?

Decapitation can happen as soon as Torpor and still expedites them straight to final death. It should still be very easy to FD if you intend to, this only makes accidental deaths less likely.
Also -700 is deceptively low. If a vampire is on fire, expect them to meet this threshold regardless unless quenched.

## Testing Photographs and Procedure
![4ef5d87527067509cecff187bd407ae8](https://github.com/user-attachments/assets/87e70934-bacd-4beb-ae85-c6e6b031c2e6)



</details>

## Changelog

:cl:
balance: Bringing a vampire to Final Death is now more deliberate and less prone to accidents.
balance: Recovering from brain and eye trauma is now easier for Kindred and KJ.
fix: Adminheal removes Torpor.
add: Rage heal now heals brain damage.

/:cl:
