### PR TITLE
Gives the Baron the Punk Jacket

### DIFF
--- a/code/modules/vtmb/jobs/anarchs/baron.dm
+++ b/code/modules/vtmb/jobs/anarchs/baron.dm
@@ -44,7 +44,7 @@
 	id = /obj/item/card/id/baron
 	glasses = /obj/item/clothing/glasses/vampire/sun
 	uniform = /obj/item/clothing/under/vampire/bar
-	suit = /obj/item/clothing/suit/vampire/jacket/better
+	suit = /obj/item/clothing/suit/vampire/jacket/punk
 	shoes = /obj/item/clothing/shoes/vampire
 	gloves = /obj/item/clothing/gloves/vampire/work
 	l_pocket = /obj/item/vamp/phone/barkeeper

--- a/code/modules/vtmb/jobs/primogen.dm
+++ b/code/modules/vtmb/jobs/primogen.dm
@@ -228,7 +228,7 @@
 
 	id = /obj/item/card/id/primogen
 	glasses = /obj/item/clothing/glasses/vampire/yellow
-	uniform = /obj/item/clothing/under/vampire/bandit
+	uniform = /obj/item/clothing/under/vampire/turtleneck_navy
 	suit = /obj/item/clothing/suit/vampire/vest
 	shoes = /obj/item/clothing/shoes/vampire/jackboots
 	l_pocket = /obj/item/vamp/phone/banu

--- a/code/modules/vtmb/jobs/primogen.dm
+++ b/code/modules/vtmb/jobs/primogen.dm
@@ -229,7 +229,7 @@
 	id = /obj/item/card/id/primogen
 	glasses = /obj/item/clothing/glasses/vampire/yellow
 	uniform = /obj/item/clothing/under/vampire/bandit
-	suit = /obj/item/clothing/suit/vampire/jacket/punk
+	suit = /obj/item/clothing/suit/vampire/vest
 	shoes = /obj/item/clothing/shoes/vampire/jackboots
 	l_pocket = /obj/item/vamp/phone/banu
 	r_pocket = /obj/item/cockclock


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives the Baron the 'Punk Jacket' which previously belonged to the Brujah Primogen and then the... Banu Primogen? For some reason?

This also replaces the jacket with an armoured vest for the Banu Haqim Primogen.

## Why It's Good For The Game
It was always frankly silly that the Banu Haqim received this spray painted, anarchy themed jacket and not... the Anarchs. It was a pretty lame thing to see thematically. I've maintained the regular Baron armoured jacket spawn in their office so that Barons will have a choice whether to wear the current red jacket or the new punk jacket.

The Banu Primogen will receive an armoured vest (and a more respectable turtleneck, as opposed to default wifebeater) to fit with their flavour of being a cafe owning police consultant...

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![baron1](https://github.com/user-attachments/assets/49c38240-f32b-4d09-9187-ca860b4e11b4)
![baron2](https://github.com/user-attachments/assets/dbd5004e-da93-40d8-ad39-cc94d2278466)
The new look Baron

![banu1](https://github.com/user-attachments/assets/69a22268-7023-45d2-b218-10f8f10e2d98)
![banu2](https://github.com/user-attachments/assets/8a42fdb5-7c5e-40b8-a45c-fb8acb9059c5)
And the same for the Banu Primogen


</details>

