### PR TITLE
Punch Damage for Homid

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -10,9 +10,6 @@
 	liked_food = JUNKFOOD | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 1
-	punchdamagelow = 10
-	punchdamagehigh = 20
-	dust_anim = "dust-h"
 	selectable = TRUE
 
 /datum/action/humaninfo

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -10,6 +10,9 @@
 	liked_food = JUNKFOOD | FRIED
 	changesource_flags = MIRROR_BADMIN | WABBAJACK | MIRROR_MAGIC | MIRROR_PRIDE | ERT_SPAWN | RACE_SWAP | SLIME_EXTRACT
 	payday_modifier = 1
+	punchdamagelow = 10
+	punchdamagehigh = 20
+	dust_anim = "dust-h"
 	selectable = TRUE
 
 /datum/action/humaninfo

--- a/code/modules/vtmb/werewolf_species.dm
+++ b/code/modules/vtmb/werewolf_species.dm
@@ -12,6 +12,8 @@
 	heatmod = 1
 	burnmod = 1
 	dust_anim = "dust-h"
+	punchdamagelow = 10
+	punchdamagehigh = 20
 	whitelisted = FALSE
 	selectable = TRUE
 	species_language_holder = /datum/language_holder/werewolf


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves Garou Homid punch damage upper-lower from their default of 1-10 to 10-20, on level with all other supernatural splats.

## Why It's Good For The Game

Consistency. Even Ghouls have 10-20 punch damage, so it's weird that never got packaged in for Garou.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/32f2b5d7-6ffa-413e-b599-c990049d3ccf)
![image](https://github.com/user-attachments/assets/4614bf3c-7e6d-4505-8dbb-9429a7bc0151)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Garou Homid punch damage is now 10-20, on level with other splats.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
