### PR TITLE
Tzimisce "Four arms" vissi upgrade no longer delimbs you of an extra arm when unupgraded.

### DIFF
--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -457,7 +457,7 @@
 /mob/living/carbon/human/change_number_of_hands(amt)
 	var/old_limbs = held_items.len
 	if(amt < old_limbs)
-		for(var/i in hand_bodyparts.len to amt step -1)
+		for(var/i in hand_bodyparts.len to amt)
 			var/obj/item/bodypart/BP = hand_bodyparts[i]
 			BP.dismember()
 			hand_bodyparts[i] = null

--- a/code/modules/wod13/datums/powers/discipline/vicissitude.dm
+++ b/code/modules/wod13/datums/powers/discipline/vicissitude.dm
@@ -442,6 +442,7 @@
 			user.remove_movespeed_modifier(/datum/movespeed_modifier/centipede)
 		if ("Second pair of arms")
 			var/limbs = user.held_items.len
+			user.active_hand_index = 1
 			user.change_number_of_hands(limbs - 2)
 			user.remove_overlay(PROTEAN_LAYER)
 			QDEL_NULL(upgrade_overlay)


### PR DESCRIPTION
## About The Pull Request
The Vissicitude "4-arms" upgrade would delimb an arm too much when unupgraded, it would also spew 3 arms from your body, despite requiring no actual arm to upgrade. I believe you could also runtime by having the 3rd hand selected and swapping hand.

## Why It's Good For The Game
Bug fix! No more runtime! No more infinite flesh generation!
Fixes #68 

## Testing Photographs and Procedure
<details>




<summary>Video proof</summary>



https://github.com/user-attachments/assets/03011642-6e79-46e8-a5bb-6dccd4994149



</details>





:cl: Somniworld

fix: unupgrading Vissicitude's "2nd pair of arms" will no longer delimb one of your original limbs, you will also no longer take damage from doing so.

/:cl:

