### PR TITLE
Moves Pale Aura to Ghouls only

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -140,7 +140,7 @@ Dancer
 	value = 3
 	gain_text = "<span class='warning'>You feel like you're standing in the shade.</span>"
 	lose_text = "<span class='notice'>You feel a subtle warmth.</span>"
-	allowed_species = list("Human", "Ghoul")
+	allowed_species = list("Ghoul")
 
 /datum/quirk/warm_aura
 	name = "Lively Aura"


### PR DESCRIPTION
## About The Pull Request

Fixes an oversight with Pale Aura only applying to Humans and Ghouls and not just Ghouls. Humans cant purchase this merit.

## Why It's Good For The Game

Lore accuracy,

## Testing Photographs and Procedure
It compiles

## Changelog

:cl:
tweak: fixes aura oversight
/:cl:
