### PR TITLE
Fixes Berettas Not Fitting in Holsters

### DIFF
--- a/code/game/objects/items/storage/holsters.dm
+++ b/code/game/objects/items/storage/holsters.dm
@@ -45,6 +45,8 @@
 		/obj/item/gun/ballistic/automatic/vampire/m1911,
 		/obj/item/gun/ballistic/automatic/vampire/glock19,
 		/obj/item/gun/ballistic/automatic/vampire/glock21,
+		/obj/item/gun/ballistic/automatic/vampire/beretta/toreador,
+		/obj/item/gun/ballistic/automatic/vampire/beretta,
 		/obj/item/ammo_box/vampire/c9mm/moonclip,
 		/obj/item/ammo_box/magazine/m44,
 		/obj/item/ammo_box/magazine/m50,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes an oversight which meant the 'Elite 92G' and the 'Silver Series' pistols couldn't fit in holsters.

## Why It's Good For The Game
Various pistols of the same size and calibre fit in these holsters, these two weren't included simply by oversight.

## Testing Photographs and Procedure
![image](https://github.com/user-attachments/assets/ba7ec674-fe16-4956-b148-757fb45ce15e)


