### PR TITLE
removes fbi from the whitelist

### DIFF
--- a/code/modules/vtmb/jobs/fbi.dm
+++ b/code/modules/vtmb/jobs/fbi.dm
@@ -24,7 +24,6 @@
 	minimal_masquerade = 0
 	my_contact_is_important = FALSE
 	known_contacts = list("Police Chief")
-	whitelisted = TRUE
 
 /datum/outfit/job/fbi
 	name = "Federal Investigator"


### PR DESCRIPTION
## About The Pull Request

After talking to Yina about it, I made this PR. The priority of giving FBI content shifted to Garou so FBI are getting unwhitelisted for now.

## Why It's Good For The Game

Ditto.

## Testing Photographs and Procedure
Its a one line change.


## Changelog
:cl:
tweak: unwhitelists FBI after talking to Yina
/:cl:
