### PR TITLE
[REVIEW-READY] [TESTED] Fishing Less Profitable

### DIFF
--- a/code/modules/vtmb/gridventory.dm
+++ b/code/modules/vtmb/gridventory.dm
@@ -1092,7 +1092,7 @@ VENTORY!
 	grid_width = 3 GRID_BOXES
 	grid_height = 1 GRID_BOXES
 
-/obj/item/food/fish/tune
+/obj/item/food/fish/tuna
 	grid_width = 2 GRID_BOXES
 	grid_height = 1 GRID_BOXES
 

--- a/code/modules/wod13/fishing.dm
+++ b/code/modules/wod13/fishing.dm
@@ -11,22 +11,22 @@
 /obj/item/food/fish/shark
 	name = "leopard shark"
 	icon_state = "fish1"
-	cost = 400
+	cost = 40
 
 /obj/item/food/fish/tune
 	name = "tune"
 	icon_state = "fish2"
-	cost = 125
+	cost = 15
 
 /obj/item/food/fish/catfish
 	name = "catfish"
 	icon_state = "fish3"
-	cost = 50
+	cost = 5
 
 /obj/item/food/fish/crab
 	name = "crab"
 	icon_state = "fish4"
-	cost = 200
+	cost = 20
 
 /obj/item/fishing_rod
 	name = "fishing rod"

--- a/code/modules/wod13/fishing.dm
+++ b/code/modules/wod13/fishing.dm
@@ -13,8 +13,8 @@
 	icon_state = "fish1"
 	cost = 40
 
-/obj/item/food/fish/tune
-	name = "tune"
+/obj/item/food/fish/tuna
+	name = "tuna"
 	icon_state = "fish2"
 	cost = 15
 
@@ -73,7 +73,7 @@
 				var/diceroll = rand(1, 20)
 				var/IT
 				if(diceroll <= 5)
-					IT = /obj/item/food/fish/tune
+					IT = /obj/item/food/fish/tuna
 				else if(diceroll <= 10)
 					IT = /obj/item/food/fish/catfish
 				else if(diceroll <= 15)

--- a/code/modules/wod13/items/stores/guns.dm
+++ b/code/modules/wod13/items/stores/guns.dm
@@ -5,7 +5,7 @@
 		new /datum/data/mining_equipment("Elite 92G",	/obj/item/gun/ballistic/automatic/vampire/beretta,	500),
 		new /datum/data/mining_equipment("desert eagle",	/obj/item/gun/ballistic/automatic/vampire/deagle,	600),
 		new /datum/data/mining_equipment("hunting rifle",	/obj/item/gun/ballistic/automatic/vampire/huntrifle, 2000),
-		new /datum/data/mining_equipment("fishing rod",		/obj/item/fishing_rod,	200),
+		new /datum/data/mining_equipment("fishing rod",		/obj/item/fishing_rod,	50),
 		new	/datum/data/mining_equipment("5.45 ammo",	/obj/item/ammo_box/vampire/c545,	1000),
 		new	/datum/data/mining_equipment(".45 ACP ammo",	/obj/item/ammo_box/vampire/c45acp,	2100),
 		new /datum/data/mining_equipment("9mm ammo",	/obj/item/ammo_box/vampire/c9mm,	600),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Renames "tune" to "tuna"
Cuts the price of all fish by a tenfold, reduces fishing rod price in the store. New numbers as follows:
Leopard shark - 40
Tuna - 15
Catfish - 5
Crab - 20
Fishing rod - 50

## Why It's Good For The Game

Currently, fishing is arguably the BEST way to farm money roundstart - trumped only slightly by meth in terms of a faster immediate profit. It is a no-resource, zero-commitment AFK farm that can be done with an autoclicker, scales with the amount of people participating, cannot be traced, and does not breed any conflict of interest in the slightest - with minimal social interaction involved.

On average, you'll be getting ~194 per 15 seconds a fishing process, with frame-perfect autoclicking this scales up to a hefty 776 per minute. It'll take you 11-12 minutes to afford a longsword, an assault rifle with a spare mag, and a box of incendiary ammo.

This still leaves fishing as a piece of flavor you can pursue for roleplay purposes (or still money, if you're a masochist), but largely removes fishing from the economy in favour of more conflict-stirring endeavors such as contesting the limited amount of meth labs on the map, making use of the Anarch weed farm, butchering NPCs, heisting/loaning from the Giovanni/Bianchi bank, mugging other players, or breaking into faction armories.
I'm giving my thoughts on a few potential questions to avoid spamming up comments too much.

<details>
<summary>How is fishing different from all other money-making?</summary>
Unlike drugs, fishing does not have you contesting pre-mapped drug spots or gathering prior resources. Unlike organ trade, you do not run the risk of upsetting the Camarilla for hurting the herd, or the much more interested Assamites for the same reason. Unlike interacting with the Bank, or any other player business, you do not need to haggle or butt heads with players that could also be away, or not present in the round. Player-given employ in general falls very flat, and only pays in roleplay interaction. You can fish in an infinite, untraceable, very much antisocial and round-unfriendly manner with a rod bought with roundstart money and - if the supply warehouse is empty to be broken into - not even have to interact with a single player along the way.
</details>

<details>
<summary>"It's not so bad."</summary>
It is. Look to either the docks/beach area or to the southern tunnel-adjacent fishing cliff, and count how many people are there at the start of a mid/highpop round. Most of the dealership's business comes from this roundstart rush, and while this will reduce the amount of traffic it gets - that's an issue of Supply's greater design. Currently, it exists as a way to support moneyhoarding powergamers, with how most factions and even Kindred Havens have solid roundstart weaponry available.
The fishing moneyfarm being "hidden in plain sight" only serves to increase the immense powergap between less experienced players and otherwise, as well as decrease the power of major factions by having their roundstart armories fall back behind hand-picked kits.
</details>

<details>
<summary>How will this change the round flow?</summary>
This will effectively force people to interact with others more - choose between either contesting the limited drug farm spots on the map, to piss antag-hunting players off, or to ask other factions for employ and sponsoring. This won't eliminate money farmers by a long shot, but this *will* make San Francisco look less like swordpunk with a dozen mercenaries popping up in full load after the 20 minute mark. This will also, as mentioned, serve as an indirect powerbuff to factions by making  large amounts of money more "exclusive".
</details>

<details>
<summary>Why would I fish now?</summary>
For fun and flavor, you Pentex-partnered monster.  San Francisco's fish population should be about extinct by now. Think of the... Leopard sharks?..
</details>

<details>
<summary>What about the poor widdle independents? What if I don't want to take Humanity hits for drug and organ trade, and the Giovanni don't like me enough for a loan?</summary>
**GET A JOB!!**
</details>


## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

<img width="295" alt="fishing1" src="https://github.com/user-attachments/assets/b2bedd86-8045-447c-8700-19dc57d1f34e" />
<img width="922" alt="fishing2" src="https://github.com/user-attachments/assets/adb47315-9ace-4a05-8f87-23f4b92d0286" />


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Nerfed fish sellprices by x10, reduced fishing rod price
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
