### PR TITLE
Increases Spraycan Capacity

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -663,6 +663,7 @@
 	is_capped = TRUE
 	self_contained = FALSE // Don't disappear when they're empty
 	can_change_colour = TRUE
+	charges = 70
 
 	reagent_contents = list(/datum/reagent/fuel = 1, /datum/reagent/consumable/ethanol = 1)
 


### PR DESCRIPTION
## About The Pull Request
* Increases spraycan capacity to 70 charges.

that's it really

![image](https://github.com/user-attachments/assets/26b49c83-829d-4a69-ad1c-907ce1b60cec)

## Why It's Good For The Game
30 charges lasts way too little for the average spraycan art.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
qol: Spraycan capacity increased.
/:cl: