### PR TITLE
Endron phones start with numbers

### DIFF
--- a/code/_globalvars/phonesnumbers.dm
+++ b/code/_globalvars/phonesnumbers.dm
@@ -14,6 +14,10 @@ GLOBAL_VAR_INIT(lasombranumber, "")
 GLOBAL_VAR_INIT(tremerenumber, "")
 GLOBAL_VAR_INIT(voivodenumber, "")
 GLOBAL_VAR_INIT(harpynumber, "")
+GLOBAL_VAR_INIT(endronleadnumber, "")
+GLOBAL_VAR_INIT(endronexecnumber, "")
+GLOBAL_VAR_INIT(endronaffairsnumber, "")
+GLOBAL_VAR_INIT(endronsecchiefnumber, "")
 
 // Important Names for contacts
 
@@ -31,3 +35,7 @@ GLOBAL_VAR_INIT(lasombraname, "")
 GLOBAL_VAR_INIT(tremerename, "")
 GLOBAL_VAR_INIT(voivodename, "")
 GLOBAL_VAR_INIT(harpyname, "")
+GLOBAL_VAR_INIT(endronleadname, "")
+GLOBAL_VAR_INIT(endronexecname, "")
+GLOBAL_VAR_INIT(endronaffairsname, "")
+GLOBAL_VAR_INIT(endronsecchiefname, "")

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -645,6 +645,8 @@
 	contacts += L
 	var/datum/phonecontact/voivode/Z = new()
 	contacts += Z
+	var/datum/phonecontact/endronlead/ENDRONLEAD = new()
+	contacts += ENDRONLEAD
 
 /obj/item/vamp/phone/sheriff
 	exchange_num = 267
@@ -993,3 +995,60 @@
 	contacts += Z
 	var/datum/phonecontact/ventrue/V = new()
 	contacts += V
+
+/obj/item/vamp/phone/endronlead/Initialize()
+	..()
+	GLOB.endronleadnumber = number
+	GLOB.endronleadname = owner
+	var/datum/phonecontact/endronexec/ENDRONEXEC = new()
+	contacts += ENDRONEXEC
+	var/datum/phonecontact/endronaffairs/ENDRONAFFAIRS = new()
+	contacts += ENDRONAFFAIRS
+	var/datum/phonecontact/endronsecchief/ENDRONSECCHIEF = new()
+	contacts += ENDRONSECCHIEF
+	var/datum/phonecontact/prince/PRINCE = new()
+	contacts += PRINCE
+
+/obj/item/vamp/phone/endronexec/Initialize()
+	..()
+	GLOB.endronexecnumber = number
+	GLOB.endronexecname = owner
+	var/datum/phonecontact/endronlead/ENDRONLEAD = new()
+	contacts += ENDRONLEAD
+	var/datum/phonecontact/endronaffairs/ENDRONAFFAIRS = new()
+	contacts += ENDRONAFFAIRS
+	var/datum/phonecontact/endronsecchief/ENDRONSECCHIEF = new()
+	contacts += ENDRONSECCHIEF
+
+/obj/item/vamp/phone/endronaffairs/Initialize()
+	..()
+	GLOB.endronaffairsnumber = number
+	GLOB.endronaffairsname = owner
+	var/datum/phonecontact/endronlead/ENDRONLEAD = new()
+	contacts += ENDRONLEAD
+	var/datum/phonecontact/endronexec/ENDRONEXEC = new()
+	contacts += ENDRONEXEC
+	var/datum/phonecontact/endronsecchief/ENDRONSECCHIEF = new()
+	contacts += ENDRONSECCHIEF
+
+/obj/item/vamp/phone/endronsecchief/Initialize()
+	..()
+	GLOB.endronsecchiefnumber = number
+	GLOB.endronsecchiefname = owner
+	var/datum/phonecontact/endronlead/ENDRONLEAD = new()
+	contacts += ENDRONLEAD
+	var/datum/phonecontact/endronexec/ENDRONEXEC = new()
+	contacts += ENDRONEXEC
+	var/datum/phonecontact/endronaffairs/ENDRONAFFAIRS = new()
+	contacts += ENDRONAFFAIRS
+
+/obj/item/vamp/phone/endron/Initialize()
+	..()
+	var/datum/phonecontact/endronlead/ENDRONLEAD = new()
+	contacts += ENDRONLEAD
+	var/datum/phonecontact/endronexec/ENDRONEXEC = new()
+	contacts += ENDRONEXEC
+	var/datum/phonecontact/endronaffairs/ENDRONAFFAIRS = new()
+	contacts += ENDRONAFFAIRS
+	var/datum/phonecontact/endronsecchief/ENDRONSECCHIEF = new()
+	contacts += ENDRONSECCHIEF

--- a/code/modules/vtmb/electronics/phones/phone.dm
+++ b/code/modules/vtmb/electronics/phones/phone.dm
@@ -645,8 +645,6 @@
 	contacts += L
 	var/datum/phonecontact/voivode/Z = new()
 	contacts += Z
-	var/datum/phonecontact/endronlead/ENDRONLEAD = new()
-	contacts += ENDRONLEAD
 
 /obj/item/vamp/phone/sheriff
 	exchange_num = 267
@@ -1006,8 +1004,6 @@
 	contacts += ENDRONAFFAIRS
 	var/datum/phonecontact/endronsecchief/ENDRONSECCHIEF = new()
 	contacts += ENDRONSECCHIEF
-	var/datum/phonecontact/prince/PRINCE = new()
-	contacts += PRINCE
 
 /obj/item/vamp/phone/endronexec/Initialize()
 	..()

--- a/code/modules/vtmb/electronics/phones/phone_contact.dm
+++ b/code/modules/vtmb/electronics/phones/phone_contact.dm
@@ -153,3 +153,43 @@
 		name = GLOB.harpyname + " - " + name
 		return TRUE
 	..()
+
+/datum/phonecontact/endronlead
+	name = "Endron Branch Lead"
+
+/datum/phonecontact/endronlead/check_global_contacts()
+	if(number != GLOB.endronleadnumber && name_check != GLOB.endronleadname)
+		number = GLOB.endronleadnumber
+		name = GLOB.endronleadname + " - " + name
+		return TRUE
+	..()
+
+/datum/phonecontact/endronexec
+	name = "Endron Executive"
+
+/datum/phonecontact/endronexec/check_global_contacts()
+	if(number != GLOB.endronexecnumber && name_check != GLOB.endronexecname)
+		number = GLOB.endronexecnumber
+		name = GLOB.endronexecname + " - " + name
+		return TRUE
+	..()
+
+/datum/phonecontact/endronaffairs
+	name = "Internal Affairs"
+
+/datum/phonecontact/endronaffairs/check_global_contacts()
+	if(number != GLOB.endronaffairsnumber && name_check != GLOB.endronaffairsname)
+		number = GLOB.endronaffairsnumber
+		name = GLOB.endronaffairsname + " - " + name
+		return TRUE
+	..()
+
+/datum/phonecontact/endronsecchief
+	name = "Chief of Security"
+
+/datum/phonecontact/endronsecchief/check_global_contacts()
+	if(number != GLOB.endronsecchiefnumber && name_check != GLOB.endronsecchiefname)
+		number = GLOB.endronsecchiefnumber
+		name = GLOB.endronsecchiefname + " - " + name
+		return TRUE
+	..()

--- a/code/modules/vtmb/jobs/garou/poisonshore.dm
+++ b/code/modules/vtmb/jobs/garou/poisonshore.dm
@@ -45,7 +45,7 @@
 	uniform =  /obj/item/clothing/under/pentex/pentex_executive_suit
 	shoes = /obj/item/clothing/shoes/vampire/businessblack
 	suit = /obj/item/clothing/suit/pentex/pentex_labcoat_alt
-	l_pocket = /obj/item/vamp/phone
+	l_pocket = /obj/item/vamp/phone/endronlead
 	r_pocket = /obj/item/vamp/keys/pentex
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/vampire/deagle=1, /obj/item/phone_book=1, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/prince=1)
 
@@ -109,7 +109,7 @@
 	id = /obj/item/card/id/garou/spiral/executive
 	uniform =  /obj/item/clothing/under/pentex/pentex_executive_suit
 	shoes = /obj/item/clothing/shoes/vampire/businessblack
-	l_pocket = /obj/item/vamp/phone
+	l_pocket = /obj/item/vamp/phone/endronexec
 	r_pocket = /obj/item/vamp/keys/pentex
 	backpack_contents = list(/obj/item/phone_book=1, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/seneschal=1)
 
@@ -173,7 +173,7 @@
 	id = /obj/item/card/id/garou/spiral/affairs
 	uniform =  /obj/item/clothing/under/pentex/pentex_suit
 	shoes = /obj/item/clothing/shoes/vampire/businessblack
-	l_pocket = /obj/item/vamp/phone
+	l_pocket = /obj/item/vamp/phone/endronaffairs
 	r_pocket = /obj/item/vamp/keys/pentex
 	backpack_contents = list(/obj/item/phone_book=1, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/veil_contract, /obj/item/vamp/creditcard/rich=1)
 
@@ -242,7 +242,7 @@
 	head = /obj/item/clothing/head/pentex/pentex_beret
 	suit = /obj/item/clothing/suit/vampire/vest
 	glasses = /obj/item/clothing/glasses/vampire/sun
-	l_pocket = /obj/item/vamp/phone
+	l_pocket = /obj/item/vamp/phone/endronsecchief
 	r_pocket = /obj/item/vamp/keys/pentex
 	backpack_contents = list(/obj/item/gun/ballistic/automatic/vampire/deagle=1, /obj/item/phone_book=1, /obj/item/veil_contract, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard/rich=1)
 
@@ -301,7 +301,7 @@
 	shoes = /obj/item/clothing/shoes/vampire/jackboots
 	gloves = /obj/item/clothing/gloves/vampire/work
 	suit = /obj/item/clothing/suit/vampire/vest
-	l_pocket = /obj/item/vamp/phone
+	l_pocket = /obj/item/vamp/phone/endron
 	r_pocket = /obj/item/vamp/keys/pentex
 	backpack_contents = list(/obj/item/phone_book=1, /obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard=1)
 
@@ -360,7 +360,7 @@
 	gloves = /obj/item/clothing/gloves/vampire/work
 	shoes = /obj/item/clothing/shoes/vampire
 	r_pocket = /obj/item/vamp/keys/pentex
-	l_pocket = /obj/item/vamp/phone
+	l_pocket = /obj/item/vamp/phone/endron
 	backpack_contents = list(/obj/item/passport=1, /obj/item/cockclock=1, /obj/item/flashlight=1, /obj/item/vamp/creditcard=1)
 
 	backpack = /obj/item/storage/backpack


### PR DESCRIPTION
## About The Pull Request

Adds the phone numbers of important Endron roles to the phones of faction members, similar to how it works for the Camarila faction. ~~(Also shares the Prince's number with the Endron lead, and vice-versa)~~

## Why It's Good For The Game

- QoL so one does not have to hunt down everyone's number each round
- Makes it a little easier to stay connected in the 21th century. 

## Testing Photographs and Procedure

Spawned in with all the roles, called all the phones. (Do ignore the same name, I kept respawning with the same doggo)
<details>

<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/6840d6ac-5bf5-4dc2-ad46-6ea26fe4aa73)
![image](https://github.com/user-attachments/assets/20a4c3ba-b517-4640-badd-2e2b5b2ac505)
![image](https://github.com/user-attachments/assets/33480030-0332-49e3-a58b-9e3e589e841b)

</details>

## Changelog



:cl:
add: Endron phones start with numbers
/:cl:


