### PR TITLE
The Woof Among Us (some garou tweaks)

### DIFF
--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -14,6 +14,7 @@
 //	var/move_delay_add = -1.5 // movement delay to add    also didn't work
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	armour_penetration = 35
 	health = 150
 	maxHealth = 150
 	werewolf_armor = 10

--- a/code/modules/mob/living/carbon/werewolf/lupus.dm
+++ b/code/modules/mob/living/carbon/werewolf/lupus.dm
@@ -12,8 +12,8 @@
 //	dextrous = FALSE
 //	speed = -1.5     doesn't work on carbons
 //	var/move_delay_add = -1.5 // movement delay to add    also didn't work
-	melee_damage_lower = 15
-	melee_damage_upper = 35
+	melee_damage_lower = 30
+	melee_damage_upper = 30
 	health = 150
 	maxHealth = 150
 	werewolf_armor = 10

--- a/code/modules/mob/living/carbon/werewolf/werewolf.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf.dm
@@ -170,7 +170,7 @@
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	limb_destroyer = 1
 	hud_type = /datum/hud/werewolf
-	melee_damage_lower = 35
+	melee_damage_lower = 65
 	melee_damage_upper = 65
 	health = 250
 	maxHealth = 250

--- a/code/modules/mob/living/carbon/werewolf/werewolf_defense.dm
+++ b/code/modules/mob/living/carbon/werewolf/werewolf_defense.dm
@@ -79,11 +79,6 @@
 					visible_message("<span class='danger'>[M] punches [src]!</span>", \
 									"<span class='userdanger'>[M] punches you!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, M)
 					to_chat(M, "<span class='danger'>You punch [src]!</span>")
-					if ((stat != DEAD) && (prob(5)))//Regular humans have a very small chance of knocking an alien down.
-						Unconscious(3 SECONDS)
-						visible_message("<span class='danger'>[M] knocks [src] down!</span>", \
-										"<span class='userdanger'>[M] knocks you down!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", null, M)
-						to_chat(M, "<span class='danger'>You knock [src] down!</span>")
 					var/obj/item/bodypart/affecting = get_bodypart(ran_zone(M.zone_selected))
 					apply_damage(damage, BRUTE, affecting)
 					log_combat(M, src, "attacked")
@@ -95,25 +90,17 @@
 
 			if ("disarm")
 				if (body_position == STANDING_UP)
-					if (prob(5))
-						Unconscious(3 SECONDS)
+					if (prob(50))
+						dropItemToGround(get_active_held_item())
 						playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
-						log_combat(M, src, "pushed")
-						visible_message("<span class='danger'>[M] pushes [src] down!</span>", \
-										"<span class='userdanger'>[M] pushes you down!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", null, M)
-						to_chat(M, "<span class='danger'>You push [src] down!</span>")
+						visible_message("<span class='danger'>[M] disarms [src]!</span>", \
+										"<span class='userdanger'>[M] disarms you!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, M)
+						to_chat(M, "<span class='danger'>You disarm [src]!</span>")
 					else
-						if (prob(50))
-							dropItemToGround(get_active_held_item())
-							playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
-							visible_message("<span class='danger'>[M] disarms [src]!</span>", \
-											"<span class='userdanger'>[M] disarms you!</span>", "<span class='hear'>You hear aggressive shuffling!</span>", COMBAT_MESSAGE_RANGE, M)
-							to_chat(M, "<span class='danger'>You disarm [src]!</span>")
-						else
-							playsound(loc, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
-							visible_message("<span class='danger'>[M] fails to disarm [src]!</span>",\
-											"<span class='danger'>[M] fails to disarm you!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, M)
-							to_chat(M, "<span class='warning'>You fail to disarm [src]!</span>")
+						playsound(loc, 'sound/weapons/punchmiss.ogg', 25, TRUE, -1)
+						visible_message("<span class='danger'>[M] fails to disarm [src]!</span>",\
+										"<span class='danger'>[M] fails to disarm you!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, M)
+						to_chat(M, "<span class='warning'>You fail to disarm [src]!</span>")
 
 
 

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -458,21 +458,24 @@
 	H.regenerate_icons()
 	H.update_transform()
 	animate(H, transform = null, color = "#FFFFFF", time = 1)
-	H.remove_movespeed_modifier(/datum/movespeed_modifier/crinosform)
+	H.remove_movespeed_modifier(/datum/movespeed_modifier/hispoform)
 	H.add_movespeed_modifier(/datum/movespeed_modifier/lupusform)
 
 /datum/action/gift/hispo/proc/trans_hispo(mob/living/carbon/werewolf/lupus/H)
 	H.icon = 'code/modules/wod13/hispo.dmi'
 	H.pixel_w = -16
 	H.pixel_z = -16
-	H.melee_damage_lower = 35
-	H.melee_damage_upper = 55
+	H.melee_damage_lower = 45
+	H.melee_damage_upper = 45
 	H.hispo = TRUE
 	H.regenerate_icons()
 	H.update_transform()
 	animate(H, transform = null, color = "#FFFFFF", time = 1)
 	H.remove_movespeed_modifier(/datum/movespeed_modifier/lupusform)
-	H.add_movespeed_modifier(/datum/movespeed_modifier/crinosform)
+	H.add_movespeed_modifier(/datum/movespeed_modifier/hispoform)
+
+/datum/movespeed_modifier/hispoform
+	multiplicative_slowdown = -0.5
 
 
 /datum/action/gift/glabro

--- a/code/modules/vtmb/werewolf/gifts.dm
+++ b/code/modules/vtmb/werewolf/gifts.dm
@@ -454,6 +454,7 @@
 	H.pixel_z = 0
 	H.melee_damage_lower = initial(H.melee_damage_lower)
 	H.melee_damage_upper = initial(H.melee_damage_upper)
+	H.armour_penetration = initial(H.armour_penetration)
 	H.hispo = FALSE
 	H.regenerate_icons()
 	H.update_transform()
@@ -467,6 +468,7 @@
 	H.pixel_z = -16
 	H.melee_damage_lower = 45
 	H.melee_damage_upper = 45
+	H.armour_penetration = 50
 	H.hispo = TRUE
 	H.regenerate_icons()
 	H.update_transform()


### PR DESCRIPTION
## About The Pull Request

Makes garou damage consistent. No more RNG 35-65 dmg strikes on crinos. Every strike is 65 dmg now. The same treatment has been given to hispo and lupus, which are closer to their average damage.

Armor penetration for wolf and hispo are no longer 100. Wolves have knife level penetration, hispo is 50 ap.

Makes hispo faster. For some reason, it used crinos speed. Now it has it's own speed modifier at -0.5 (might reduce to -0.4 we'll see if I feel quirky).

Removes the code that makes it so you can one punch knockout a garou. It was peak but nah.

## Why It's Good For The Game

Because I said I'd do this a while ago. I'm also hoping that my melee PR gets full merged so this should really go with it since otherwise garou are gonna get jacked up.

I think it's wack that the "ultimate werewolf form" had such inconsistent damage. You'd think you're getting near potence levels with this stuff. Now it'll be a little more jacked, especially when you start adding on your gifts.

I'm coping I just don't think dogs should be able to completely bite through EOD suits. Sue me, go crinos and rip him in half if you need that much anti-armor it's not like he can outrun you. 

Hispo seems like the middle ground between lupus and crinos, the "chase predator" so it makes sense it should be faster. Have fun in the woods folks.

Removing the punch KO code is bad for the game I'm sorry. I want celerity super speed punches back so I can stunlock garou please god I'll sacrifice my firstborn just give me the meme stun punches I'll do anything-

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>

Wolf AP reduction
![image](https://github.com/user-attachments/assets/1d30be58-ee9e-4631-8985-0c98cbef8656)
Crinos damage 
![image](https://github.com/user-attachments/assets/b4756413-f406-4893-9112-6d46ad7ff888)

Hispo moving faster
https://github.com/user-attachments/assets/eb8b6f99-5dc5-43b6-98fa-d0220374c885

Garou not being knocked down by rapid punching.
https://github.com/user-attachments/assets/415aff47-4cd1-41fc-8e94-40752719d03e
</details>

## Changelog

:cl:
balance: Hispo form moves faster.
balance: Makes garou forms do consistent damage. This makes them stronger in melee.
balance: Reduces AP on hispo and lupus to more reasonable levels.
fix: Prevents crinos from being one punch KO'd by unarmed attacks.
/:cl:


