### PR TITLE
Warren and Nostown Remap!

### DIFF
--- a/_maps/map_files/Vampire/SanFrancisco.dmm
+++ b/_maps/map_files/Vampire/SanFrancisco.dmm
@@ -445,6 +445,16 @@
 /mob/living/simple_animal/pet/cat/vampire,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"agB" = (
+/obj/effect/decal/wallpaper/paper/low,
+/obj/effect/decal/wallpaper/paper/stripe/low,
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/closed/wall/vampwall/bar/low/window,
+/area/vtm/interior)
 "agH" = (
 /obj/effect/decal/trash,
 /turf/open/floor/plating/sidewalk/poor,
@@ -576,6 +586,10 @@
 /obj/structure/vampfence/corner,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf)
+"ain" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "aip" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -780,6 +794,16 @@
 /obj/structure/roadsign/crosswalk,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/financialdistrict)
+"akv" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "akw" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/pacificheights/forest)
@@ -937,7 +961,10 @@
 /turf/open/openspace,
 /area/vtm/interior/millennium_tower/f2)
 "aml" = (
-/obj/effect/decal/bordur,
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_y = 4
+	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/sewer/nosferatu_town)
 "amt" = (
@@ -1091,6 +1118,15 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"aoy" = (
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aoA" = (
 /obj/structure/flora/junglebush,
 /turf/open/floor/plating/vampgrass,
@@ -1177,7 +1213,6 @@
 "aqr" = (
 /obj/machinery/door/poddoor/shutters{
 	damage_deflection = 60;
-	id = 1;
 	max_integrity = 300;
 	name = "Parking Shutter"
 	},
@@ -1256,6 +1291,18 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/anarch)
+"arm" = (
+/obj/structure/bed/maint{
+	pixel_x = 14;
+	pixel_y = 8
+	},
+/obj/item/restraints/handcuffs/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aro" = (
 /obj/effect/decal/bordur{
 	dir = 6
@@ -1541,6 +1588,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"auN" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "auP" = (
 /obj/structure/curtain/cloth,
 /obj/structure/table,
@@ -1549,6 +1600,12 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/baali)
+"auQ" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "auT" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -1637,6 +1694,17 @@
 	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/clinic/haven)
+"awg" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/item/candle/infinite{
+	pixel_y = 18
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "awj" = (
 /mob/living/simple_animal/hostile/tanker/hostile,
 /turf/open/floor/plating/rough/cave,
@@ -1777,6 +1845,18 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/library)
+"axQ" = (
+/obj/effect/decal/bordur,
+/obj/item/candle/infinite{
+	pixel_y = -8
+	},
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "axY" = (
 /obj/structure/window/reinforced/indestructable{
 	alpha = 0;
@@ -1964,6 +2044,15 @@
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/millennium_tower)
+"azN" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4;
+	color = "#50C878"
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "azO" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -2007,6 +2096,13 @@
 "aAj" = (
 /turf/open/floor/plasteel/dark,
 /area/vtm/pacificheights/old)
+"aAm" = (
+/obj/structure/railing,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aAt" = (
 /obj/effect/decal/trash,
 /obj/effect/decal/cleanable/dirt/dust,
@@ -2017,6 +2113,14 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/northbeach)
+"aAw" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/junglebush,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "aAG" = (
 /obj/machinery/light{
 	dir = 8
@@ -2096,8 +2200,9 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/supply)
 "aBQ" = (
+/obj/effect/decal/wallpaper/paper/low,
 /turf/closed/wall/vampwall/junk,
-/area/space)
+/area/vtm/sewer/nosferatu_town)
 "aCi" = (
 /obj/structure/table,
 /obj/machinery/griddle,
@@ -2151,8 +2256,8 @@
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/staff)
 "aDb" = (
-/obj/effect/decal/wallpaper/gold,
-/turf/closed/wall/vampwall/junk/alt,
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "aDf" = (
 /obj/effect/decal/bordur{
@@ -2238,8 +2343,12 @@
 /turf/closed/wall/vampwall,
 /area/vtm/sewer/tzimisce_sanctum)
 "aEg" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating/parquetry/old,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/grate{
+	icon_state = "lattice_new_dirt"
+	},
 /area/vtm/sewer/nosferatu_town)
 "aEh" = (
 /obj/structure/chair/wood/wings,
@@ -2311,6 +2420,12 @@
 /obj/item/storage/crayons,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"aEL" = (
+/obj/structure/barrels{
+	icon_state = "barrels9"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "aEM" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/vampplating/mono,
@@ -2518,6 +2633,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/ventrue)
+"aHq" = (
+/obj/structure/dresser,
+/obj/item/camera,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aHy" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/green,
@@ -2680,6 +2802,20 @@
 "aJd" = (
 /turf/closed/wall/vampwall/metal,
 /area/vtm/interior/millennium_tower/f3)
+"aJe" = (
+/obj/structure/table/wood/bar,
+/obj/item/flashlight/lamp{
+	pixel_x = -9;
+	pixel_y = 11
+	},
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aJi" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/strip/toreador)
@@ -2697,6 +2833,16 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/carpet/black,
 /area/vtm/cabaret)
+"aJy" = (
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 10
+	},
+/obj/effect/decal/litter,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aJS" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -2753,11 +2899,12 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
 "aKy" = (
-/obj/structure/chair/plastic{
-	dir = 8;
-	pixel_y = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/plating/parquetry/old,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
 /area/vtm/sewer/nosferatu_town)
 "aKB" = (
 /obj/effect/turf_decal/siding/white{
@@ -2927,6 +3074,24 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"aMz" = (
+/obj/structure/table,
+/obj/effect/decal/rugs,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_off";
+	pixel_y = 13
+	},
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_analog";
+	pixel_y = 29
+	},
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aMB" = (
 /obj/machinery/light{
 	dir = 1
@@ -3007,6 +3172,12 @@
 /obj/vampire_computer,
 /turf/open/floor/plating/vampplating/stone,
 /area/vtm/interior/bianchiBank)
+"aNU" = (
+/obj/structure/chair/sofa/corp/left{
+	color = "#50C878"
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "aNX" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -3095,15 +3266,12 @@
 /turf/open/floor/plating/toilet,
 /area/vtm/anarch)
 "aOV" = (
-/obj/structure/railing{
-	dir = 9;
-	pixel_y = 8
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
 	},
-/obj/structure/railing{
-	dir = 8;
-	pixel_y = -6
-	},
-/turf/open/floor/plating/shit,
+/turf/closed/wall/vampwall/junk/alt/low/window,
 /area/vtm/sewer/nosferatu_town)
 "aOW" = (
 /turf/closed/wall/vampwall/market,
@@ -3157,14 +3325,11 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/millennium_tower/ventrue)
 "aQk" = (
-/obj/structure/vampdoor/reinf{
-	lock_id = "primNosferatu";
-	locked = 1;
-	lockpick_difficulty = 15;
-	name = "primogen hideout"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/obj/effect/decal/bordur,
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "aQs" = (
 /obj/effect/turf_decal/siding/white{
@@ -3198,6 +3363,11 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/laundromat)
+"aRd" = (
+/obj/effect/decal/trash,
+/obj/structure/disposalpipe/broken,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "aRf" = (
 /obj/structure/chair{
 	dir = 8
@@ -3488,10 +3658,8 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/northbeach)
 "aUm" = (
-/obj/structure/table,
-/obj/item/bailer,
-/obj/item/bong,
-/turf/open/floor/plating/rough,
+/obj/item/toy/beach_ball/holoball,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "aUn" = (
 /obj/structure/table/abductor{
@@ -3511,6 +3679,23 @@
 /obj/structure/vampdoor/setite/high_sec,
 /turf/open/floor/plating/church,
 /area/vtm/interior/setite/basement)
+"aUx" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/pallet,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aUz" = (
 /obj/structure/vampfence/rich{
 	dir = 4
@@ -3698,6 +3883,14 @@
 "aWz" = (
 /turf/closed/wall/vampwall/old,
 /area/vtm/graveyard/interior)
+"aWH" = (
+/obj/structure/bed,
+/obj/item/bedsheet/rd,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "aWU" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/item/clothing/suit/vampire/kasaya,
@@ -3922,6 +4115,15 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/bianchiBank)
+"bao" = (
+/obj/effect/decal/pallet{
+	layer = 2
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "baE" = (
 /turf/closed/wall/vampwall/bar/low,
 /area/vtm/sewer)
@@ -3929,6 +4131,13 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/baali)
+"baL" = (
+/obj/structure/coclock,
+/obj/machinery/photocopier,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
+	},
+/area/vtm/sewer/nosferatu_town)
 "baM" = (
 /obj/structure/chair{
 	dir = 4
@@ -4012,6 +4221,14 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/ghetto)
+"bbD" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "bbF" = (
 /obj/machinery/light/small/pink{
 	pixel_y = 32
@@ -4048,14 +4265,34 @@
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/tzimisce_manor)
 "bbU" = (
-/obj/structure/railing{
-	dir = 9;
-	pixel_y = 5
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	layer = 4.2;
+	pixel_y = 10
 	},
-/turf/open/floor/plating/shit,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
 /area/vtm/sewer/nosferatu_town)
 "bbW" = (
 /turf/closed/wall/vampwall/rich/old,
+/area/vtm/sewer)
+"bbZ" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampgrass,
+/area/vtm/sewer)
+"bci" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/item/vtm_artifact/rand,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer)
 "bco" = (
 /obj/structure/vampdoor/wood/giovanni/high_security,
@@ -4151,6 +4388,11 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"bdL" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcarpet,
+/area/vtm/interior)
 "bdO" = (
 /obj/structure/fluff/hedge,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -4222,6 +4464,14 @@
 /obj/structure/table,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower)
+"beV" = (
+/obj/effect/decal/trash,
+/obj/structure/coclock,
+/obj/structure/closet/cabinet,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "beW" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag,
@@ -4305,6 +4555,17 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f5)
+"bfV" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/flora/rock/jungle,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "bga" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/table,
@@ -4375,6 +4636,16 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower)
+"bgW" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "bgX" = (
 /obj/effect/decal/wallpaper/blue,
 /turf/closed/wall/vampwall/market,
@@ -4413,6 +4684,11 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/giovanni/outside)
+"bhv" = (
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/interior)
 "bhG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -4522,6 +4798,15 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
+"biS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "biT" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -4630,6 +4915,12 @@
 /obj/structure/vampdoor/camarilla,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower)
+"bkm" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "bkr" = (
 /obj/structure/chinesesign/alt{
 	dir = 4
@@ -4772,6 +5063,16 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/anarch/basement)
+"blX" = (
+/obj/structure/chair/plastic{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "bme" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -4895,11 +5196,11 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
 "bns" = (
-/obj/machinery/light/small{
-	pixel_y = 32
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
 	},
-/obj/machinery/griddle,
-/turf/open/floor/plating/rough,
+/obj/structure/chair/sofa/corner,
+/turf/open/floor/plating/vampcarpet,
 /area/vtm/interior)
 "bnt" = (
 /turf/open/floor/carpet,
@@ -5170,6 +5471,14 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/strip/toreador)
+"brf" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_y = 12
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/closet/crate/large,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "brk" = (
 /obj/structure/big_vamprocks,
 /obj/structure/vampstatue/cloaked,
@@ -5319,6 +5628,14 @@
 /obj/structure/fence,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"btc" = (
+/obj/structure/vampipe{
+	icon_state = "piping32"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "btl" = (
 /obj/structure/coclock/grandpa{
 	pixel_y = 12
@@ -5379,6 +5696,43 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
+"btZ" = (
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
+"bua" = (
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
+"buc" = (
+/obj/structure/table,
+/obj/item/weedpack{
+	desc = "Green and smelly... It's a special one, maybe costs hundreds of dollars...";
+	name = "Unique green package"
+	},
+/obj/item/weedpack{
+	desc = "Green and smelly... It's a special one, maybe costs hundreds of dollars...";
+	name = "Unique green package"
+	},
+/obj/item/weedpack{
+	desc = "Green and smelly... It's a special one, maybe costs hundreds of dollars...";
+	name = "Unique green package"
+	},
+/obj/item/vamp/keys/hack,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "bug" = (
 /obj/structure/lamppost/sidewalk/chinese{
 	dir = 8
@@ -5396,6 +5750,15 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f3)
+"buq" = (
+/obj/structure/chair/sofa{
+	dir = 4
+	},
+/obj/effect/decal/trash{
+	icon_state = "trash7"
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "buw" = (
 /obj/structure/table/wood,
 /obj/item/stack/dollar/fifty,
@@ -5493,6 +5856,16 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
+"bvC" = (
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/sidewalk/old,
+/area/vtm/sewer/nosferatu_town)
 "bvD" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -5536,6 +5909,11 @@
 /obj/item/toy/plush/awakenedplushie,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"bwr" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "bwu" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -5546,6 +5924,17 @@
 /obj/structure/roadsign/noparking,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/financialdistrict)
+"bwz" = (
+/obj/item/kirbyplants/fullysynthetic,
+/obj/structure/flora/rock/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/vampipe{
+	icon_state = "piping38"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "bwA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer/vampire,
@@ -5641,7 +6030,8 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/chantry)
 "byn" = (
-/turf/open/floor/plating/parquetry/old,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/sewer/nosferatu_town)
 "byp" = (
 /obj/structure/vampfence/rich{
@@ -5701,6 +6091,19 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/trujah)
+"byY" = (
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_nature";
+	layer = 4.2;
+	pixel_y = 29
+	},
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_analog";
+	pixel_y = 12
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "bzp" = (
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/trujah)
@@ -5769,6 +6172,10 @@
 /obj/structure/chair/sofa/left,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
+"bAk" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "bAl" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/structure/roadblock{
@@ -5820,6 +6227,13 @@
 "bAO" = (
 /turf/closed/wall/vampwall/rich/low/window,
 /area/vtm/interior/strip/toreador)
+"bAX" = (
+/obj/machinery/camera/directional/west,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "bAY" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -5830,12 +6244,7 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
 "bBa" = (
-/obj/structure/closet,
-/obj/item/vampire_flamethrower{
-	masquerade_violating = 0
-	},
-/obj/item/gas_can/full,
-/turf/open/floor/plating/parquetry/old,
+/turf/open/floor/plating/dirt,
 /area/vtm/sewer/nosferatu_town)
 "bBd" = (
 /obj/structure/vampfence/rich{
@@ -5899,13 +6308,12 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
 "bBA" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/structure/vampdoor/npc{
+/obj/structure/vampdoor/wood/apartment{
 	dir = 8
 	},
-/turf/open/floor/plating/rough/cave,
+/obj/effect/decal/rugs,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rough,
 /area/vtm/interior)
 "bBC" = (
 /obj/structure/rack,
@@ -6132,6 +6540,15 @@
 	},
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer)
+"bEz" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "bEC" = (
 /obj/structure/vampdoor/camarilla{
 	dir = 4;
@@ -6160,6 +6577,13 @@
 /obj/structure/trashbag,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch/basement)
+"bFg" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/structure/chair/pew/right,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "bFh" = (
 /obj/structure/vampdoor/camarilla{
 	lock_id = "milleniumCommon";
@@ -6302,8 +6726,11 @@
 /turf/open/floor/carpet/purple,
 /area/vtm/jazzclub)
 "bHG" = (
-/obj/structure/coclock,
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/table/wood/bar,
+/obj/item/flashlight/lamp/green,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
 /area/vtm/sewer/nosferatu_town)
 "bHI" = (
 /obj/structure/bed/maint,
@@ -6475,9 +6902,9 @@
 /area/vtm/interior)
 "bKy" = (
 /obj/effect/decal/bordur,
-/obj/structure/vampdoor/simple,
-/turf/open/floor/plating/sidewalk/poor,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/decal/wallpaper/paper/green/low,
+/turf/closed/wall/vampwall/junk,
+/area/vtm/interior)
 "bKB" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/vampplating,
@@ -6549,6 +6976,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/strip/toreador)
+"bLu" = (
+/obj/structure/vampdoor/wood/old{
+	dir = 4
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "bLv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -6559,8 +6994,16 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch)
 "bLN" = (
-/obj/structure/pole,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "bLP" = (
 /obj/effect/decal/litter,
@@ -6577,17 +7020,11 @@
 /turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/jazzclub)
 "bLZ" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
+/obj/structure/chair/plastic{
+	dir = 8
 	},
 /turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "bMd" = (
 /obj/structure/table,
 /obj/item/vamp/keys/brujah,
@@ -6606,6 +7043,19 @@
 /obj/item/clothing/suit/vampire/imam,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/banu/haven)
+"bMu" = (
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
+"bMw" = (
+/obj/structure/table,
+/obj/item/drinkable_bloodpack/elite,
+/obj/item/drinkable_bloodpack/elite,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "bMx" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -6713,6 +7163,13 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto/old)
+"bNH" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "bNR" = (
 /obj/effect/decal/cardboard,
 /obj/structure/railing{
@@ -6759,11 +7216,13 @@
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower/f2)
 "bOo" = (
-/obj/structure/chair/plastic{
+/obj/structure/barricade/wooden/crude,
+/obj/structure/vampfence/rich{
 	dir = 4;
-	pixel_y = 7
+	layer = 5;
+	name = "window bars"
 	},
-/turf/open/floor/plating/parquetry/old,
+/turf/closed/wall/vampwall/rustbad,
 /area/vtm/sewer/nosferatu_town)
 "bOt" = (
 /obj/structure/chair/wood{
@@ -6782,6 +7241,15 @@
 /obj/structure/fluff/paper/stack,
 /turf/open/floor/plating,
 /area/vtm/clinic/haven)
+"bOG" = (
+/obj/structure/chair/sofa/corp{
+	dir = 4;
+	color = "#50C878"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "bOJ" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/vampdirt,
@@ -7193,6 +7661,13 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
+"bVc" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	icon_state = "lavendergrass_3"
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "bVk" = (
 /obj/machinery/light{
 	dir = 4;
@@ -7338,6 +7813,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/laundromat)
+"bWM" = (
+/obj/machinery/light/small/pink{
+	dir = 1;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "bXb" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -7362,6 +7844,14 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/tzimisce_manor)
+"bXn" = (
+/obj/matrix,
+/turf/open/space/basic,
+/area/vtm/sewer/nosferatu_town)
+"bXs" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "bXA" = (
 /obj/structure/table/reinforced,
 /obj/item/melee/vampirearms/knife,
@@ -7450,11 +7940,8 @@
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/giovanni)
 "bYE" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	dir = 4
-	},
-/turf/open/floor/plating/vampcanalplating,
+/obj/effect/decal/wallpaper/blue,
+/turf/closed/wall/vampwall/bar,
 /area/vtm/interior)
 "bYK" = (
 /obj/effect/turf_decal/stripes/line{
@@ -7478,9 +7965,18 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/baali)
+"bZs" = (
+/obj/structure/vampipe,
+/turf/closed/wall/vampwall/junk/alt,
+/area/vtm/sewer/nosferatu_town)
 "bZx" = (
 /turf/closed/wall/vampwall/junk/alt/low/window,
 /area/vtm/interior/ghetto)
+"bZB" = (
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial5"
+	},
+/area/vtm/sewer/nosferatu_town)
 "bZF" = (
 /obj/machinery/light{
 	dir = 1;
@@ -7504,6 +8000,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/baali)
+"bZV" = (
+/obj/structure/curtain/bounty,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "bZW" = (
 /obj/effect/decal/litter,
 /obj/item/cigbutt,
@@ -7513,6 +8015,14 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/church/interior/haven)
+"cai" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cal" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/mansion)
@@ -7700,6 +8210,17 @@
 	color = "#636363"
 	},
 /area/vtm/interior/police/upstairs)
+"cdE" = (
+/obj/structure/vampipe{
+	icon_state = "piping3";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "cdG" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 10
@@ -7793,6 +8314,15 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/jazzclub)
+"ceO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "ceQ" = (
 /obj/effect/decal/cleanable/ash/large,
 /obj/structure/curtain/cloth/fancy{
@@ -7820,6 +8350,11 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict)
+"cfe" = (
+/obj/manholeup,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/vampgrass,
+/area/vtm/sewer)
 "cfm" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -7849,9 +8384,12 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf/lower)
 "cfJ" = (
-/obj/structure/table/wood,
-/obj/item/weedpack,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "cfM" = (
 /obj/effect/decal/shadow{
@@ -7924,6 +8462,10 @@
 "cgl" = (
 /turf/open/floor/carpet/black,
 /area/vtm/cabaret)
+"cgo" = (
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "cgt" = (
 /obj/structure/closet/cabinet,
 /obj/item/melee/vampirearms/katana/kosa{
@@ -8028,6 +8570,11 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/vtm/clinic/haven)
+"chG" = (
+/obj/structure/railing,
+/obj/structure/roadblock,
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "chH" = (
 /obj/structure/table/wood,
 /obj/structure/curtain/bounty{
@@ -8042,6 +8589,15 @@
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/chinatown)
+"chO" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 4
+	},
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/turf/open/floor/plating/vampcarpet,
+/area/vtm/interior)
 "chT" = (
 /turf/open/floor/plating/circled,
 /area/vtm/interior)
@@ -8052,6 +8608,16 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
+"chZ" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/trash,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "cid" = (
 /obj/effect/decal/bordur/corner{
 	dir = 8
@@ -8111,6 +8677,19 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/vjanitor)
+"ciV" = (
+/obj/machinery/light/small{
+	pixel_y = 32
+	},
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = 1
+	},
+/obj/structure/curtain,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/interior)
 "cje" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/vampdoor/simple,
@@ -8472,6 +9051,13 @@
 /obj/item/detective_scanner,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/police)
+"cmJ" = (
+/obj/structure/railing,
+/obj/structure/roadblock,
+/turf/open/floor/plating/grate{
+	icon_state = "lattice_new_dirt"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cmL" = (
 /obj/effect/decal/trash,
 /turf/open/floor/plating/rough,
@@ -8483,6 +9069,13 @@
 /obj/effect/decal/cardboard,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
+"cmQ" = (
+/obj/effect/decal/rugs,
+/obj/machinery/camera{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "cmT" = (
 /mob/living/carbon/human/npc/shop{
 	resistant_to_disciplines = 1
@@ -8657,6 +9250,17 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/unionsquare)
+"coG" = (
+/obj/structure/vampdoor/wood/old{
+	dir = 8;
+	lock_id = "nosferatu"
+	},
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "coM" = (
 /obj/machinery/light{
 	dir = 1
@@ -8733,10 +9337,15 @@
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/ghetto)
 "cpS" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
 	},
-/turf/open/floor/plating/rough,
+/obj/effect/decal/pallet{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/woodrough,
 /area/vtm/sewer/nosferatu_town)
 "cpU" = (
 /obj/effect/decal/crosswalk{
@@ -8861,6 +9470,14 @@
 	alpha = 0
 	},
 /area/vtm)
+"cqN" = (
+/obj/structure/chair/plastic{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cqQ" = (
 /obj/effect/decal/graffiti{
 	icon_state = "graffiti12"
@@ -8880,6 +9497,15 @@
 /obj/effect/decal/litter,
 /turf/open/floor/carpet/red,
 /area/vtm/clinic/haven)
+"crp" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "crx" = (
 /obj/structure/vampdoor/anarch{
 	dir = 8
@@ -9038,10 +9664,9 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/anarch/basement)
 "ctI" = (
-/obj/structure/railing{
-	dir = 6
-	},
-/turf/open/floor/plating/shit,
+/obj/item/kirbyplants/random,
+/obj/effect/decal/litter,
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "ctL" = (
 /obj/structure/toilet,
@@ -9084,6 +9709,11 @@
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf/lower)
+"cul" = (
+/obj/effect/decal/trash,
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "cum" = (
 /obj/structure/table/wood/fancy/orange,
 /obj/item/storage/pill_bottle/estrogen{
@@ -9195,10 +9825,19 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
 "cvP" = (
-/obj/structure/table/wood,
-/obj/item/vamp/keys/hack,
-/turf/open/floor/plating/parquetry/old,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/closet/crate/large,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/obj/effect/decal/trash,
+/obj/item/flashlight/lantern{
+	light_color = "#013220";
+	pixel_y = 8
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "cvQ" = (
 /obj/structure/table/wood/fancy/black,
 /obj/fusebox,
@@ -9274,6 +9913,18 @@
 "cwL" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior/penumbra/enoch)
+"cwM" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/junglebush,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "cwN" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/morphine,
@@ -9308,6 +9959,15 @@
 /obj/effect/decal/bordur/corner,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"cxi" = (
+/obj/effect/decal/trash,
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "cxl" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -9367,6 +10027,19 @@
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall,
 /area/vtm/hotel)
+"cxX" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 2
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
+"cxZ" = (
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cyb" = (
 /obj/structure/roofstuff/alt2,
 /turf/open/floor/plating/sidewalk/poor,
@@ -9519,6 +10192,15 @@
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"cAh" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "cAi" = (
 /obj/machinery/light/prince{
 	dir = 8
@@ -9534,6 +10216,18 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"cAu" = (
+/obj/structure/vampdoor/reinf{
+	lock_id = "primNosferatu";
+	locked = 1;
+	lockpick_difficulty = 15;
+	name = "primogen hideout"
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cAx" = (
 /obj/structure/table/wood,
 /obj/item/clothing/suit/vampire/vest,
@@ -9586,6 +10280,15 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/tzimisce_manor)
+"cBl" = (
+/obj/structure/table/reinforced,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "cBn" = (
 /obj/structure/vampfence/rich,
 /obj/structure/vampfence/corner/rich,
@@ -9646,12 +10349,10 @@
 /turf/closed/wall/vampwall,
 /area/vtm/fishermanswharf/lower)
 "cCs" = (
-/obj/structure/chair/wood/wings{
-	dir = 8;
-	pixel_y = 6
-	},
-/turf/open/floor/plating/parquetry/old,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "cCC" = (
 /mob/living/simple_animal/deer,
 /obj/item/food/grown/moonflower,
@@ -9707,11 +10408,30 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"cDy" = (
+/obj/structure/railing{
+	layer = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/structure/closet/crate/large,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "cDC" = (
 /obj/item/binoculars,
 /obj/structure/table/wood,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights/forest)
+"cDI" = (
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "cDQ" = (
 /obj/structure/table/wood,
 /obj/item/drinkable_bloodpack,
@@ -9784,6 +10504,14 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
+"cEH" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "cEI" = (
 /obj/structure/trashbag,
 /obj/effect/decal/litter,
@@ -9793,6 +10521,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/giovanni)
+"cEQ" = (
+/obj/effect/decal/cleanable/blood,
+/obj/structure/vampdoor/wood/old{
+	dir = 4
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer)
 "cER" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -9890,6 +10625,10 @@
 "cGg" = (
 /turf/closed/wall/vampwall/brick/low/window,
 /area/vtm/financialdistrict/construction)
+"cGi" = (
+/obj/effect/decal/bordur,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "cGk" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/plating/saint,
@@ -9913,6 +10652,11 @@
 /obj/vampire_computer,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/strip/toreador)
+"cGr" = (
+/obj/structure/vampdoor/simple,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "cGB" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -10116,12 +10860,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/clinic/haven)
 "cIr" = (
-/obj/machinery/light/small/pink{
-	dir = 4;
-	pixel_x = -16
+/turf/closed/wall/vampwall/rock{
+	density = 0
 	},
-/turf/open/floor/plating/rough/cave,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/sewer)
 "cIv" = (
 /obj/structure/trashcan,
 /turf/open/floor/plating/rough/cave,
@@ -10221,6 +10963,26 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
+"cJB" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 8;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
+"cJC" = (
+/obj/structure/vampdoor/old{
+	dir = 8;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "cJP" = (
 /obj/effect/decal/pallet,
 /turf/open/floor/plating/rough,
@@ -10307,6 +11069,15 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/bianchiBank)
+"cKY" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cLa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -10402,6 +11173,14 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/black,
 /area/vtm/hotel)
+"cMA" = (
+/obj/machinery/light/small/red{
+	pixel_y = 24
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cMC" = (
 /obj/structure/table/wood,
 /obj/item/newspaper,
@@ -10512,6 +11291,12 @@
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights/old)
+"cNI" = (
+/obj/structure/railing,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cNN" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/parquetry,
@@ -10528,6 +11313,14 @@
 /obj/structure/curtain,
 /turf/open/floor/plating/toilet,
 /area/vtm/clinic)
+"cNY" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "cOf" = (
 /obj/structure/foodrack,
 /turf/open/floor/plating/bacotell,
@@ -10639,6 +11432,12 @@
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating/roofwalk,
 /area/vtm/pacificheights/forest)
+"cPB" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "cPF" = (
 /obj/structure/chair{
 	dir = 4
@@ -10646,11 +11445,13 @@
 /turf/open/floor/plating/toilet,
 /area/vtm/interior)
 "cPI" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 16
 	},
-/obj/structure/curtain,
-/turf/open/floor/plating/vampcanalplating,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
 /area/vtm/interior)
 "cPX" = (
 /turf/open/floor/plating/vampdirt,
@@ -10661,6 +11462,16 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/millennium_tower/f4)
+"cQa" = (
+/obj/structure/table,
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cQg" = (
 /obj/structure/barrels/rand,
 /turf/open/floor/plating/rough,
@@ -10850,11 +11661,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/church/interior/haven)
 "cSO" = (
-/obj/structure/railing{
-	pixel_y = -14
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
 	},
-/obj/effect/decal/graffiti,
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/sewer/nosferatu_town)
 "cSZ" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -11017,14 +11827,20 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "cUN" = (
-/obj/structure/vampdoor/wood{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/vampdoor/old{
+	dir = 1;
 	lock_id = "nosferatu";
-	lockpick_difficulty = 8
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
 	},
-/obj/effect/decal/bordur{
-	dir = 1
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = 5467;
+	max_integrity = 3500;
+	name = "Warrens"
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/grate,
 /area/vtm/sewer/nosferatu_town)
 "cUO" = (
 /turf/closed/wall/vampwall/rich,
@@ -11087,6 +11903,19 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/bianchiBank)
+"cVH" = (
+/obj/structure/table,
+/obj/item/vamp/keys/camarilla{
+	accesslocks = list("nosferatu","nosferatu1","nosferatu2","nosferatu3");
+	name = "Master key"
+	},
+/obj/machinery/light{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "cVP" = (
 /obj/structure/railing{
 	layer = 4;
@@ -11206,8 +12035,13 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf)
 "cXg" = (
-/obj/effect/decal/wallpaper/paper/stripe,
-/turf/closed/wall/vampwall/junk,
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/obj/effect/decal/wallpaper/paper/stripe/low,
+/turf/closed/wall/vampwall/bar/low/window,
 /area/vtm/interior)
 "cXh" = (
 /obj/structure/trashbag{
@@ -11259,6 +12093,17 @@
 /obj/item/storage/box/aquarium_props,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/ventrue)
+"cXI" = (
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_y = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "cXK" = (
 /obj/effect/decal/bordur/corner{
 	dir = 4
@@ -11317,6 +12162,21 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights/community)
+"cYy" = (
+/obj/structure/table/wood,
+/obj/effect/decal/carpet{
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
+"cYB" = (
+/obj/structure/vampfence/rich{
+	pixel_x = -16
+	},
+/turf/closed/wall/vampwall/junk,
+/area/vtm/sewer/nosferatu_town)
 "cYO" = (
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/strip)
@@ -11336,12 +12196,14 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "cZu" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	pixel_y = 32
+/obj/effect/decal/bordur{
+	dir = 8
 	},
-/turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/coclock,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/interior)
 "cZv" = (
 /obj/effect/decal/wallpaper/red,
 /turf/closed/wall/vampwall/market,
@@ -11414,6 +12276,16 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/tzimisce_manor)
+"daP" = (
+/obj/effect/decal/litter,
+/obj/structure/chair/plastic{
+	dir = 1;
+	name = "Seat of Shame"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "daY" = (
 /obj/effect/landmark/npcwall,
 /obj/structure/flora/ausbushes/fullgrass,
@@ -11500,6 +12372,11 @@
 /obj/structure/trashcan,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"dcn" = (
+/turf/open/floor/plating/grate{
+	icon_state = "lattice_new_dirt"
+	},
+/area/vtm/sewer)
 "dct" = (
 /obj/effect/decal/shadow{
 	pixel_y = -32
@@ -11583,6 +12460,14 @@
 /obj/structure/coclock,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"ddy" = (
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/closed/wall/vampwall/rich/old/low/window/reinforced,
+/area/vtm/sewer/nosferatu_town)
 "ddB" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/sidewalk/rich,
@@ -11664,12 +12549,10 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/financialdistrict/construction)
 "deB" = (
-/obj/effect/decal/pallet,
-/obj/structure/railing{
-	pixel_y = -6
-	},
-/turf/open/floor/plating/shit,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/footprints,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "deI" = (
 /obj/structure/lamppost/one{
 	dir = 1
@@ -11922,6 +12805,15 @@
 /obj/structure/fence/corner,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
+"dhx" = (
+/obj/structure/coclock,
+/mob/living/carbon/human/npc/shop,
+/obj/structure/chair/comfy/black,
+/obj/item/cane,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dhF" = (
 /turf/open/floor/plating/circled,
 /area/vtm/interior/wyrm_corrupted)
@@ -12028,12 +12920,7 @@
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/shop)
 "diP" = (
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/mob_spawn/human/citizen,
+/obj/structure/closet/cabinet,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "diR" = (
@@ -12242,6 +13129,22 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f3)
+"dlX" = (
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_nature";
+	layer = 4.2;
+	pixel_y = 29
+	},
+/obj/structure/showcase/machinery/tv{
+	pixel_y = 12
+	},
+/obj/structure/table,
+/obj/structure/table,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dlZ" = (
 /obj/machinery/light/small/pink{
 	dir = 1
@@ -12331,6 +13234,10 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/ghetto/old)
+"dnc" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "dnj" = (
 /turf/open/floor/plating/vampwood,
 /area/vtm/northbeach)
@@ -12466,6 +13373,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"dpv" = (
+/obj/structure/vampdoor/wood/old{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "dpw" = (
 /obj/effect/decal/bordur{
 	dir = 5
@@ -12704,6 +13617,21 @@
 /obj/item/melee/vampirearms/tire,
 /turf/open/floor/carpet,
 /area/vtm/anarch)
+"dsc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "dsn" = (
 /obj/effect/decal/cleanable/ash,
 /obj/item/melee/vampirearms/knife,
@@ -12747,6 +13675,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/hotel)
+"dsY" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "dta" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -12797,6 +13732,11 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/clinic/haven)
+"dtr" = (
+/obj/structure/table/wood/poker,
+/obj/effect/decal/carpet,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "dtG" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -12853,6 +13793,15 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/shop)
+"duF" = (
+/obj/effect/decal/kopatich{
+	pixel_x = -20;
+	pixel_y = -20
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "duI" = (
 /obj/effect/decal/wallpaper/paper,
 /obj/effect/decal/wallpaper/light,
@@ -12871,6 +13820,10 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"dvm" = (
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "dvn" = (
 /obj/structure/stairs/south{
 	dir = 1
@@ -12918,6 +13871,18 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/park)
+"dvJ" = (
+/obj/effect/decal/trash,
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	pixel_x = 6;
+	pixel_y = 10
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dvK" = (
 /obj/structure/vampipe{
 	pixel_y = 32
@@ -13095,8 +14060,7 @@
 /turf/open/floor/carpet/orange,
 /area/vtm/interior/strip/toreador)
 "dxU" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/plating/vampcanalplating,
+/turf/closed/wall/vampwall/bar,
 /area/vtm/sewer/nosferatu_town)
 "dxZ" = (
 /obj/structure/chair/wood/wings,
@@ -13116,9 +14080,12 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower)
 "dyB" = (
-/obj/structure/table/wood,
-/turf/open/floor/plating/parquetry/old,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "dyJ" = (
 /obj/structure/safe/floor{
 	pixel_y = 25
@@ -13299,6 +14266,13 @@
 /obj/effect/decal/wallpaper/grey/low,
 /turf/closed/wall/vampwall/market/low/window,
 /area/vtm/interior/shop)
+"dAR" = (
+/obj/effect/decal/litter,
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "dAU" = (
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/church/interior/staff)
@@ -13343,6 +14317,12 @@
 /obj/item/melee/vampirearms/tire,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
+"dBX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "dCa" = (
 /obj/structure/chair/wood{
 	dir = 4;
@@ -13445,6 +14425,13 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/tzimisce_manor)
+"dDe" = (
+/obj/structure/table,
+/obj/item/vamp/keys/nosferatu,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dDf" = (
 /obj/effect/decal/wallpaper/paper/low,
 /turf/closed/wall/vampwall/old/low/window,
@@ -13488,9 +14475,28 @@
 /obj/item/clothing/under/suit/white,
 /turf/open/floor/carpet/black,
 /area/vtm/interior/laundromat)
+"dDW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "dEi" = (
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
+"dEl" = (
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_nature";
+	layer = 4.2;
+	pixel_y = 29
+	},
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_off";
+	pixel_y = 13
+	},
+/obj/structure/table,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "dEo" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/pacificheights/forest)
@@ -13512,6 +14518,10 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"dES" = (
+/obj/structure/table/wood,
+/turf/closed/wall/vampwall/junk/low,
+/area/vtm/sewer/nosferatu_town)
 "dEW" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -13522,6 +14532,12 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/carpet/red,
 /area/vtm/clinic/haven)
+"dFd" = (
+/obj/structure/table/wood/bar,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dFj" = (
 /obj/machinery/vamp/atm{
 	dir = 4;
@@ -13568,6 +14584,14 @@
 /obj/structure/clothinghanger,
 /turf/open/floor/carpet,
 /area/vtm/interior/giovanni)
+"dFK" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dFO" = (
 /obj/structure/vampmap,
 /turf/open/floor/plating/sidewalk,
@@ -13677,9 +14701,9 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/park)
 "dHx" = (
-/obj/structure/coclock,
-/obj/structure/chair/sofa/right,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
 /area/vtm/sewer/nosferatu_town)
 "dHz" = (
 /obj/machinery/light/small{
@@ -13900,14 +14924,37 @@
 /obj/lombard,
 /turf/open/floor/plating/concrete,
 /area/vtm/supply)
+"dJT" = (
+/obj/effect/decal/bordur{
+	dir = 10
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "dJU" = (
 /mob/living/carbon/human/npc/walkby,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
+"dKf" = (
+/obj/item/clothing/head/cone,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "dKk" = (
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/fishermanswharf/lower)
+"dKp" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "dKt" = (
 /obj/structure/toilet{
 	dir = 8
@@ -13983,6 +15030,10 @@
 /obj/item/weedseed,
 /turf/open/floor/plating/rough,
 /area/vtm/anarch/basement)
+"dLo" = (
+/obj/matrix,
+/turf/open/floor/plating/shit,
+/area/space)
 "dLq" = (
 /obj/structure/chair/sofa/corp/left,
 /obj/structure/extinguisher_cabinet{
@@ -14002,6 +15053,12 @@
 /obj/item/cockclock,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/setite)
+"dLD" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "dLN" = (
 /obj/structure/filingcabinet{
 	pixel_x = 7
@@ -14123,6 +15180,20 @@
 /obj/effect/landmark/start/citizen,
 /turf/open/floor/carpet/black,
 /area/vtm/hotel)
+"dOo" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/vampipe{
+	icon_state = "piping6";
+	pixel_y = 32
+	},
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "dOq" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small{
@@ -14208,6 +15279,14 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/sewer/tzimisce_sanctum)
+"dPO" = (
+/obj/item/bedsheet/random,
+/obj/structure/bed,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dPQ" = (
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalkalt,
@@ -14262,6 +15341,23 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/chantry)
+"dQJ" = (
+/obj/item/flashlight/lamp/green{
+	pixel_y = 14;
+	pixel_x = 19
+	},
+/obj/structure/chair/comfy/beige{
+	pixel_y = 4
+	},
+/obj/effect/landmark/start/citizen{
+	name = "Primogen Nosferatu"
+	},
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
+"dQK" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "dQN" = (
 /turf/closed/wall/vampwall/metal,
 /area/vtm/interior/endron_facility/restricted)
@@ -14274,11 +15370,11 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "dQT" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
+/obj/structure/vampdoor/old{
+	locked = 1
 	},
-/turf/open/floor/plating/parquetry/old,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "dQW" = (
 /obj/effect/decal/bordur,
@@ -14290,6 +15386,13 @@
 /obj/item/reagent_containers/glass/bowl/mushroom_bowl,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
+"dRi" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dRm" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/vampfence/rich{
@@ -14443,6 +15546,12 @@
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating/rough,
 /area/vtm/sewer)
+"dTS" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "dTT" = (
 /obj/structure/closet/crate/bin,
 /obj/machinery/light{
@@ -14496,6 +15605,12 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/sewer/cappadocian)
+"dUQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "dUR" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 1
@@ -14611,7 +15726,10 @@
 /turf/closed/wall/vampwall/rich,
 /area/vtm/jazzclub)
 "dWx" = (
-/turf/open/space/basic,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plating/dirt,
 /area/vtm/sewer/nosferatu_town)
 "dWG" = (
 /obj/structure/chair/wood/wings{
@@ -14619,6 +15737,14 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/theatre)
+"dWO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "dWT" = (
 /obj/structure/table/wood,
 /obj/lombard,
@@ -14634,6 +15760,15 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/bacotell,
 /area/vtm/clinic/haven)
+"dXf" = (
+/obj/effect/decal/litter,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "dXg" = (
 /obj/effect/decal/litter{
 	pixel_x = 5;
@@ -14819,6 +15954,20 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/carpet/purple,
 /area/vtm/hotel)
+"dZg" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "dZm" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/open/floor/mineral/plastitanium,
@@ -14931,6 +16080,17 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/construction)
+"eaO" = (
+/obj/structure/chair/plastic{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "eaR" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -14969,6 +16129,17 @@
 /obj/structure/closet/crate/freezer,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/setite)
+"ebq" = (
+/obj/structure/dresser,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/obj/effect/decal/trash,
+/obj/item/clothing/mask/vampire,
+/turf/open/floor/carpet/green,
+/area/vtm/sewer/nosferatu_town)
 "ebs" = (
 /mob/living/simple_animal/hostile/retaliate/frog,
 /obj/item/toy/seashell,
@@ -14979,6 +16150,17 @@
 /obj/item/bedsheet/black,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/graveyard/interior)
+"ebx" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "ebz" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights/forest)
@@ -15049,18 +16231,9 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
 "ecc" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
 	},
-/obj/structure/vampdoor/wood/old{
-	dir = 4;
-	lock_id = "nosferatu2";
-	locked = 1;
-	lockpick_difficulty = 6;
-	name = "house-2"
-	},
-/obj/effect/decal/cardboard,
-/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "ecd" = (
 /obj/effect/decal/bordur{
@@ -15132,6 +16305,13 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic/haven)
+"ecL" = (
+/obj/effect/decal/rugs,
+/obj/structure/closet/mini_fridge,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "ecR" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/item/drinkable_bloodpack,
@@ -15165,14 +16345,27 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "edn" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/railing{
+	layer = 4
+	},
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "edq" = (
 /turf/open/openspace,
 /area/vtm/financialdistrict)
+"edu" = (
+/obj/machinery/light/small/pink{
+	dir = 1;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "edz" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -15251,6 +16444,10 @@
 	dir = 8
 	},
 /area/vtm/interior/tzimisce_manor)
+"eeM" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "eeN" = (
 /obj/structure/closet/cabinet,
 /obj/item/ammo_box/vampire/c45acp,
@@ -15326,6 +16523,11 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"efV" = (
+/obj/effect/decal/wallpaper/paper/stripe,
+/obj/effect/decal/wallpaper/light,
+/turf/closed/wall/vampwall/bar,
+/area/vtm/interior)
 "efX" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 8
@@ -15350,6 +16552,10 @@
 /obj/item/bong,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/graveyard/interior)
+"ege" = (
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "egf" = (
 /obj/effect/decal/pallet{
 	pixel_x = 6;
@@ -15389,6 +16595,21 @@
 	},
 /turf/open/floor/plating/vampwood,
 /area/vtm/cabaret)
+"egT" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/pallet,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "egY" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 8
@@ -15488,10 +16709,24 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
+"ehV" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/structure/coclock,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "eig" = (
 /obj/structure/railing,
 /turf/open/floor/plating/vampwood,
 /area/vtm/sewer/cappadocian)
+"eii" = (
+/obj/structure/flora/junglebush/b,
+/obj/structure/vampipe{
+	icon_state = "piping6";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "eir" = (
 /turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
@@ -15780,6 +17015,15 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/ghetto)
+"emj" = (
+/obj/structure/vampipe{
+	icon_state = "piping3";
+	pixel_y = 32
+	},
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "eml" = (
 /obj/structure/vampipe{
 	icon_state = "piping43"
@@ -15805,6 +17049,14 @@
 "emw" = (
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/financialdistrict/construction)
+"emx" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "emy" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -15824,6 +17076,11 @@
 /mob/living/carbon/human/npc/business,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/giovanni/basement)
+"emX" = (
+/obj/structure/window/reinforced/indestructable,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "enk" = (
 /obj/structure/fluff/hedge{
 	pixel_y = 6
@@ -15908,10 +17165,8 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
 "enM" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
-	},
-/turf/open/floor/plating/vampdirt,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "enT" = (
 /obj/structure/vampdoor/wood/pentex{
@@ -16067,6 +17322,16 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/strip/elysium)
+"eqi" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/decal/trash,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "eqj" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -16085,12 +17350,28 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/restricted)
+"eqs" = (
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "eqz" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
 	},
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"eqQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/decal/graffiti,
+/obj/effect/decal/bordur,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "eqV" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/belt/vampire/sheathe/longsword,
@@ -16169,10 +17450,10 @@
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
 "erZ" = (
-/obj/structure/chair/plastic{
-	dir = 1
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
 	},
-/turf/open/floor/plating/parquetry/old,
 /area/vtm/sewer/nosferatu_town)
 "esa" = (
 /turf/open/floor/plating/vampwood,
@@ -16196,10 +17477,42 @@
 /obj/item/storage/fancy/hardcase,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/police)
+"esw" = (
+/obj/structure/lamppost/sidewalk,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "esx" = (
 /obj/structure/coclock,
 /turf/open/floor/carpet,
 /area/vtm/interior/giovanni)
+"esD" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/junglebush/c,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
+"esJ" = (
+/obj/effect/decal/pallet{
+	layer = 2
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/woodrough,
+/area/vtm/sewer/nosferatu_town)
 "esT" = (
 /mob/living/simple_animal/hostile/ghost,
 /turf/open/floor/plating/umbra,
@@ -16240,6 +17553,17 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/baali)
+"etP" = (
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "etV" = (
 /obj/structure/closet/crate/large,
 /obj/effect/decal/pallet,
@@ -16257,6 +17581,15 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/strip/toreador)
+"eub" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "eug" = (
 /obj/structure/flora/ausbushes/grassybush,
 /mob/living/simple_animal/butterfly,
@@ -16330,6 +17663,13 @@
 /obj/structure/toilet,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/ghetto)
+"euW" = (
+/obj/structure/vampdoor/simple{
+	dir = 8
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "euZ" = (
 /obj/structure/railing{
 	dir = 4
@@ -16569,6 +17909,16 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/tzimisce_manor)
+"eyG" = (
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	pixel_x = -2;
+	pixel_y = 12
+	},
+/obj/effect/decal/pallet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "eyN" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -16883,8 +18233,13 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/oldchurch)
 "eDO" = (
-/obj/structure/chair/sofa/right,
-/turf/open/floor/plating/rough,
+/obj/structure/closet,
+/obj/structure/coclock,
+/obj/item/clothing/under/vampire/janitor,
+/obj/item/clothing/under/vampire/military_fatigues,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
 /area/vtm/sewer/nosferatu_town)
 "eDU" = (
 /turf/open/floor/plating/parquetry/old,
@@ -17006,9 +18361,12 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f3)
 "eFt" = (
-/obj/structure/table/wood/poker,
-/obj/item/stack/dollar/hundred,
-/turf/open/floor/plating/vampdirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "eFy" = (
 /obj/structure/vampipe{
@@ -17170,6 +18528,13 @@
 /obj/structure/bricks,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/financialdistrict/construction)
+"eIy" = (
+/obj/structure/disposalpipe/broken{
+	dir = 1
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "eIB" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -17190,6 +18555,12 @@
 /obj/vampire_car/retro/rand,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights/old)
+"eIK" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "eIR" = (
 /obj/effect/gibspawner/human,
 /turf/open/floor/plating/rough/cave,
@@ -17320,8 +18691,12 @@
 	},
 /area/vtm/interior/police/upstairs)
 "eKD" = (
-/obj/effect/decal/wallpaper/paper/green,
-/turf/closed/wall/vampwall/junk/alt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
 /area/vtm/sewer/nosferatu_town)
 "eKJ" = (
 /obj/effect/turf_decal/siding/wood{
@@ -17427,6 +18802,11 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/chinatown)
+"eMq" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "eMv" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -17572,11 +18952,11 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/police)
 "eOE" = (
-/obj/machinery/light/small/red{
-	pixel_y = 24
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/obj/structure/chair/plastic,
-/turf/open/floor/plating/vampdirt,
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/dirt,
 /area/vtm/sewer/nosferatu_town)
 "eOF" = (
 /obj/effect/turf_decal/siding/white{
@@ -17714,6 +19094,11 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/park)
+"eQf" = (
+/obj/effect/decal/wallpaper,
+/obj/structure/sign/painting/library,
+/turf/closed/wall/vampwall/junk/alt,
+/area/vtm/sewer/nosferatu_town)
 "eQg" = (
 /obj/structure/toilet{
 	dir = 4
@@ -17725,6 +19110,12 @@
 /mob/living/carbon/human/npc/guard,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/restricted)
+"eQj" = (
+/obj/structure/table/wood/bar,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing/green,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "eQk" = (
 /obj/structure/guillotine,
 /turf/open/floor/plating/parquetry/rich,
@@ -17909,6 +19300,16 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/park)
+"eSF" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 4;
+	lock_id = "nosferatu3";
+	lockpick_difficulty = 6;
+	name = "house-3"
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "eSH" = (
 /obj/machinery/light/prince/ghost{
 	pixel_x = 32;
@@ -17986,6 +19387,19 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf)
+"eTH" = (
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 2
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "eTM" = (
 /obj/structure/roadblock/alt{
 	dir = 4
@@ -18120,6 +19534,13 @@
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior)
+"eVR" = (
+/obj/effect/decal/graffiti,
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "eVU" = (
 /obj/structure/railing{
 	dir = 4
@@ -18132,6 +19553,13 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"eVW" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "eVX" = (
 /obj/effect/turf_decal/siding/white{
 	icon_state = "siding_corner"
@@ -18139,16 +19567,25 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
 "eWh" = (
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating/rough,
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "eWi" = (
 /obj/effect/decal/garou_glyph/galestalkers,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"eWw" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/junglebush/c,
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "eWA" = (
 /obj/structure/chair/plastic{
 	dir = 8;
@@ -18177,6 +19614,13 @@
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/plating/vampplating/stone,
 /area/vtm/interior/bianchiBank)
+"eWY" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "eXb" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -18205,11 +19649,17 @@
 /turf/open/floor/plating/circled,
 /area/vtm/interior/setite/basement)
 "eXk" = (
-/obj/machinery/light/small/red{
-	dir = 4;
-	pixel_x = -16
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
 	},
-/turf/open/floor/plating/rough,
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "eXr" = (
 /obj/structure/chair/plastic{
@@ -18308,17 +19758,16 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
 "eYU" = (
-/obj/effect/decal/pallet{
-	pixel_x = 2;
-	pixel_y = 25
-	},
-/obj/structure/railing{
-	dir = 1;
-	layer = 4;
+/obj/structure/chair/pew/right,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
+"eYX" = (
+/obj/structure/toilet{
+	dir = 4;
 	pixel_y = 4
 	},
-/turf/open/floor/plating/shit,
-/area/vtm/sewer/nosferatu_town)
+/turf/open/floor/plating/industrial,
+/area/vtm/interior)
 "eZa" = (
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/junk/alt,
@@ -18395,6 +19844,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/f3)
+"faK" = (
+/obj/item/kirbyplants/random,
+/obj/structure/strip_club,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "faR" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -18441,6 +19897,19 @@
 /obj/structure/trashcan,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
+"fbp" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fbq" = (
 /obj/structure/chair{
 	dir = 4
@@ -18573,6 +20042,14 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/setite)
+"fct" = (
+/obj/effect/decal/carpet{
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/obj/structure/table/wood/poker,
+/turf/open/floor/plating/vampcarpet,
+/area/vtm/interior)
 "fcy" = (
 /obj/structure/fluff/hedge,
 /obj/structure/railing,
@@ -18679,8 +20156,13 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
 "fdO" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plating/vampdirt,
+/obj/structure/chair/sofa/corp/left{
+	color = "#50C878"
+	},
+/obj/structure/coclock,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "fdU" = (
 /obj/effect/decal/bordur{
@@ -18920,12 +20402,15 @@
 /turf/open/water,
 /area/vtm/interior/bianchiBank)
 "fgS" = (
-/obj/effect/decal/trash,
-/obj/structure/railing{
-	pixel_y = -4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/rough/cave,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/sewer)
 "fgT" = (
 /obj/machinery/light{
 	dir = 4
@@ -18959,14 +20444,14 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
 "fhl" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/structure/dresser,
+/obj/item/flashlight/lamp{
+	pixel_y = 4;
+	pixel_x = 6
 	},
-/obj/structure/sink{
-	pixel_y = 16
-	},
-/turf/open/floor/plating/vampcanalplating,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/coclock,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "fhm" = (
 /obj/effect/decal/bordur,
 /obj/structure/fluff/hedge{
@@ -18978,6 +20463,32 @@
 /obj/structure/coclock,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/setite)
+"fhw" = (
+/obj/structure/railing{
+	dir = 4;
+	layer = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
+"fhF" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/railing{
+	layer = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "fhG" = (
 /obj/structure/chair/sofa/corp{
 	dir = 1
@@ -19050,6 +20561,13 @@
 /obj/structure/roadsign/stop,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights)
+"fis" = (
+/obj/structure/rack/bubway/east,
+/obj/machinery/microwave{
+	pixel_y = 9
+	},
+/turf/open/floor/plating/industrial,
+/area/vtm/sewer/nosferatu_town)
 "fiy" = (
 /obj/vampire_car/track/volkswagen,
 /turf/open/floor/plating/asphalt,
@@ -19206,6 +20724,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/vtm/interior/millennium_tower/ventrue)
+"fkV" = (
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "fkW" = (
 /obj/item/stack/dollar/five,
 /turf/open/floor/plating/parquetry/old,
@@ -19268,6 +20792,17 @@
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/vampcrossableocean,
 /area/vtm/forest)
+"flT" = (
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_analog";
+	pixel_y = 12
+	},
+/obj/structure/table,
+/obj/structure/showcase/machinery/tv{
+	pixel_y = 29
+	},
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "flU" = (
 /obj/structure/chair,
 /turf/open/floor/plating/vampplating,
@@ -19358,6 +20893,14 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/cog/pantry)
+"fmP" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/junglebush/c,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "fmR" = (
 /obj/structure/vampipe{
 	icon_state = "piping35"
@@ -19403,6 +20946,16 @@
 /obj/item/candle,
 /turf/open/floor/plating/parquetry,
 /area/vtm/jazzclub)
+"fnv" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "fnx" = (
 /obj/structure/punching_bag,
 /turf/open/floor/plating/vampplating/mono,
@@ -19678,6 +21231,33 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"fro" = (
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 2
+	},
+/obj/structure/flora/junglebush/c,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
+"frr" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing{
+	layer = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "frv" = (
 /obj/structure/table/reinforced/ctf,
 /obj/machinery/light/small{
@@ -19729,8 +21309,9 @@
 /turf/open/floor/plating/umbra,
 /area/vtm/interior/penumbra/enoch)
 "fsi" = (
-/obj/structure/chair/wood,
-/turf/open/floor/plating/rough,
+/obj/structure/railing,
+/obj/structure/chair/plastic,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "fsk" = (
 /obj/structure/small_vamprocks,
@@ -19923,8 +21504,9 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
 "fut" = (
-/obj/structure/clothinghanger,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
 /area/vtm/sewer/nosferatu_town)
 "fux" = (
 /obj/structure/trashbag,
@@ -20009,6 +21591,13 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower)
+"fvr" = (
+/obj/structure/table/wood/bar,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fvs" = (
 /obj/structure/table/wood,
 /obj/underplate{
@@ -20057,6 +21646,21 @@
 /obj/effect/landmark/start/giovanni,
 /turf/open/floor/carpet,
 /area/vtm/interior/giovanni)
+"fvN" = (
+/obj/effect/decal/pallet{
+	layer = 2
+	},
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "fvP" = (
 /obj/item/ammo_box/vampire/c9mm,
 /turf/open/floor/plating/concrete,
@@ -20183,6 +21787,15 @@
 /obj/effect/decal/stock,
 /turf/open/floor/plating/asphalt,
 /area/vtm/financialdistrict)
+"fxp" = (
+/obj/structure/vampfence/rich{
+	alpha = 155;
+	density = 0;
+	dir = 4;
+	pixel_y = 8
+	},
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "fxr" = (
 /obj/structure/table,
 /obj/item/storage/backpack/duffelbag/med/surgery,
@@ -20233,6 +21846,17 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf/lower)
+"fxS" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/litter,
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fxW" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -20517,6 +22141,14 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/vjanitor)
+"fBs" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/toilet{
+	dir = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "fBD" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -20576,9 +22208,14 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/church)
 "fBX" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fCj" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 10
@@ -20710,6 +22347,12 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/millennium_tower/f3)
+"fDY" = (
+/obj/matrix{
+	alpha = 0
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "fDZ" = (
 /turf/closed/wall/vampwall,
 /area/vtm/interior/shop)
@@ -20752,6 +22395,14 @@
 	},
 /turf/open/floor/light,
 /area/vtm/interior/strip/elysium)
+"fEO" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "fEQ" = (
 /obj/machinery/light{
 	dir = 8
@@ -20839,6 +22490,14 @@
 /obj/item/pen/blue,
 /turf/open/floor/carpet/blue,
 /area/vtm/interior/strip/toreador)
+"fFR" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fFZ" = (
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
@@ -20861,6 +22520,15 @@
 	alpha = 0
 	},
 /area/vtm)
+"fGf" = (
+/obj/machinery/washing_machine,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "fGg" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -20886,6 +22554,20 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/glasswalker)
+"fGv" = (
+/obj/structure/flora/junglebush,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "fGC" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -21027,6 +22709,10 @@
 	},
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer)
+"fIP" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "fIW" = (
 /obj/structure/railing{
 	dir = 1;
@@ -21054,6 +22740,14 @@
 	name = "flesh floor"
 	},
 /area/vtm/sewer/tzimisce_sanctum)
+"fJk" = (
+/obj/effect/decal/bordur{
+	dir = 10
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fJm" = (
 /obj/structure/table/wood,
 /obj/vampire_computer{
@@ -21067,10 +22761,26 @@
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
 /turf/closed/wall/vampwall/rich/low,
 /area/vtm/interior/millennium_tower/ventrue)
+"fJL" = (
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/decal/trash{
+	icon_state = "trash5"
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "fJO" = (
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/brick,
 /area/vtm/supply)
+"fJP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "fJS" = (
 /obj/structure/vampdoor/wood/giovanni,
 /turf/open/floor/plating/parquetry,
@@ -21080,10 +22790,20 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"fJZ" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "fKg" = (
 /obj/machinery/light/small,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/cog/pantry)
+"fKo" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fKr" = (
 /obj/effect/decal/painting/second,
 /turf/open/openspace,
@@ -21154,6 +22874,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/strip)
+"fLi" = (
+/obj/structure/closet/crate/freezer/fridge,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fLj" = (
 /obj/structure/weedshit,
 /obj/effect/turf_decal/weather/dirt{
@@ -21238,6 +22964,10 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/unionsquare)
+"fMm" = (
+/obj/effect/decal/wallpaper/light,
+/turf/closed/wall/vampwall/bar,
+/area/vtm/interior)
 "fMn" = (
 /obj/effect/decal/trash,
 /obj/structure/cable/layer1,
@@ -21325,17 +23055,27 @@
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/millennium_tower/f3)
 "fNj" = (
-/obj/structure/railing{
-	dir = 4;
-	pixel_x = 2;
-	pixel_y = 3
+/obj/structure/closet/crate/freezer/fridge,
+/obj/item/drinkable_bloodpack,
+/obj/item/drinkable_bloodpack,
+/obj/item/drinkable_bloodpack,
+/obj/item/drinkable_bloodpack,
+/obj/item/drinkable_bloodpack,
+/obj/effect/decal/litter,
+/obj/machinery/camera{
+	dir = 4
 	},
-/obj/structure/railing{
-	dir = 6;
-	pixel_x = 2;
-	pixel_y = -7
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/flour,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/reagent_containers/food/condiment/sugar,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/fancy/egg_box,
+/obj/item/storage/box/beakers,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
 	},
-/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "fNk" = (
 /obj/structure/closet/cardboard,
@@ -21411,6 +23151,15 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
+"fNY" = (
+/obj/structure/closet/crate/large{
+	pixel_y = 10
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fNZ" = (
 /obj/machinery/light{
 	dir = 8
@@ -21523,6 +23272,16 @@
 	},
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer)
+"fPN" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 5;
+	pixel_x = -14
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/railing,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "fPO" = (
 /obj/structure/chair/wood{
 	dir = 4
@@ -21703,6 +23462,11 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/trujah)
+"fSi" = (
+/obj/structure/chair/sofa/right,
+/obj/item/toy/plush/beeplushie,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "fSj" = (
 /obj/effect/decal/cleanable/plastic,
 /turf/open/floor/plating/concrete,
@@ -21882,17 +23646,11 @@
 /turf/open/floor/plating/vampdirt,
 /area/vtm/interior/cog/caern)
 "fUz" = (
-/obj/structure/vampdoor/wood/old{
-	dir = 4;
-	lock_id = "nosferatu3";
-	locked = 1;
-	lockpick_difficulty = 6;
-	name = "house-3"
+/obj/effect/decal/pallet{
+	pixel_x = 4;
+	pixel_y = 4
 	},
-/obj/effect/decal/bordur{
-	dir = 8
-	},
-/turf/open/floor/plating/rough/cave,
+/turf/open/floor/plating/woodrough,
 /area/vtm/sewer/nosferatu_town)
 "fUA" = (
 /obj/structure/table/wood,
@@ -21924,8 +23682,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/sewer)
 "fUT" = (
-/obj/effect/decal/wallpaper/gold/alt,
-/turf/closed/wall/vampwall/junk/alt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "fUU" = (
 /obj/effect/turf_decal/siding/wood{
@@ -21998,6 +23758,11 @@
 "fVz" = (
 /turf/open/floor/plating/stone,
 /area/vtm/forest)
+"fVO" = (
+/obj/effect/gibspawner/human,
+/obj/item/reagent_containers/food/drinks/meth/cocaine,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer)
 "fVR" = (
 /obj/structure/chair/office,
 /turf/open/floor/plating/parquetry/old,
@@ -22024,6 +23789,12 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/restricted)
+"fWA" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "fWI" = (
 /obj/item/trash/popcorn,
 /turf/open/floor/plating/rough,
@@ -22047,6 +23818,16 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"fXj" = (
+/obj/machinery/light/small/blacklight{
+	pixel_y = 25
+	},
+/obj/effect/decal/graffiti,
+/obj/structure/methlab,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fXn" = (
 /obj/machinery/light/small{
 	dir = 1;
@@ -22081,6 +23862,18 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
+"fXM" = (
+/obj/effect/decal/pallet,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
+"fXO" = (
+/obj/structure/chair/sofa/left,
+/obj/effect/decal/litter,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "fXR" = (
 /obj/structure/rack,
 /obj/machinery/light{
@@ -22506,6 +24299,11 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
+"gdH" = (
+/obj/structure/chair/sofa/left,
+/obj/structure/coclock,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "gdQ" = (
 /obj/machinery/light/prince{
 	dir = 8
@@ -22521,6 +24319,13 @@
 /obj/machinery/microwave,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/setite)
+"geb" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "ged" = (
 /obj/structure/chair/sofa/left{
 	dir = 4
@@ -22682,6 +24487,16 @@
 /mob/living/carbon/human/npc/shop,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
+"ggA" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "ggB" = (
 /obj/effect/turf_decal/siding/white/corner{
 	dir = 1
@@ -22800,6 +24615,12 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/pacificheights/community)
+"ghG" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampbeach,
+/area/vtm/sewer)
 "ghI" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -22890,6 +24711,15 @@
 /obj/item/drinkable_bloodpack/elite,
 /turf/open/floor/carpet/black,
 /area/vtm/interior/millennium_tower/f3)
+"giJ" = (
+/obj/structure/curtain,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = 1
+	},
+/obj/item/soap,
+/turf/open/floor/plating/industrial,
+/area/vtm/interior)
 "giO" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -22964,6 +24794,15 @@
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
+"gjA" = (
+/obj/effect/decal/trash,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gjB" = (
 /obj/structure/table/wood/fancy/purple,
 /obj/item/reagent_containers/food/drinks/beer/vampire,
@@ -23007,6 +24846,11 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"gjY" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "gjZ" = (
 /obj/effect/decal/bordur{
 	dir = 6
@@ -23023,6 +24867,13 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/tzimisce_manor)
+"gkv" = (
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "gkw" = (
 /obj/structure/dresser,
 /turf/open/floor/carpet/black,
@@ -23097,10 +24948,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/strip/elysium)
 "gle" = (
-/obj/structure/chair/wood/wings{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "glg" = (
 /obj/structure/chair/office{
@@ -23204,11 +25055,10 @@
 /turf/open/floor/plating/vampdirt,
 /area/vtm/forest)
 "gmj" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
+/obj/effect/decal/rugs,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rough,
-/area/vtm/interior)
+/area/vtm/sewer/nosferatu_town)
 "gmo" = (
 /obj/effect/turf_decal/siding/wideplating/dark,
 /obj/machinery/light/prince{
@@ -23317,6 +25167,13 @@
 /obj/structure/sign/poster/random,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/gnawer)
+"gnU" = (
+/obj/structure/vampdoor/prison{
+	lock_id = "nosferatu";
+	lockpick_difficulty = 15
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "gnW" = (
 /obj/structure/chair/sofa/corp,
 /obj/effect/landmark/start/harpy,
@@ -23369,6 +25226,17 @@
 /obj/effect/decal/trash,
 /turf/open/floor/carpet,
 /area/vtm/interior/cog/caern)
+"goQ" = (
+/obj/structure/vampdoor/wood{
+	lock_id = "nosferatu";
+	lockpick_difficulty = 8;
+	dir = 8
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "goT" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/concrete,
@@ -23852,6 +25720,25 @@
 /obj/item/lighter,
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f2)
+"guW" = (
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/structure/flora/ausbushes/sparsegrass{
+	icon_state = "lavendergrass_3"
+	},
+/obj/effect/decal/graffiti,
+/obj/structure/closet/crate/large,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "guZ" = (
 /obj/structure/table/abductor{
 	name = "elegant table";
@@ -24000,6 +25887,17 @@
 "gwI" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/sewer)
+"gwK" = (
+/obj/effect/decal/cardboard,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
+"gxc" = (
+/obj/structure/chair/plastic{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "gxj" = (
 /obj/structure/vampdoor/setite{
 	dir = 4
@@ -24168,6 +26066,12 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/vtm/interior/millennium_tower/ventrue)
+"gzN" = (
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gzP" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -24199,6 +26103,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"gAu" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/closet/crate/large,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gAx" = (
 /obj/structure/chair/comfy/brown{
 	dir = 4
@@ -24206,21 +26119,23 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/giovanni)
 "gAA" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/rack/bubway/east,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
 	},
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plating/rough,
 /area/vtm/interior)
 "gAH" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/trujah)
+"gBb" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gBe" = (
 /obj/effect/decal/bordur/corner{
 	dir = 8
@@ -24414,6 +26329,16 @@
 /mob/living/carbon/human/npc/guard,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/giovanni/outside)
+"gCO" = (
+/obj/structure/clothinghanger,
+/obj/effect/decal/trash,
+/obj/machinery/light/small{
+	pixel_y = 32
+	},
+/obj/effect/decal/graffiti,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "gCP" = (
 /obj/structure/table/wood,
 /obj/item/vtm_artifact/rand,
@@ -24479,6 +26404,16 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch/basement)
+"gDu" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = -2
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gDv" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -24503,6 +26438,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
+"gDQ" = (
+/obj/structure/table/wood/bar,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gDZ" = (
 /obj/structure/table/wood/fancy,
 /obj/item/food/cannoli,
@@ -24622,6 +26565,19 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/unionsquare)
+"gFA" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 2
+	},
+/obj/structure/railing{
+	layer = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "gFJ" = (
 /obj/structure/chair/wood/wings{
 	dir = 1
@@ -24634,14 +26590,10 @@
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
 "gFP" = (
-/obj/machinery/light/small{
-	dir = 1
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
 	},
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/area/vtm/sewer)
 "gFW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/parquetry/old,
@@ -24664,6 +26616,18 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/anarch)
+"gGk" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
+"gGl" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "gGt" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -24885,6 +26849,14 @@
 /obj/item/ammo_box/vampire/c44/silver,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower/f4)
+"gIU" = (
+/obj/structure/flora/rock/jungle,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "gJa" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -24926,6 +26898,9 @@
 "gJs" = (
 /turf/closed/wall/vampwall/rich/low/window/reinforced,
 /area/vtm/interior/millennium_tower/f3)
+"gJD" = (
+/turf/open/floor/carpet/green,
+/area/vtm/sewer/nosferatu_town)
 "gJH" = (
 /obj/structure/chair/plastic,
 /turf/open/floor/plating/concrete,
@@ -24957,6 +26932,17 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"gKh" = (
+/obj/item/drinkable_bloodpack/elite,
+/obj/item/drinkable_bloodpack/elite,
+/obj/item/drinkable_bloodpack/elite,
+/obj/item/drinkable_bloodpack/elite,
+/obj/item/drinkable_bloodpack/elite,
+/obj/structure/closet/crate,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gKl" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /mob/living/simple_animal/hostile/ghost/hostile,
@@ -25048,11 +27034,18 @@
 /turf/open/indestructible/necropolis/air,
 /area/vtm/sewer/tzimisce_sanctum)
 "gLM" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = -16
+/obj/structure/table,
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
 	},
-/turf/open/floor/plating/vampcanalplating,
+/obj/effect/decal/litter,
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
 /area/vtm/sewer/nosferatu_town)
 "gLX" = (
 /mob/living/carbon/human/npc/guard,
@@ -25077,6 +27070,23 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/wyrm_corrupted)
+"gMi" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/litter,
+/obj/structure/vamprocks{
+	icon_state = "rock6";
+	pixel_y = 10
+	},
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/turf/open/floor/plating/vampgrass,
+/area/vtm/sewer)
 "gMl" = (
 /obj/effect/decal/bordur{
 	dir = 6
@@ -25131,6 +27141,22 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry)
+"gMM" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
+"gMN" = (
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/decal/asphaltline/alt{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "gMQ" = (
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
@@ -25178,6 +27204,13 @@
 /obj/effect/landmark/start/garou/glade/guardian,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/forest)
+"gNI" = (
+/obj/structure/roadblock,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gNW" = (
 /obj/machinery/light{
 	dir = 4
@@ -25287,6 +27320,15 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/pacificheights/community)
+"gPy" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 10
+	},
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gPG" = (
 /obj/structure/table/wood,
 /obj/vampire_computer,
@@ -25355,6 +27397,16 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampbeach,
 /area/vtm/northbeach)
+"gQq" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
+"gQs" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "gQD" = (
 /obj/machinery/light/small/red{
 	dir = 8;
@@ -25440,6 +27492,13 @@
 /obj/structure/table/wood,
 /turf/closed/wall/vampwall/old/low,
 /area/vtm/interior/techshop)
+"gRl" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_y = 12
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "gRn" = (
 /obj/structure/table/reinforced,
 /obj/item/drinkable_bloodpack/elite,
@@ -25449,6 +27508,15 @@
 /obj/item/drinkable_bloodpack/elite,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/tzimisce_manor)
+"gRp" = (
+/obj/machinery/camera{
+	dir = 8
+	},
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gRq" = (
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/shit/border,
@@ -25535,13 +27603,8 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
 "gSn" = (
-/obj/structure/weedshit,
-/obj/machinery/light/small/pink{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/effect/decal/pallet,
-/turf/open/floor/plating/rough,
+/obj/structure/table/wood,
+/turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer/nosferatu_town)
 "gSo" = (
 /obj/structure/table/wood/fancy,
@@ -25661,6 +27724,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/f3)
+"gTG" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "gTJ" = (
 /obj/effect/decal/wallpaper/stone,
 /turf/closed/wall/vampwall/rich/old,
@@ -25679,11 +27749,27 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/graveyard)
 "gTY" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/structure/chair/stool/bar,
-/turf/open/floor/plating/rough,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/effect/decal/trash,
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
+"gUn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/sidewalk/poor,
 /area/vtm/sewer/nosferatu_town)
 "gUp" = (
 /obj/structure/stairs/north,
@@ -25703,6 +27789,14 @@
 /obj/item/pen/fountain,
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/haven)
+"gUB" = (
+/obj/structure/table{
+	color = "#CD5C5C"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "gUD" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -25881,8 +27975,9 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict)
 "gXe" = (
-/obj/structure/clothinghanger,
-/turf/open/floor/plating/rough,
+/obj/effect/decal/rugs,
+/obj/effect/decal/carpet,
+/turf/open/floor/plating/vampcarpet,
 /area/vtm/interior)
 "gXh" = (
 /obj/item/kirbyplants/random,
@@ -26062,12 +28157,39 @@
 /obj/structure/vampdoor/church,
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/staff)
+"gZz" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "gZB" = (
 /obj/structure/milleniumsign{
 	pixel_y = 32
 	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
+"gZD" = (
+/obj/structure/table,
+/obj/item/modular_computer/laptop,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
+"gZJ" = (
+/obj/structure/closet/crate/large,
+/obj/item/flashlight/lantern{
+	light_color = "#013220";
+	pixel_y = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "gZL" = (
 /obj/effect/decal/wallpaper/gold/alt,
 /turf/closed/wall/vampwall/rich,
@@ -26413,9 +28535,12 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/giovanni/outside)
 "heU" = (
-/obj/structure/table/wood,
-/obj/vampire_computer,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "hfc" = (
 /obj/structure/table,
@@ -26433,9 +28558,22 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
 "hfi" = (
-/obj/item/kirbyplants/random,
-/obj/effect/decal/graffiti,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/decal/trash,
+/obj/structure/vampfence/rich{
+	pixel_x = -16
+	},
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
 /area/vtm/sewer/nosferatu_town)
 "hfl" = (
 /obj/machinery/light/prince{
@@ -26525,11 +28663,12 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
 "hgu" = (
-/obj/structure/vampdoor{
-	dir = 8
+/obj/structure/vampdoor/wood/old{
+	dir = 1;
+	lock_id = "nosferatu"
 	},
-/turf/open/floor/plating/vampcanalplating,
-/area/vtm/sewer/nosferatu_town)
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "hgv" = (
 /obj/effect/decal/coastline{
 	dir = 4
@@ -26541,9 +28680,23 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/park)
+"hgJ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/spray/cleaner,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "hgL" = (
-/obj/structure/chair/plastic,
-/turf/open/floor/plating/rough,
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "hgN" = (
 /obj/effect/decal/bordur{
@@ -26574,6 +28727,11 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
+"hgY" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "hhb" = (
 /obj/effect/decal/shadow{
 	icon_state = "shadow-alt";
@@ -26676,10 +28834,9 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/financialdistrict)
 "hil" = (
-/obj/structure/chair/sofa/right,
-/obj/effect/decal/graffiti,
-/turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/glowshroom,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "hio" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/drinks/bottle/champagne,
@@ -26702,6 +28859,18 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"hiE" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/mineral/equipment_vendor/fastfood/sodavendor{
+	pixel_y = 20
+	},
+/obj/machinery/light/small/pink{
+	dir = 8;
+	pixel_x = 16;
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "hiG" = (
 /obj/item/trash/cheesie,
 /turf/open/indestructible/necropolis/air,
@@ -26780,12 +28949,22 @@
 /turf/open/floor/plating/toilet,
 /area/vtm/clinic/haven)
 "hjE" = (
-/obj/structure/trashbag,
-/obj/structure/trashbag{
-	pixel_x = -9;
-	pixel_y = 8
+/obj/structure/vampdoor/wood/old{
+	dir = 1;
+	lock_id = "nosferatu1";
+	lockpick_difficulty = 6;
+	name = "house-1"
 	},
-/turf/open/floor/plating/rough/cave,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
+"hjI" = (
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "hjS" = (
 /obj/structure/railing,
@@ -26982,6 +29161,18 @@
 /obj/item/newspaper,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
+"hmx" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	icon_state = "mirror_broke";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hmD" = (
 /obj/effect/decal/rugs,
 /turf/open/floor/plating/asphalt,
@@ -27032,6 +29223,19 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/financialdistrict)
+"hnN" = (
+/obj/machinery/microwave{
+	pixel_y = 9
+	},
+/obj/structure/rack/bubway/horizontal,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/interior)
 "hnO" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -27069,6 +29273,14 @@
 "hoA" = (
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/chantry)
+"hoE" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 8;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "hoF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27181,10 +29393,9 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/chantry)
 "hqb" = (
-/obj/structure/table/wood,
-/obj/item/vtm_artifact/rand,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/effect/decal/wallpaper,
+/turf/closed/wall/vampwall/junk/alt,
+/area/vtm/sewer/nosferatu_town)
 "hqc" = (
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk/poor,
@@ -27202,6 +29413,12 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/banu/haven)
+"hqo" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hqt" = (
 /obj/machinery/computer/security{
 	id_tag = "bank";
@@ -27218,15 +29435,13 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/community)
 "hqL" = (
-/obj/structure/railing{
-	dir = 4;
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/obj/structure/railing{
-	pixel_y = -6
-	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
+"hqO" = (
+/obj/structure/table/wood,
+/obj/item/kitchen/knife,
+/obj/item/food/cake/chocolate,
+/turf/closed/wall/vampwall/junk/low,
 /area/vtm/sewer/nosferatu_town)
 "hqU" = (
 /obj/machinery/light/small{
@@ -27258,6 +29473,10 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/techshop)
+"hru" = (
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "hrx" = (
 /obj/structure/curtain/cloth/fancy,
 /turf/closed/wall/vampwall/painted/low/window,
@@ -27350,6 +29569,10 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
+"hsB" = (
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "hsE" = (
 /obj/structure/stairs/north,
 /obj/structure/railing{
@@ -27444,6 +29667,12 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/northbeach)
+"htK" = (
+/obj/structure/chair/sofa/right{
+	dir = 8
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "htL" = (
 /obj/structure/table/wood/fancy,
 /obj/item/ammo_box/magazine/vampthompson,
@@ -27658,6 +29887,22 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/banu/haven)
+"hxd" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
+"hxh" = (
+/obj/structure/table/wood,
+/obj/machinery/mineral/equipment_vendor/fastfood/costumes,
+/turf/closed/wall/vampwall/junk/alt/low,
+/area/vtm/sewer/nosferatu_town)
+"hxn" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "hxQ" = (
 /turf/open/floor/carpet/black,
 /area/vtm/interior/laundromat)
@@ -27677,14 +29922,18 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights/community)
 "hyt" = (
-/obj/structure/chair/greyscale{
-	dir = 8
+/obj/structure/rack,
+/obj/item/bailer,
+/obj/item/weedseed,
+/obj/item/weedseed,
+/obj/item/weedseed,
+/obj/item/weedseed,
+/obj/item/weedseed,
+/obj/item/weedseed,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
 	},
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "hyJ" = (
 /obj/structure/chair/stool/bar,
@@ -27729,6 +29978,11 @@
 	},
 /turf/closed/wall/vampwall/metal/glass,
 /area/vtm/interior/millennium_tower/f3)
+"hzb" = (
+/obj/structure/closet,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "hzi" = (
 /obj/structure/aquarium,
 /turf/open/floor/carpet/black,
@@ -27741,6 +29995,10 @@
 "hzq" = (
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower/ventrue)
+"hzy" = (
+/obj/machinery/light/small/red,
+/turf/closed/wall/vampwall/junk/alt,
+/area/vtm/sewer/nosferatu_town)
 "hzG" = (
 /obj/structure/stairs/west,
 /obj/structure/railing,
@@ -27806,13 +30064,14 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/community)
 "hBd" = (
-/obj/structure/mirror{
-	pixel_y = 32
+/obj/effect/decal/litter,
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp{
+	pixel_y = 13;
+	pixel_x = -11
 	},
-/obj/structure/sink{
-	pixel_y = 16
-	},
-/turf/open/floor/plating/vampcanalplating,
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/rough,
 /area/vtm/interior)
 "hBt" = (
 /turf/closed/wall/vampwall/market/low/window,
@@ -27852,6 +30111,13 @@
 /obj/structure/roadblock,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/supply)
+"hBQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "hBR" = (
 /obj/machinery/light{
 	dir = 4
@@ -27943,6 +30209,14 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"hCT" = (
+/obj/structure/chair/greyscale{
+	dir = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hCW" = (
 /obj/structure/rack,
 /obj/item/assembly/infra,
@@ -28030,12 +30304,11 @@
 /turf/closed/wall/vampwall/rich/low,
 /area/vtm/interior/millennium_tower/f2)
 "hDF" = (
-/obj/machinery/shower{
-	dir = 4
+/obj/structure/vampfence/rich{
+	pixel_x = -16
 	},
-/obj/structure/curtain,
-/turf/open/floor/plating/vampcanalplating,
-/area/vtm/interior)
+/turf/closed/wall/vampwall/junk/alt/low/window,
+/area/vtm/sewer/nosferatu_town)
 "hDG" = (
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
@@ -28134,6 +30407,17 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
+"hEs" = (
+/obj/structure/closet/crate/large,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_nature";
+	layer = 4.2;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hEA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/glass/rag,
@@ -28170,6 +30454,18 @@
 /obj/effect/turf_decal/siding/wideplating/dark,
 /turf/closed/wall/vampwall/rich/low,
 /area/vtm/interior/millennium_tower)
+"hEW" = (
+/obj/effect/decal/bordur,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
+"hFb" = (
+/obj/effect/decal/litter,
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/obj/structure/glowshroom,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "hFe" = (
 /obj/effect/decal/trash{
 	icon_state = "trash7"
@@ -28188,9 +30484,12 @@
 /turf/open/floor/plating/vampwood,
 /area/vtm/interior/police/fed)
 "hFL" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/beer/vampire,
-/turf/open/floor/plating/parquetry/old,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
 /area/vtm/sewer/nosferatu_town)
 "hFR" = (
 /obj/structure/stairs/north,
@@ -28265,12 +30564,33 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/ventrue)
+"hGL" = (
+/obj/structure/barrels{
+	icon_state = "barrels9"
+	},
+/obj/structure/anarchsign,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hGR" = (
 /obj/machinery/light/small/broken{
 	pixel_y = 32
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/setite)
+"hGS" = (
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/obj/item/reagent_containers/glass/bucket,
+/obj/structure/mopbucket,
+/obj/item/mop/cyborg,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hGY" = (
 /obj/machinery/mineral/equipment_vendor/fastfood/illegal,
 /obj/structure/table/wood,
@@ -28294,6 +30614,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
+"hHb" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hHc" = (
 /obj/structure/barrels,
 /turf/open/floor/plating/rough,
@@ -28483,10 +30809,24 @@
 /obj/structure/stairs/north,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/oldchurch)
+"hKk" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/lamppost/sidewalk,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hKl" = (
 /obj/effect/decal/wallpaper,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f2)
+"hKn" = (
+/obj/structure/closet/crate/large,
+/obj/structure/flora/ausbushes/grassybush,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "hKq" = (
 /obj/structure/railing{
 	dir = 4;
@@ -28515,6 +30855,14 @@
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"hKR" = (
+/obj/effect/decal/litter,
+/obj/machinery/light/small{
+	pixel_y = 32
+	},
+/obj/item/kirbyplants/fullysynthetic,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "hLc" = (
 /obj/effect/landmark/npc_spawn_point,
 /turf/open/floor/plating/asphalt,
@@ -28535,6 +30883,18 @@
 /obj/effect/decal/wallpaper/paper/low,
 /turf/closed/wall/vampwall/rich/low/window/reinforced,
 /area/vtm/interior/laundromat)
+"hLt" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
+"hLu" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "hLB" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 6
@@ -28678,11 +31038,14 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch)
 "hNk" = (
-/obj/machinery/light/small{
+/obj/effect/decal/graffiti,
+/obj/structure/chair/sofa/corp/corner{
 	dir = 4;
-	pixel_x = -16
+	color = "#50C878"
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
 /area/vtm/sewer/nosferatu_town)
 "hNp" = (
 /turf/closed/wall/vampwall/junk,
@@ -28831,6 +31194,12 @@
 /obj/item/melee/vampirearms/katana/kosa,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/mansion)
+"hPa" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "hPj" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -28863,11 +31232,9 @@
 /turf/closed/wall/vampwall,
 /area/vtm/pacificheights/forest)
 "hQm" = (
-/obj/effect/decal/pallet{
-	pixel_x = -3;
-	pixel_y = 17
-	},
-/turf/open/floor/plating/shit,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "hQn" = (
 /obj/structure/railing{
@@ -28896,10 +31263,13 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/ventrue)
 "hQo" = (
-/obj/structure/railing{
-	pixel_y = -10
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
 	},
-/turf/open/floor/plating/rough/cave,
+/obj/structure/table/wood,
+/obj/effect/decal/litter,
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "hQs" = (
 /obj/machinery/light/small/pink{
@@ -28912,10 +31282,9 @@
 /turf/closed/wall/vampwall/rich/old/low/window,
 /area/vtm/interior/strip)
 "hQw" = (
-/obj/structure/table/wood,
-/obj/machinery/mineral/equipment_vendor/fastfood/costumes,
-/turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/sign/warning,
+/turf/closed/wall/vampwall/rock,
+/area/vtm/sewer)
 "hQQ" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 1
@@ -28948,6 +31317,12 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"hRd" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "hRf" = (
 /obj/effect/decal/cardboard,
 /obj/effect/decal/trash,
@@ -29153,6 +31528,10 @@
 	},
 /turf/open/floor/plating/shit,
 /area/vtm/sewer)
+"hTH" = (
+/obj/fusebox,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "hTO" = (
 /obj/item/stack/rods,
 /turf/open/floor/plating/sidewalk/poor,
@@ -29183,6 +31562,10 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/vtm/hotel)
+"hUd" = (
+/obj/effect/decal/wallpaper/grey/low,
+/turf/closed/wall/vampwall/junk/alt/low/window,
+/area/vtm/sewer/nosferatu_town)
 "hUg" = (
 /obj/vampire_car/retro/rand/clinic{
 	access = "director"
@@ -29269,6 +31652,13 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/cog/pantry)
+"hVh" = (
+/obj/effect/decal/trash,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "hVs" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -29356,6 +31746,17 @@
 	},
 /turf/open/floor/plating/circled,
 /area/vtm/interior/wyrm_corrupted)
+"hWF" = (
+/obj/structure/railing{
+	dir = 4;
+	layer = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "hWR" = (
 /obj/structure/railing{
 	dir = 8
@@ -29384,6 +31785,9 @@
 /obj/structure/coclock,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"hXj" = (
+/turf/closed/wall/vampwall/junk/alt,
+/area/vtm/sewer)
 "hXl" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -29406,6 +31810,26 @@
 /obj/keypad/armory,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f4)
+"hXq" = (
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
+"hXz" = (
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/structure/holohoop{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "hXC" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -29571,6 +31995,13 @@
 /obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/laundromat)
+"hZl" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "hZC" = (
 /obj/structure/railing{
 	layer = 4;
@@ -29592,6 +32023,12 @@
 	},
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/tzimisce_manor)
+"hZN" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "hZO" = (
 /obj/effect/decal/trash,
 /turf/open/floor/plating/rough/cave,
@@ -29610,6 +32047,16 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/financialdistrict/library)
+"iaq" = (
+/obj/effect/decal/graffiti,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "ias" = (
 /obj/machinery/light/prince{
 	pixel_y = 32;
@@ -29649,6 +32096,42 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/tzimisce_manor)
+"iaP" = (
+/obj/structure/table,
+/obj/item/vamp/keys/police{
+	accesslocks = list("nosferatu3");
+	name = "nosferatu house-3"
+	},
+/obj/item/vamp/keys/police{
+	accesslocks = list("nosferatu3");
+	name = "nosferatu house-3"
+	},
+/obj/item/vamp/keys/police{
+	accesslocks = list("nosferatu2");
+	name = "nosferatu house-2"
+	},
+/obj/item/vamp/keys/police{
+	accesslocks = list("nosferatu2");
+	name = "nosferatu house-2"
+	},
+/obj/item/vamp/keys/police{
+	accesslocks = list("nosferatu1");
+	name = "nosferatu house-1"
+	},
+/obj/item/vamp/keys/police{
+	accesslocks = list("nosferatu1");
+	name = "nosferatu house-1"
+	},
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
+"iaQ" = (
+/obj/structure/table/wood,
+/obj/item/modular_computer/laptop,
+/turf/closed/wall/vampwall/junk/low,
+/area/vtm/sewer/nosferatu_town)
 "iaR" = (
 /obj/item/clothing/head/cone,
 /turf/open/floor/plating/concrete,
@@ -29663,11 +32146,11 @@
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/strip)
 "iaW" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
 	},
-/turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "iba" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 5
@@ -29709,6 +32192,11 @@
 	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/museum)
+"ibp" = (
+/obj/effect/decal/pallet,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "ibv" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/parquetry/old,
@@ -29751,6 +32239,16 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"ibU" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "icg" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/plating/concrete,
@@ -29795,9 +32293,10 @@
 /area/vtm/interior/endron_facility/restricted)
 "icG" = (
 /obj/effect/decal/bordur,
-/obj/effect/decal/wallpaper/paper/stripe,
-/turf/closed/wall/vampwall/junk,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/vampdoor/wood/apartment,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/interior)
 "icL" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -29865,6 +32364,15 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/financialdistrict/construction)
+"idr" = (
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "ids" = (
 /obj/effect/decal/bordur{
 	dir = 9
@@ -30089,6 +32597,15 @@
 /obj/elevator_door/start_closed,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f5)
+"iha" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 5;
+	pixel_x = -14
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "ihd" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plating/vampgrass,
@@ -30158,6 +32675,14 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/chantry)
+"ihV" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/flora/rock/jungle,
+/obj/machinery/light/small/blacklight{
+	pixel_y = 25
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "iih" = (
 /obj/structure/chair/greyscale{
 	dir = 8
@@ -30243,6 +32768,14 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/setite/basement)
+"iiW" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 1;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "ijj" = (
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f3)
@@ -30443,6 +32976,15 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/police/fed)
+"imW" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 2
+	},
+/obj/structure/railing,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "ind" = (
 /obj/structure/barrels{
 	icon_state = "barrel5"
@@ -30483,6 +33025,13 @@
 /mob/living/carbon/human/npc/walkby,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/construction)
+"ioc" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "iof" = (
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/junk/alt,
@@ -30546,9 +33095,11 @@
 /turf/closed/wall/vampwall/brick/low,
 /area/vtm/interior/cog/pantry)
 "ioV" = (
-/obj/structure/closet,
-/obj/item/vamp/keys/nosferatu,
-/turf/open/floor/plating/parquetry/old,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer/nosferatu_town)
 "ipn" = (
 /obj/machinery/light/small/red{
@@ -30611,6 +33162,13 @@
 	},
 /turf/open/floor/plating/vampwood,
 /area/vtm/interior/tzimisce_manor)
+"ipz" = (
+/obj/structure/closet,
+/obj/item/clothing/mask/vampire/balaclava,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "ipA" = (
 /obj/machinery/door/poddoor/shutters{
 	damage_deflection = 50;
@@ -30641,6 +33199,14 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/fishermanswharf/lower)
+"ipQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/trash,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "ipX" = (
 /obj/effect/vip_barrier/elysium_2,
 /turf/closed/wall/vampwall/rich/low/window,
@@ -30673,6 +33239,16 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/sewer)
+"iqh" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/vampdoor/wood/old{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "iqn" = (
 /obj/structure/curtain/bounty,
 /turf/closed/wall/vampwall/rich/low/window,
@@ -30700,6 +33276,14 @@
 /obj/structure/chair/wood/wings,
 /turf/open/floor/carpet/royalblue,
 /area/vtm/interior/tzimisce_manor)
+"iqO" = (
+/obj/structure/coclock,
+/obj/structure/table,
+/obj/item/paper_bin,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "iqY" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/light/small{
@@ -30911,11 +33495,16 @@
 /turf/open/floor/plating/vampwood,
 /area/vtm/forest)
 "iub" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/vampipe{
+	icon_state = "piping3";
 	pixel_y = 32
 	},
-/obj/structure/chair/sofa/right,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
 /area/vtm/sewer/nosferatu_town)
 "iuc" = (
 /obj/structure/table/wood/poker,
@@ -30952,6 +33541,14 @@
 "iuE" = (
 /obj/structure/chair/wood,
 /turf/open/floor/plating/parquetry/old,
+/area/vtm/sewer)
+"iuI" = (
+/obj/structure/vampipe{
+	icon_state = "piping40"
+	},
+/obj/effect/decal/trash,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/sewer)
 "iuJ" = (
 /obj/effect/turf_decal/siding/white{
@@ -31055,8 +33652,19 @@
 /obj/effect/decal/wallpaper/paper/rich,
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower)
+"ivO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "ivT" = (
-/obj/structure/coclock,
+/obj/structure/table/wood,
+/obj/item/weedpack,
+/obj/machinery/light/small/blacklight{
+	pixel_y = 25
+	},
 /turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "iwd" = (
@@ -31083,6 +33691,13 @@
 /obj/effect/decal/garou_glyph/caern,
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer)
+"iwH" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "iwJ" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -31180,6 +33795,19 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/interior/glasswalker)
+"ixS" = (
+/obj/item/kirbyplants/random,
+/obj/effect/decal/litter,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "ixY" = (
 /obj/structure/window/reinforced/indestructable,
 /obj/structure/window/reinforced/indestructable{
@@ -31228,6 +33856,11 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
+"iyw" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "iyV" = (
 /obj/effect/decal/bordur{
 	dir = 6
@@ -31423,11 +34056,12 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/mansion)
 "iBO" = (
-/obj/structure/railing{
-	dir = 10;
-	pixel_y = -9
+/obj/effect/decal/bordur{
+	dir = 1
 	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
 /area/vtm/sewer/nosferatu_town)
 "iBX" = (
 /obj/effect/turf_decal/siding/wood{
@@ -31445,6 +34079,11 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/pacificheights/forest)
+"iCc" = (
+/turf/closed/wall/vampwall/rock{
+	density = 0
+	},
+/area/vtm/sewer/nosferatu_town)
 "iCd" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -31528,6 +34167,17 @@
 /obj/structure/vampdoor/wood,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"iCR" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/decal/graffiti,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "iCT" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plating/parquetry/old,
@@ -31537,11 +34187,9 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/hotel)
 "iDb" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/plating/vampcanalplating,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "iDe" = (
 /turf/open/water,
 /area/vtm/forest)
@@ -31646,6 +34294,13 @@
 	},
 /turf/open/floor/plating/vampcanal,
 /area/vtm/sewer)
+"iEv" = (
+/obj/effect/decal/trash,
+/obj/machinery/camera{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "iEC" = (
 /obj/structure/rack,
 /obj/item/ammo_box/magazine/glock9mm,
@@ -31686,6 +34341,10 @@
 "iEV" = (
 /turf/open/floor/plating/vampdirt,
 /area/vtm/northbeach)
+"iFa" = (
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "iFf" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/vampplating,
@@ -31736,6 +34395,17 @@
 /obj/structure/table/wood,
 /turf/closed/wall/vampwall/junk/alt/low,
 /area/vtm/interior/setite)
+"iFD" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/old{
+	dir = 1;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "iFJ" = (
 /obj/effect/decal/bordur{
 	dir = 9
@@ -31805,6 +34475,14 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf/lower)
+"iGX" = (
+/obj/effect/decal/bordur/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer/nosferatu_town)
 "iHc" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rough,
@@ -31964,6 +34642,12 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/jazzclub)
+"iIK" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "iIL" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -31978,19 +34662,12 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "iIW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
 /obj/effect/decal/trash,
-/obj/structure/clothingrack/rand{
-	dir = 1
-	},
-/obj/structure/trashbag{
-	pixel_x = -9;
-	pixel_y = 8
-	},
-/obj/machinery/light/small/red{
-	dir = 8;
-	pixel_x = 16
-	},
-/turf/open/floor/plating/rough,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "iIY" = (
 /obj/structure/table/wood,
@@ -32100,6 +34777,18 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/trujah)
+"iKz" = (
+/obj/structure/vampdoor/reinf{
+	lock_id = "primNosferatu";
+	locked = 1;
+	lockpick_difficulty = 16;
+	name = "primogen hideout";
+	dir = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "iKD" = (
 /obj/manholedown{
 	icon_state = "ladder"
@@ -32161,11 +34850,10 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/sewer)
 "iMh" = (
-/obj/structure/sign/barsign{
-	pixel_y = 32
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
 	},
-/turf/open/floor/plating/rough/cave,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "iMn" = (
 /obj/structure/vampstatue/cloaked,
 /turf/open/floor/plating/parquetry/rich,
@@ -32334,6 +35022,12 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/financialdistrict)
+"iOP" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "iOS" = (
 /obj/item/kirbyplants/random,
 /obj/machinery/light{
@@ -32351,6 +35045,12 @@
 /obj/structure/flora/ausbushes/grassybush,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"iPd" = (
+/obj/structure/chair/plastic{
+	dir = 1
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "iPg" = (
 /obj/effect/decal/stock{
 	dir = 1
@@ -32422,6 +35122,9 @@
 /obj/structure/vamptree/pine,
 /turf/open/floor/plating/vampgrass,
 /area/vtm)
+"iQn" = (
+/turf/open/floor/plating/dirt/jungle,
+/area/vtm/sewer/nosferatu_town)
 "iQq" = (
 /turf/open/floor/plasteel/stairs/medium,
 /area/vtm/interior/millennium_tower)
@@ -32723,6 +35426,13 @@
 "iTZ" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
+"iUa" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "iUf" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -32773,6 +35483,13 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/anarch)
+"iUI" = (
+/obj/effect/decal/trash,
+/obj/effect/decal/trash,
+/turf/closed/wall/vampwall/rock{
+	density = 0
+	},
+/area/vtm/sewer)
 "iUJ" = (
 /obj/effect/decal/wallpaper/paper/rich,
 /obj/effect/decal/wallpaper/paper/rich,
@@ -32891,6 +35608,16 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower)
+"iWn" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/pallet,
+/obj/structure/bed/maint,
+/obj/structure/bed/maint{
+	pixel_y = 2
+	},
+/obj/item/bedsheet/ian,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "iWo" = (
 /obj/structure/chair/plastic{
 	dir = 4
@@ -32914,10 +35641,12 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "iWE" = (
-/obj/structure/vampdoor/reinf{
-	dir = 8
+/obj/structure/pole{
+	pixel_y = 16
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
 /area/vtm/sewer/nosferatu_town)
 "iWF" = (
 /obj/structure/fire_barrel,
@@ -32967,6 +35696,9 @@
 /obj/item/cigbutt,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/gnawer)
+"iXh" = (
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "iXi" = (
 /obj/structure/fluff/hedge,
 /turf/open/floor/plating/vampplating,
@@ -33116,6 +35848,14 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/techshop)
+"iZx" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "iZy" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/vampdoor/glass,
@@ -33277,6 +36017,17 @@
 /obj/item/trash/chips,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"jbG" = (
+/obj/structure/flora/junglebush/c,
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "jbK" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/saint,
@@ -33471,6 +36222,13 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/ghetto)
+"jeX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/railing,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "jfg" = (
 /obj/structure/table/wood/fancy/red,
 /obj/item/ammo_casing/caseless/bolt,
@@ -33649,6 +36407,16 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
+"jiI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "jiN" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -33752,6 +36520,13 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/fishermanswharf)
+"jjS" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jjV" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/space)
@@ -34152,12 +36927,10 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/graveyard)
 "joI" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/parquetry/old,
-/area/vtm/sewer/nosferatu_town)
+/obj/structure/flora/junglebush,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "joK" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 10
@@ -34192,6 +36965,12 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/construction)
+"jpk" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "jps" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -34259,12 +37038,10 @@
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/techshop)
 "jqn" = (
-/obj/structure/chair/wood{
-	dir = 4;
-	pixel_y = 4
-	},
+/obj/structure/fireplace,
+/obj/structure/fireplace,
 /turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "jqo" = (
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/plating/parquetry,
@@ -34287,18 +37064,23 @@
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/vampcanal,
 /area/vtm/interior/strip)
+"jqC" = (
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/obj/item/chair/plastic,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "jqR" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
 "jqU" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = -16
-	},
-/obj/structure/table/wood,
+/obj/structure/coclock,
+/obj/structure/table/wood/poker,
+/obj/effect/decal/rugs,
 /turf/open/floor/plating/rough,
-/area/vtm/interior)
+/area/vtm/sewer/nosferatu_town)
 "jqW" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -34326,16 +37108,13 @@
 /turf/open/floor/plating/roofwalk/cobblestones,
 /area/vtm/jazzclub)
 "jrx" = (
-/obj/structure/trashbag,
-/obj/structure/trashbag{
-	pixel_x = -5;
-	pixel_y = -13
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/trash,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
 	},
-/obj/structure/trashbag{
-	pixel_x = -7;
-	pixel_y = 9
-	},
-/turf/open/floor/plating/rough/cave,
+/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "jry" = (
 /obj/machinery/photocopier,
@@ -34366,6 +37145,16 @@
 "jse" = (
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/giovanni/basement)
+"jsf" = (
+/obj/effect/decal/trash,
+/obj/structure/vampipe{
+	icon_state = "piping6";
+	pixel_y = 32
+	},
+/obj/structure/flora/junglebush/large,
+/obj/machinery/camera,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "jsk" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry/old,
@@ -34381,6 +37170,11 @@
 /obj/item/reagent_containers/food/drinks/meth/cocaine,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
+"jss" = (
+/obj/effect/decal/graffiti,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "jsv" = (
 /obj/effect/decal/bordur,
 /obj/effect/decal/litter,
@@ -34422,9 +37216,10 @@
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/techshop)
 "jsH" = (
-/obj/structure/toilet,
-/mob/living/carbon/human/npc/shop,
-/turf/open/floor/plating/rough,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "jsR" = (
 /obj/structure/mirror{
@@ -34448,6 +37243,14 @@
 /obj/item/lighter/greyscale,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/police/upstairs)
+"jsY" = (
+/obj/effect/decal/bordur{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jsZ" = (
 /obj/item/cigbutt,
 /turf/open/floor/plating/rough/cave,
@@ -34456,6 +37259,16 @@
 /obj/effect/decal/cleanable/blood/drip,
 /turf/closed/wall/vampwall/rock,
 /area/vtm/graveyard)
+"jtj" = (
+/obj/effect/decal/trash,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jtr" = (
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/sidewalk/poor,
@@ -34525,6 +37338,10 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/banu/haven)
+"jtT" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "jtU" = (
 /obj/machinery/light{
 	pixel_y = 32
@@ -34679,6 +37496,17 @@
 "jvr" = (
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior/endron_facility/forest)
+"jvA" = (
+/obj/structure/table,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_off";
+	pixel_y = 13
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jvG" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt{
@@ -34751,6 +37579,17 @@
 /obj/effect/decal/wallpaper/gold,
 /turf/closed/wall/vampwall/rich/low/window,
 /area/vtm/interior/millennium_tower/ventrue)
+"jwI" = (
+/obj/structure/vampdoor/old{
+	dir = 8;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "jwO" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/effect/turf_decal/weather/dirt{
@@ -34819,11 +37658,10 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/financialdistrict)
 "jxW" = (
-/obj/structure/rack,
-/obj/item/weedseed,
-/obj/item/weedseed,
-/obj/item/weedseed,
-/turf/open/floor/plating/rough,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
 /area/vtm/sewer/nosferatu_town)
 "jxY" = (
 /obj/effect/turf_decal/siding/white{
@@ -34892,6 +37730,18 @@
 /obj/structure/stairs/east,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/strip)
+"jza" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "jzb" = (
 /obj/manholeup,
 /obj/machinery/light/small{
@@ -34903,6 +37753,14 @@
 	},
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer)
+"jzd" = (
+/obj/effect/decal/cardboard,
+/obj/structure/vampipe{
+	icon_state = "piping3";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "jzn" = (
 /obj/machinery/light{
 	dir = 1
@@ -34928,6 +37786,15 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/laundromat)
+"jzH" = (
+/obj/effect/decal/bordur,
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jzU" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 4
@@ -35250,6 +38117,9 @@
 /obj/item/fishing_rod,
 /turf/open/floor/plating/sandy_dirt,
 /area/vtm/forest)
+"jDh" = (
+/turf/open/floor/plating/vampbeach,
+/area/vtm/sewer)
 "jDB" = (
 /obj/structure/stairs/north,
 /turf/open/floor/plating/vampplating,
@@ -35258,6 +38128,16 @@
 /obj/structure/table,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/pacificheights/community)
+"jDK" = (
+/obj/structure/dresser,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/item/storage/book/bible,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jDL" = (
 /obj/effect/decal/bordur/corner{
 	dir = 8
@@ -35498,6 +38378,10 @@
 /obj/item/melee/vampirearms/fireaxe,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/forest)
+"jHs" = (
+/obj/structure/railing,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "jHu" = (
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/f2)
@@ -35555,10 +38439,42 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/church)
+"jIF" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
+"jIG" = (
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jIL" = (
 /obj/structure/table/wood/fancy/black,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/oldchurch)
+"jIO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/vampipe{
+	icon_state = "piping38"
+	},
+/obj/effect/decal/trash,
+/obj/structure/vampdoor/old{
+	dir = 1;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = 5467;
+	max_integrity = 3500;
+	name = "Warrens"
+	},
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "jIZ" = (
 /obj/structure/vampdoor/glass/clinic{
 	dir = 4;
@@ -35745,6 +38661,28 @@
 	},
 /turf/open/floor/plating/vampwood,
 /area/vtm)
+"jLG" = (
+/obj/structure/table/wood/bar,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/effect/decal/trash{
+	icon_state = "trash7"
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jLL" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -35860,6 +38798,14 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/pacificheights/forest)
+"jNk" = (
+/obj/structure/barricade/wooden/crude,
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/trimline/yellow/filled/warning,
+/obj/structure/sign/warning,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "jNl" = (
 /obj/effect/decal/cardboard,
 /turf/closed/wall/vampwall/painted,
@@ -35928,6 +38874,13 @@
 /obj/item/reagent_containers/food/drinks/beer/vampire/blue_stripe,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/wyrm_corrupted)
+"jOg" = (
+/obj/effect/decal/graffiti,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "jOh" = (
 /obj/item/bouquet/poppy,
 /turf/open/floor/plating/vampdirt,
@@ -36008,6 +38961,14 @@
 "jPo" = (
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/financialdistrict/construction)
+"jPs" = (
+/obj/structure/bloodextractor,
+/obj/structure/coclock,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jPw" = (
 /obj/structure/table,
 /obj/structure/table/wood,
@@ -36074,6 +39035,14 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/staff)
+"jQm" = (
+/obj/effect/decal/trash,
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "jQp" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -36305,6 +39274,14 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/ghetto)
+"jTi" = (
+/obj/structure/chair/sofa{
+	dir = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jTk" = (
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/chinatown)
@@ -36339,8 +39316,9 @@
 /turf/open/floor/plating/vampdirt,
 /area/vtm/pacificheights)
 "jTE" = (
-/obj/effect/decal/wallpaper/light,
-/turf/closed/wall/vampwall/junk,
+/obj/structure/table/wood,
+/obj/vampire_computer,
+/turf/open/floor/plating/rough,
 /area/vtm/interior)
 "jTG" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -36462,11 +39440,32 @@
 	},
 /turf/open/floor/plating/circled,
 /area/vtm/interior/wyrm_corrupted)
+"jVv" = (
+/obj/item/vtm_artifact/rand,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/vampbeach,
+/area/vtm/sewer)
 "jVA" = (
-/obj/machinery/light/small{
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/structure/vampipe{
+	icon_state = "piping5";
 	pixel_y = 32
 	},
-/turf/open/floor/plating/rough,
+/obj/structure/barrels{
+	icon_state = "barrels9"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
 /area/vtm/sewer/nosferatu_town)
 "jVD" = (
 /obj/structure/vampipe{
@@ -36488,6 +39487,11 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/construction)
+"jVO" = (
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jVY" = (
 /obj/manholedown,
 /turf/open/floor/plating/sidewalk,
@@ -36596,8 +39600,14 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
 "jXo" = (
-/obj/structure/curtain/cloth,
-/turf/closed/wall/vampwall/junk/alt/low/window,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/obj/effect/decal/litter,
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "jXv" = (
 /turf/open/floor/carpet/royalblack,
@@ -36684,9 +39694,9 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/chantry)
 "jYo" = (
-/obj/effect/decal/wallpaper/light,
+/obj/effect/decal/wallpaper/paper/green,
 /turf/closed/wall/vampwall/junk,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "jYC" = (
 /obj/effect/decal/wallpaper/red/low,
 /obj/effect/decal/wallpaper/red/low,
@@ -36762,6 +39772,10 @@
 /obj/order4,
 /turf/closed/wall/vampwall/bar,
 /area/vtm/interior/shop)
+"jZz" = (
+/obj/structure/table,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "jZA" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -36777,6 +39791,11 @@
 /obj/structure/methlab,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"jZK" = (
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "jZR" = (
 /obj/structure/fuelstation,
 /obj/effect/decal/bordur{
@@ -36891,6 +39910,10 @@
 /obj/structure/vampfence,
 /turf/open/floor/plating/concrete,
 /area/vtm/supply)
+"kbB" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/plating/industrial,
+/area/vtm/interior)
 "kbD" = (
 /obj/structure/railing{
 	dir = 8
@@ -36981,6 +40004,13 @@
 /obj/item/weedseed,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/cog/caern)
+"kcM" = (
+/obj/effect/decal/pallet{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/woodfancy,
+/area/vtm/sewer/nosferatu_town)
 "kcP" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/open/floor/plating/vampdirt,
@@ -37246,6 +40276,17 @@
 /obj/structure/trashbag,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto/old)
+"kgp" = (
+/obj/structure/table/wood/bar,
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "kgu" = (
 /turf/open/floor/plating/circled,
 /area/vtm/interior/laundromat)
@@ -37732,6 +40773,13 @@
 /obj/structure/roadsign/warningpedestrian,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/park)
+"knT" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "knW" = (
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
@@ -37755,6 +40803,14 @@
 /obj/manholedown,
 /turf/open/floor/plating,
 /area/vtm/interior)
+"kox" = (
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "koz" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer/vampire,
@@ -37847,8 +40903,14 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
 "kpW" = (
-/obj/effect/decal/graffiti,
-/turf/open/floor/plating/rough,
+/obj/structure/table/wood,
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
 /area/vtm/sewer/nosferatu_town)
 "kqf" = (
 /obj/effect/landmark/npcwall,
@@ -37905,6 +40967,14 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/northbeach)
+"kqY" = (
+/obj/structure/flora/junglebush,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "kri" = (
 /obj/structure/railing{
 	dir = 8;
@@ -37952,6 +41022,13 @@
 	},
 /turf/open/floor/plating/vampwood,
 /area/vtm/pacificheights/forest)
+"krB" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "krG" = (
 /turf/closed/wall/vampwall/rich/low/window/reinforced,
 /area/vtm/interior/strip/elysium)
@@ -38030,14 +41107,10 @@
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
 "ksB" = (
-/obj/structure/mirror{
-	icon_state = "mirror_broke";
-	pixel_y = 32
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
 	},
-/obj/structure/sink{
-	pixel_y = 16
-	},
-/turf/open/floor/plating/vampcanalplating,
+/turf/open/floor/plating/dirt,
 /area/vtm/sewer/nosferatu_town)
 "ksJ" = (
 /obj/structure/table,
@@ -38174,10 +41247,14 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
 "kvt" = (
-/obj/structure/chair/greyscale{
-	dir = 4
+/obj/machinery/jukebox,
+/obj/machinery/light/small/pink{
+	dir = 8;
+	pixel_x = 16
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
 /area/vtm/sewer/nosferatu_town)
 "kvE" = (
 /obj/structure/dresser,
@@ -38432,6 +41509,12 @@
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/carpet,
 /area/vtm/church/interior/haven)
+"kyX" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "kza" = (
 /turf/open/floor/carpet/purple,
 /area/vtm/jazzclub)
@@ -38712,16 +41795,50 @@
 	color = "#636363"
 	},
 /area/vtm/interior/police/upstairs)
+"kCz" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/interior)
 "kCB" = (
 /obj/vampire_car/track/volkswagen{
 	access = "triad"
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/chinatown)
+"kCC" = (
+/obj/effect/decal/trash,
+/obj/structure/table/wood/bar,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing/yellow,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "kCD" = (
 /obj/structure/vampstatue,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/church/interior/staff)
+"kCH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/large,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
+"kCK" = (
+/obj/structure/vampdoor/simple,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
+/area/vtm/interior)
 "kCM" = (
 /obj/structure/vampdoor/glass/clinic{
 	dir = 4;
@@ -38837,16 +41954,25 @@
 /obj/structure/chair/wood,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
+"kDR" = (
+/obj/effect/decal/pallet{
+	pixel_x = 2;
+	pixel_y = 25
+	},
+/obj/effect/decal/pallet{
+	layer = 2
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "kDU" = (
 /obj/structure/cargo_take,
 /turf/open/floor/plating/concrete,
 /area/vtm/supply)
 "kEc" = (
-/obj/structure/trashbag,
-/obj/structure/trashbag{
-	pixel_x = 11
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
-/obj/effect/decal/graffiti,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/sewer/nosferatu_town)
 "kEi" = (
@@ -38972,6 +42098,12 @@
 	dir = 4
 	},
 /area/vtm)
+"kFI" = (
+/obj/structure/dresser,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "kFJ" = (
 /obj/effect/decal/wallpaper/grey,
 /obj/order1{
@@ -38999,8 +42131,11 @@
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/baali)
 "kFZ" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/plating/rough,
+/obj/machinery/chem_dispenser/drinks/fullupgrade,
+/obj/structure/rack/bubway/horizontal,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
+	},
 /area/vtm/sewer/nosferatu_town)
 "kGa" = (
 /obj/item/kirbyplants/random,
@@ -39030,6 +42165,10 @@
 	density = 0
 	},
 /area/vtm/interior/cog/caern)
+"kGp" = (
+/obj/item/bikehorn/rubberducky,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "kGu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -39112,11 +42251,10 @@
 /turf/open/floor/plating/vampcanal,
 /area/vtm/sewer)
 "kHq" = (
-/obj/structure/railing{
-	dir = 1;
-	pixel_y = 4
+/obj/effect/decal/pallet{
+	layer = 2
 	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/woodrough,
 /area/vtm/sewer/nosferatu_town)
 "kHE" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -39133,6 +42271,16 @@
 /obj/effect/decal/wallpaper/stone/low,
 /turf/closed/wall/vampwall/rich/low/window/reinforced,
 /area/vtm/anarch/basement)
+"kIb" = (
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_nature";
+	layer = 4.2;
+	pixel_y = 12
+	},
+/obj/effect/decal/wallpaper/paper/darkgreen/low,
+/obj/structure/table/wood/bar,
+/turf/closed/wall/vampwall/junk/alt/low,
+/area/vtm/sewer/nosferatu_town)
 "kIc" = (
 /obj/structure/vampfence/corner{
 	dir = 8
@@ -39231,6 +42379,14 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/anarch/basement)
+"kJT" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 8;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "kJZ" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -39268,11 +42424,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/strip/toreador)
 "kKP" = (
-/obj/structure/railing{
-	dir = 4;
-	pixel_x = 2;
-	pixel_y = 3
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
 	},
+/obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "kKQ" = (
@@ -39318,6 +42473,11 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf/lower)
+"kLi" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "kLG" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -39362,10 +42522,9 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
 "kMq" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "kMz" = (
 /obj/vampire_car/rand,
@@ -39498,9 +42657,8 @@
 /turf/open/floor/carpet/purple,
 /area/vtm/hotel)
 "kPe" = (
-/obj/effect/decal/pallet{
-	pixel_x = 4;
-	pixel_y = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
 /turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
@@ -40162,6 +43320,16 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/endron_facility/restricted)
+"kXg" = (
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_y = 4
+	},
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "kXi" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -40211,12 +43379,29 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/clinic)
+"kXS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "kXT" = (
 /obj/effect/decal/bordur{
 	dir = 4
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/financialdistrict/library)
+"kXU" = (
+/obj/structure/closet/crate/freezer/fridge,
+/obj/item/food/breadslice/moldy,
+/obj/item/drinkable_bloodpack,
+/obj/item/drinkable_bloodpack,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/interior)
 "kYb" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -40304,6 +43489,13 @@
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/old)
+"kYJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/item/reagent_containers/food/drinks/beer/vampire,
+/turf/open/floor/plating/stone,
+/area/vtm/sewer)
 "kYQ" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/machinery/light{
@@ -40330,6 +43522,10 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict)
+"kZo" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "kZs" = (
 /obj/structure/railing{
 	dir = 1;
@@ -40452,6 +43648,21 @@
 	},
 /turf/open/floor/bronze,
 /area/vtm/interior/giovanni)
+"laK" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/railing{
+	dir = 8;
+	pixel_x = 2
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "laP" = (
 /obj/structure/chair/pew/left{
 	dir = 1
@@ -40492,6 +43703,10 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/laundromat)
+"lbf" = (
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "lbj" = (
 /obj/effect/decal/bordur,
 /obj/effect/decal/graffiti,
@@ -40524,6 +43739,17 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
+"lbv" = (
+/obj/structure/table,
+/obj/item/vamp/keys/nosferatu,
+/obj/item/vamp/keys/nosferatu,
+/obj/item/vamp/keys/nosferatu,
+/obj/item/vamp/keys/nosferatu,
+/obj/item/vamp/keys/nosferatu,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lbB" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/mineral/equipment_vendor/fastfood/library,
@@ -40559,6 +43785,22 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/gnawer)
+"lbS" = (
+/obj/effect/decal/trash,
+/obj/structure/railing{
+	layer = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/closet/crate/large,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lbV" = (
 /obj/effect/decal/bordur{
 	dir = 10
@@ -40652,6 +43894,10 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/circled,
 /area/vtm/interior/wyrm_corrupted)
+"ldr" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "ldw" = (
 /obj/structure/closet/crate/coffin,
 /obj/effect/decal/cleanable/ash,
@@ -40741,6 +43987,13 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
+"ley" = (
+/obj/structure/bed/pod,
+/obj/item/bedsheet/black,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "leC" = (
 /obj/structure/janitorialcart,
 /obj/item/mop,
@@ -40935,6 +44188,17 @@
 /obj/item/clothing/suit/vampire/noddist,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/trujah)
+"lgV" = (
+/obj/structure/closet/crate/large,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lgW" = (
 /obj/machinery/light/small/pink{
 	pixel_y = 32
@@ -41161,6 +44425,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/ventrue)
+"ljM" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "ljN" = (
 /obj/effect/turf_decal/stripes/white/line{
 	dir = 8
@@ -41168,6 +44438,13 @@
 /obj/effect/decal/cardboard,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"lka" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/sparsegrass{
+	icon_state = "ywflowers_1"
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "lkm" = (
 /obj/structure/vampdoor/children_of_gaia,
 /turf/open/floor/plating/parquetry/old,
@@ -41218,6 +44495,13 @@
 /obj/item/vampire_stake,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"lla" = (
+/obj/effect/decal/bordur,
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "llb" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/parquetry/old,
@@ -41285,6 +44569,15 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/strip/elysium)
+"lmE" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lmH" = (
 /obj/effect/decal/bordur/corner{
 	dir = 4
@@ -41486,6 +44779,12 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/cog/caern)
+"lpt" = (
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "lpS" = (
 /obj/structure/railing{
 	dir = 9;
@@ -41493,6 +44792,16 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"lpU" = (
+/obj/structure/vampdoor/wood/apartment{
+	dir = 8
+	},
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "lpX" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -41578,11 +44887,10 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
 "lrG" = (
-/obj/structure/vampdoor/wood/old{
-	dir = 1;
-	lock_id = "nosferatu"
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "lrI" = (
 /obj/structure/table/reinforced,
@@ -41596,6 +44904,13 @@
 	},
 /turf/open/floor/carpet/stellar,
 /area/vtm/clinic)
+"lrX" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "lrY" = (
 /obj/structure/fluff/hedge,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -41714,6 +45029,16 @@
 /obj/weapon_showcase,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
+"luh" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/effect/decal/trash,
+/obj/structure/railing{
+	layer = 4
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "lum" = (
 /obj/structure/railing{
 	layer = 4;
@@ -41727,6 +45052,13 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"luo" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "luq" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -41847,14 +45179,10 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/supply)
 "lvY" = (
-/obj/structure/vampdoor/old{
-	dir = 1;
-	lock_id = "nosferatu";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "old strange door"
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
 	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "lwc" = (
 /mob/living/simple_animal/pet/cat/vampire,
@@ -41917,6 +45245,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/clinic)
+"lwU" = (
+/obj/structure/holohoop{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
+"lwV" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "lxf" = (
 /obj/vampire_car/police,
 /turf/open/floor/plating/asphalt,
@@ -41929,6 +45270,27 @@
 /obj/structure/stairs/east,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
+"lxw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/vampdoor/old{
+	dir = 8;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = 5467;
+	max_integrity = 3500;
+	name = "Warrens";
+	dir = 8
+	},
+/turf/open/floor/plating/grate{
+	icon_state = "lattice_new_dirt"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lxy" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -42171,6 +45533,17 @@
 /obj/item/lipstick,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/strip)
+"lAD" = (
+/obj/structure/vampdoor/old{
+	dir = 1;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "lAH" = (
 /obj/structure/closet/cabinet,
 /obj/item/clothing/head/vampire/bogatyr,
@@ -42234,6 +45607,11 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/sewer)
+"lBF" = (
+/obj/structure/table/wood,
+/obj/item/vtm_artifact/rand,
+/turf/closed/wall/vampwall/junk/alt/low,
+/area/vtm/interior)
 "lBH" = (
 /obj/effect/landmark/start/zadruga,
 /turf/open/floor/plating/vampdirt,
@@ -42426,6 +45804,14 @@
 /obj/structure/vamptree/pine,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/forest)
+"lEp" = (
+/obj/effect/decal/graffiti,
+/obj/item/kirbyplants/random,
+/obj/machinery/camera{
+	dir = 8
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "lEq" = (
 /obj/structure/vampdoor/glass/clinic{
 	dir = 4;
@@ -42537,6 +45923,17 @@
 "lFi" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/interior)
+"lFs" = (
+/obj/structure/barrels{
+	icon_state = "barrels9"
+	},
+/obj/effect/decal/trash,
+/obj/machinery/light/small/pink{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "lFt" = (
 /obj/structure/vampdoor/camarilla{
 	dir = 4;
@@ -42544,6 +45941,11 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower)
+"lFx" = (
+/obj/structure/table/wood,
+/obj/machinery/mineral/equipment_vendor/fastfood/illegal,
+/turf/closed/wall/vampwall/wood/low,
+/area/vtm/sewer/nosferatu_town)
 "lFD" = (
 /obj/structure/fluff/hedge{
 	pixel_x = 3;
@@ -42563,6 +45965,12 @@
 /obj/item/food/burger/baconburger,
 /turf/closed/wall/vampwall/painted/low,
 /area/vtm/interior/bianchiBank)
+"lFI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "lFK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -42820,9 +46228,14 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/cog/caern)
 "lIB" = (
-/obj/structure/chair/plastic,
-/turf/open/floor/plating/vampdirt,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "lID" = (
 /obj/structure/table,
 /obj/item/stack/medical/suture,
@@ -42834,10 +46247,24 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/graveyard/interior)
+"lII" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "lIL" = (
 /obj/effect/decal/wallpaper/paper/rich,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/strip/toreador)
+"lIM" = (
+/obj/item/kirbyplants/dead,
+/obj/effect/decal/graffiti,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/interior)
 "lIO" = (
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior)
@@ -42847,6 +46274,16 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/cog/pantry)
+"lIY" = (
+/obj/effect/decal/rugs,
+/obj/effect/decal/rugs,
+/obj/structure/chair/office{
+	dir = 1
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lJb" = (
 /obj/structure/vampdoor/glass,
 /turf/open/floor/plating/parquetry/old,
@@ -42893,10 +46330,9 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/sewer/nosferatu_town)
 "lJn" = (
-/obj/matrix{
-	alpha = 0
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
 	},
-/turf/open/space/basic,
 /area/vtm/sewer/nosferatu_town)
 "lJy" = (
 /obj/structure/vampfence/rich,
@@ -42982,6 +46418,10 @@
 	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/sewer)
+"lKQ" = (
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "lKX" = (
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk,
@@ -42996,6 +46436,11 @@
 "lLc" = (
 /turf/closed/wall/vampwall/market/low/window,
 /area/vtm/interior/police/morgue)
+"lLe" = (
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lLf" = (
 /obj/machinery/light/dim{
 	dir = 4
@@ -43040,6 +46485,17 @@
 /obj/effect/decal/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/supply)
+"lLx" = (
+/obj/structure/vampipe{
+	icon_state = "piping6";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "lLE" = (
 /obj/structure/fence/corner{
 	dir = 8
@@ -43066,6 +46522,14 @@
 /obj/machinery/jukebox,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/strip)
+"lLP" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lLY" = (
 /obj/effect/decal/trash{
 	icon_state = "trash7"
@@ -43112,6 +46576,12 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/church/interior/staff)
+"lMH" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "lMJ" = (
 /obj/effect/decal/wallpaper/blue,
 /turf/closed/wall/vampwall/bar,
@@ -43134,6 +46604,16 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/techshop)
+"lMW" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 1;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lMY" = (
 /obj/fusebox,
 /turf/open/floor/plating/vampplating/mono,
@@ -43174,6 +46654,11 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto/old)
+"lNw" = (
+/obj/effect/decal/graffiti,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "lND" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -43368,6 +46853,10 @@
 /obj/item/clothing/head/vampire/bandana/red,
 /turf/open/floor/plating/concrete,
 /area/vtm/anarch)
+"lRr" = (
+/obj/effect/decal/litter,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "lRs" = (
 /obj/effect/decal/cleanable/blood/footprints,
 /turf/closed/wall/vampwall/old,
@@ -43405,11 +46894,12 @@
 /turf/open/floor/carpet/black,
 /area/vtm/interior/millennium_tower/f3)
 "lRF" = (
-/obj/item/fishing_rod,
-/obj/machinery/light/small/pink{
-	pixel_y = 32
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/turf/open/floor/plating/rough/cave,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "lRG" = (
 /obj/structure/chair/comfy/black{
@@ -43435,6 +46925,13 @@
 "lRR" = (
 /turf/open/floor/plating/shit,
 /area/vtm/interior/millennium_tower)
+"lRT" = (
+/obj/effect/decal/bordur,
+/obj/structure/curtain/bounty,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lRU" = (
 /obj/structure/chair/wood/wings{
 	dir = 8
@@ -43528,6 +47025,22 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/cabaret/basement)
+"lTA" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
+"lTF" = (
+/obj/structure/vampipe{
+	icon_state = "piping32"
+	},
+/obj/effect/decal/bordur{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "lTH" = (
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/carpet/green,
@@ -43770,6 +47283,12 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights/community)
+"lWu" = (
+/obj/structure/window/reinforced/indestructable,
+/obj/structure/chair/plastic,
+/mob/living/carbon/human/npc/shop,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "lWx" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/vampire/latex,
@@ -43904,6 +47423,21 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/chantry)
+"lYu" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
+"lYy" = (
+/obj/structure/table/wood,
+/obj/effect/decal/trash,
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "lYC" = (
 /obj/structure/trashbag,
 /turf/open/floor/plating/vampdirt,
@@ -43921,6 +47455,11 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"lYJ" = (
+/obj/effect/decal/graffiti,
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "lYN" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -44030,14 +47569,21 @@
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/gnawer)
 "lZK" = (
-/turf/open/floor/plasteel/stairs{
-	dir = 4
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
 	},
 /area/vtm/sewer/nosferatu_town)
 "lZM" = (
 /obj/structure/firepit,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
+"lZQ" = (
+/obj/item/clothing/head/cone,
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "lZX" = (
 /obj/machinery/light/small/broken{
 	pixel_y = 24
@@ -44099,12 +47645,29 @@
 /obj/structure/flora/ausbushes/brflowers,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"maP" = (
+/obj/structure/table/optable,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "maS" = (
 /obj/machinery/light{
 	pixel_y = 32
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility/forest)
+"maY" = (
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_off";
+	pixel_y = 13
+	},
+/obj/structure/table,
+/obj/structure/showcase/machinery/tv{
+	pixel_y = 29
+	},
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "mbf" = (
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampgrass,
@@ -44128,6 +47691,23 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch)
+"mbs" = (
+/obj/structure/clothingrack/rand{
+	dir = 8
+	},
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
+"mbw" = (
+/obj/structure/closet/cardboard,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "mbV" = (
 /obj/machinery/button/door{
 	pixel_y = 14;
@@ -44176,6 +47756,11 @@
 /obj/structure/vampdoor/wood,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f2)
+"mcH" = (
+/mob/living/simple_animal/pet/cat/vampire,
+/obj/structure/bed/dogbed,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "mcK" = (
 /obj/structure/table/wood,
 /obj/item/weedpack,
@@ -44254,6 +47839,10 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower)
+"mdF" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "mdI" = (
 /obj/vampire_car/track/volkswagen,
 /turf/open/floor/plating/sidewalk/poor,
@@ -44262,6 +47851,14 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/carpet,
 /area/vtm/interior/setite)
+"mdO" = (
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mdQ" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 8
@@ -44308,6 +47905,15 @@
 /obj/item/trash/can,
 /turf/open/floor/plating/rough,
 /area/vtm/anarch/basement)
+"meE" = (
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/effect/decal/trash,
+/obj/structure/closet/crate/large,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "meI" = (
 /obj/effect/decal/graffiti/large,
 /turf/closed/wall/vampwall/metal/reinforced,
@@ -44316,6 +47922,17 @@
 /obj/structure/chair/sofa/corp/left,
 /turf/open/floor/plating/parquetry,
 /area/vtm/clinic)
+"meL" = (
+/obj/effect/decal/pallet,
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	pixel_x = -2;
+	pixel_y = 12
+	},
+/obj/structure/coclock,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "meT" = (
 /obj/structure/railing{
 	dir = 1;
@@ -44455,6 +48072,12 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior)
+"mhg" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mhm" = (
 /obj/structure/statue/bone/rib,
 /turf/open/indestructible/necropolis/air,
@@ -44710,6 +48333,12 @@
 /obj/effect/decal/wallpaper/blue/low,
 /turf/closed/wall/vampwall/market/low,
 /area/vtm/financialdistrict/construction)
+"mkY" = (
+/obj/structure/chair/office,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mlf" = (
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/toilet,
@@ -44840,6 +48469,15 @@
 /obj/vampire_car/retro/rand/camarilla,
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/millennium_tower)
+"mnw" = (
+/obj/structure/table{
+	color = "#CD5C5C"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mnz" = (
 /obj/structure/vampdoor/wood/old{
 	desc = "It give you a mad vibes... Be careful!";
@@ -44852,13 +48490,29 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic/haven)
 "mnA" = (
-/obj/machinery/griddle,
-/turf/open/floor/plating/rough,
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "mnC" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/effect/decal/cardboard,
 /turf/open/floor/plating/vampwood,
+/area/vtm/sewer/nosferatu_town)
+"mnE" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 1;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial5"
+	},
 /area/vtm/sewer/nosferatu_town)
 "mnT" = (
 /obj/item/kirbyplants/random,
@@ -44935,6 +48589,12 @@
 /obj/food_cart,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/chinatown)
+"moT" = (
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/turf/open/floor/plating/industrial,
+/area/vtm/interior)
 "moV" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
 	dir = 8
@@ -44972,6 +48632,16 @@
 /obj/item/clothing/under/pentex/pentex_janitor,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/restricted)
+"mpy" = (
+/obj/structure/closet,
+/obj/structure/coclock,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/obj/item/restraints/legcuffs/beartrap,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "mpz" = (
 /obj/structure/chair/comfy{
 	dir = 4;
@@ -45129,12 +48799,14 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/cog/caern)
 "mrS" = (
-/obj/structure/table/wood,
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = -16
+/obj/structure/chair/plastic{
+	dir = 8;
+	pixel_y = 4
 	},
-/turf/open/floor/plating/rough,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
 /area/vtm/sewer/nosferatu_town)
 "mrW" = (
 /obj/effect/turf_decal/siding/white{
@@ -45156,9 +48828,8 @@
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower)
 "msg" = (
-/obj/structure/table/wood,
-/obj/item/vtm_artifact/rand,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/wallpaper/paper/darkgreen/low,
+/turf/closed/wall/vampwall/junk,
 /area/vtm/sewer/nosferatu_town)
 "msl" = (
 /obj/structure/vampfence/rich{
@@ -45176,6 +48847,30 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/financialdistrict/construction)
+"msE" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/effect/decal/cardboard,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/sidewalk/old,
+/area/vtm/sewer/nosferatu_town)
+"msL" = (
+/obj/effect/decal/bordur/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer/nosferatu_town)
+"msO" = (
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "msU" = (
 /obj/machinery/light{
 	dir = 8
@@ -45391,6 +49086,17 @@
 "mvp" = (
 /turf/closed/wall/vampwall/rich,
 /area/vtm)
+"mvr" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 10;
+	layer = 4.3
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "mvM" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/vampgrass,
@@ -45576,6 +49282,10 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"mxJ" = (
+/obj/machinery/camera/directional/east,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "mxK" = (
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalkalt,
@@ -45595,6 +49305,15 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"myh" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/junglebush/large,
+/obj/structure/railing,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "myl" = (
 /obj/effect/decal/shadow,
 /turf/open/floor/plating/granite/black,
@@ -45748,6 +49467,11 @@
 /obj/structure/cargo_put,
 /turf/open/floor/plating/rough,
 /area/vtm/supply)
+"mzz" = (
+/obj/effect/decal/wallpaper/paper/low,
+/obj/structure/sign/poster/contraband/dmc,
+/turf/closed/wall/vampwall/junk,
+/area/vtm/sewer/nosferatu_town)
 "mzA" = (
 /obj/structure/table/wood,
 /turf/open/floor/carpet,
@@ -45873,6 +49597,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/setite/basement)
+"mBO" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/effect/decal/cardboard,
+/turf/open/floor/plating/sidewalk/old,
+/area/vtm/sewer/nosferatu_town)
 "mBV" = (
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalkalt,
@@ -45934,6 +49665,17 @@
 "mCW" = (
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/laundromat)
+"mCX" = (
+/obj/effect/decal/pallet,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/decal/trash,
+/obj/structure/railing{
+	dir = 1;
+	layer = 4;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "mDa" = (
 /obj/structure/trashcan,
 /turf/open/floor/plating/sidewalk,
@@ -45989,6 +49731,13 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/fishermanswharf/lower)
+"mDT" = (
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "mDX" = (
 /obj/structure/railing{
 	dir = 1;
@@ -45998,6 +49747,14 @@
 /obj/structure/closet/crate/large,
 /turf/open/floor/plating/vampcanal,
 /area/vtm/interior/glasswalker)
+"mDZ" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mEc" = (
 /obj/structure/big_vamprocks,
 /turf/open/floor/plating/vampgrass,
@@ -46058,10 +49815,10 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "mEO" = (
-/obj/machinery/light/small{
-	pixel_y = 32
+/obj/effect/decal/pallet{
+	layer = 2
 	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/woodfancy,
 /area/vtm/sewer/nosferatu_town)
 "mER" = (
 /obj/machinery/light{
@@ -46266,10 +50023,12 @@
 /turf/open/water,
 /area/vtm/interior/tzimisce_manor)
 "mHr" = (
-/obj/structure/railing{
-	pixel_y = -6
+/obj/structure/table/wood,
+/obj/machinery/button/door{
+	id = 5467;
+	name = "Warrens Gate"
 	},
-/turf/open/floor/plating/shit,
+/turf/closed/wall/vampwall/junk/low,
 /area/vtm/sewer/nosferatu_town)
 "mHs" = (
 /obj/machinery/light{
@@ -46454,6 +50213,12 @@
 /obj/structure/roadsign/crosswalk,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
+"mJo" = (
+/obj/structure/curtain/bounty,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mJt" = (
 /obj/machinery/vending/sustenance{
 	pixel_y = 18
@@ -46643,9 +50408,17 @@
 /turf/open/floor/carpet,
 /area/vtm/hotel)
 "mLG" = (
-/obj/structure/table/wood,
-/obj/vampire_computer,
-/turf/open/floor/carpet/black,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
+"mLN" = (
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
 /area/vtm/sewer/nosferatu_town)
 "mLS" = (
 /obj/effect/decal/bordur{
@@ -46663,6 +50436,13 @@
 /obj/item/ammo_box/magazine/vamp45acp,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/laundromat)
+"mLY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "mMc" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 10
@@ -46724,10 +50504,15 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior)
 "mMW" = (
-/obj/structure/chair/comfy/beige{
-	dir = 1
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
 	},
-/turf/open/floor/plating/parquetry/old,
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/woodfancy,
 /area/vtm/sewer/nosferatu_town)
 "mMZ" = (
 /obj/item/kirbyplants/random,
@@ -46750,6 +50535,14 @@
 	},
 /turf/open/floor/plating/bacotell,
 /area/vtm/clinic/haven)
+"mNn" = (
+/obj/effect/decal/bordur/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mNu" = (
 /obj/structure/vamptree/pine,
 /turf/closed/wall/vampwall/bar,
@@ -46819,6 +50612,12 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"mNY" = (
+/obj/structure/table/wood,
+/obj/structure/closet/mini_fridge,
+/obj/item/reagent_containers/food/condiment/vampiremilk/malk,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "mNZ" = (
 /obj/structure/table/wood,
 /obj/machinery/microwave{
@@ -47048,6 +50847,13 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/jazzclub)
+"mRb" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "mRd" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs,
@@ -47071,6 +50877,12 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"mRp" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mRv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -47079,14 +50891,9 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/supply)
 "mRx" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
+/obj/effect/decal/litter,
 /turf/open/floor/plating/shit,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/sewer)
 "mRz" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light/blacklight{
@@ -47142,6 +50949,12 @@
 /obj/structure/vampstatue,
 /turf/open/water,
 /area/vtm/pacificheights/old)
+"mSo" = (
+/obj/structure/barrels{
+	icon_state = "barrels9"
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "mSq" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/vampgrass,
@@ -47209,6 +51022,14 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/millennium_tower/f3)
+"mSO" = (
+/obj/machinery/telecomms/server,
+/obj/effect/decal/rugs,
+/obj/item/vamp/keys/nosferatu,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mSQ" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -47678,6 +51499,35 @@
 /obj/effect/landmark/start/hound,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower)
+"mYA" = (
+/obj/machinery/vamp/atm{
+	dir = 8;
+	pixel_x = 10
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
+"mYH" = (
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/trashcan{
+	pixel_x = 3;
+	pixel_y = 10
+	},
+/obj/structure/trashbag{
+	pixel_x = -6;
+	pixel_y = -6
+	},
+/obj/effect/decal/cardboard,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "mYL" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green,
@@ -47776,6 +51626,12 @@
 /obj/item/clothing/gloves/boxing/yellow,
 /turf/open/floor/plating/rough,
 /area/vtm/anarch)
+"nan" = (
+/obj/effect/turf_decal/siding/wideplating/dark/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "nao" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -47844,10 +51700,8 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/cabaret/basement)
 "nbr" = (
-/obj/structure/chair/office{
-	dir = 4
-	},
-/turf/open/floor/plating/rough,
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/vampcanalplating,
 /area/vtm/sewer/nosferatu_town)
 "nbs" = (
 /obj/structure/toilet{
@@ -48122,6 +51976,16 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
+"nfG" = (
+/obj/structure/dresser,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nfL" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -48281,6 +52145,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/sewer)
+"nij" = (
+/obj/structure/table/wood,
+/obj/item/trash/plate,
+/obj/effect/decal/carpet,
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "nip" = (
 /turf/closed/wall/vampwall/bar/low/window,
 /area/vtm/interior/oldchurch)
@@ -48300,6 +52171,18 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/tzimisce_manor)
+"niB" = (
+/obj/structure/closet/crate/large,
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "niD" = (
 /obj/effect/decal/bordur,
 /obj/structure/lamppost/sidewalk,
@@ -48415,6 +52298,19 @@
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/supply)
+"nkr" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/machinery/camera{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nkv" = (
 /obj/structure/flora/ausbushes/brflowers,
 /obj/structure/flora/ausbushes/ywflowers,
@@ -48429,6 +52325,11 @@
 	pixel_y = 32
 	},
 /turf/open/floor/plating/vampcanalplating,
+/area/vtm/interior)
+"nkB" = (
+/obj/structure/table/wood,
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/vampcarpet,
 /area/vtm/interior)
 "nkE" = (
 /obj/structure/closet/crate,
@@ -48535,6 +52436,10 @@
 	},
 /turf/open/floor/plating/vampwood,
 /area/vtm/interior/chantry)
+"nmf" = (
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "nmi" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating/parquetry,
@@ -48670,6 +52575,11 @@
 	},
 /obj/structure/bed/dogbed,
 /turf/open/floor/plating/toilet,
+/area/vtm/interior)
+"noc" = (
+/obj/effect/decal/trash,
+/obj/structure/chair/plastic,
+/turf/open/floor/plating/rough,
 /area/vtm/interior)
 "nof" = (
 /obj/effect/decal/wallpaper/light,
@@ -48824,32 +52734,10 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
 "nqS" = (
-/obj/structure/table/wood,
-/obj/item/vamp/keys/police{
-	accesslocks = list("nosferatu1");
-	name = "nosferatu house-1"
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
 	},
-/obj/item/vamp/keys/police{
-	accesslocks = list("nosferatu1");
-	name = "nosferatu house-1"
-	},
-/obj/item/vamp/keys/police{
-	accesslocks = list("nosferatu2");
-	name = "nosferatu house-2"
-	},
-/obj/item/vamp/keys/police{
-	accesslocks = list("nosferatu2");
-	name = "nosferatu house-2"
-	},
-/obj/item/vamp/keys/police{
-	accesslocks = list("nosferatu3");
-	name = "nosferatu house-3"
-	},
-/obj/item/vamp/keys/police{
-	accesslocks = list("nosferatu3");
-	name = "nosferatu house-3"
-	},
-/turf/open/floor/plating/parquetry/old,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/sewer/nosferatu_town)
 "nqT" = (
 /obj/structure/chair/sofa/right{
@@ -48915,6 +52803,14 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/carpet,
 /area/vtm/interior/tzimisce_manor)
+"nrG" = (
+/obj/effect/decal/pallet{
+	pixel_x = -2;
+	pixel_y = 4
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/woodfancy,
+/area/vtm/sewer/nosferatu_town)
 "nrH" = (
 /obj/machinery/light/small/red{
 	pixel_y = 24
@@ -49369,15 +53265,8 @@
 /turf/open/floor/plating/vampwood,
 /area/vtm/forest)
 "nxz" = (
-/obj/structure/railing{
-	pixel_y = -10
-	},
-/obj/structure/railing{
-	dir = 4;
-	pixel_x = 2;
-	pixel_y = 3
-	},
-/turf/open/floor/plating/shit,
+/obj/structure/table/wood,
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "nxA" = (
 /obj/effect/decal/bordur{
@@ -49558,6 +53447,14 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/chantry/basement)
+"nAb" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/pink{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "nAl" = (
 /obj/machinery/light/small/red{
 	dir = 4;
@@ -49573,6 +53470,12 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"nAr" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nAM" = (
 /obj/structure/bed/roller,
 /obj/structure/extinguisher_cabinet{
@@ -49595,6 +53498,10 @@
 /obj/item/bodybag,
 /turf/open/floor/plating/rough,
 /area/vtm/interior/mansion)
+"nBb" = (
+/obj/effect/decal/carpet,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "nBd" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -49651,6 +53558,12 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/anarch)
+"nBs" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nBy" = (
 /obj/structure/fluff/hedge{
 	pixel_y = 6
@@ -49666,6 +53579,12 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/chantry)
+"nBA" = (
+/obj/effect/decal/bordur,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nBC" = (
 /obj/manholeup,
 /obj/machinery/light/small{
@@ -49766,6 +53685,12 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/tzimisce_manor)
+"nCI" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "nCY" = (
 /obj/machinery/light/prince{
 	pixel_y = 32
@@ -49778,10 +53703,32 @@
 /obj/effect/decal/wallpaper/paper/darkred,
 /turf/closed/wall/vampwall/painted,
 /area/vtm/interior/banu)
+"nDa" = (
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "nDb" = (
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/chinatown)
+"nDc" = (
+/obj/structure/closet,
+/obj/item/clothing/under/vampire/police,
+/obj/item/clothing/under/vampire/archivist,
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nDd" = (
 /obj/structure/trashbag,
 /turf/open/floor/plating/sidewalkalt,
@@ -49957,6 +53904,13 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior)
+"nEU" = (
+/obj/effect/decal/bordur{
+	dir = 4
+	},
+/obj/effect/decal/bordur,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "nEX" = (
 /obj/structure/railing{
 	layer = 4
@@ -50213,15 +54167,24 @@
 /turf/open/floor/plating/vampcanal,
 /area/vtm/sewer)
 "nHT" = (
-/obj/structure/table/wood,
-/obj/item/drinkable_bloodpack/elite,
-/turf/open/floor/carpet/black,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
 /area/vtm/sewer/nosferatu_town)
 "nHW" = (
 /obj/structure/table,
 /obj/item/bong,
 /turf/open/floor/plating/rough,
 /area/vtm/anarch/basement)
+"nIi" = (
+/obj/structure/closet/crate/large,
+/obj/item/drinkable_bloodpack,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "nIk" = (
 /obj/structure/railing{
 	dir = 4
@@ -50232,6 +54195,15 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/financialdistrict/construction)
+"nIr" = (
+/obj/machinery/light/small/pink{
+	dir = 1;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nIs" = (
 /obj/effect/decal/bordur,
 /obj/effect/decal/pallet,
@@ -50248,9 +54220,13 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/tzimisce_manor)
 "nIG" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/machinery/light/dim{
+	dir = 4
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nIQ" = (
 /obj/gummaguts{
 	pixel_x = 16;
@@ -50262,6 +54238,11 @@
 /obj/structure/curtain/bounty,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/sewer/cappadocian)
+"nIX" = (
+/obj/structure/table/wood,
+/obj/machinery/mineral/equipment_vendor/fastfood/clothing,
+/turf/closed/wall/vampwall/junk/alt/low,
+/area/vtm/sewer/nosferatu_town)
 "nIZ" = (
 /obj/structure/chair/sofa/corp/corner{
 	dir = 4
@@ -50443,13 +54424,9 @@
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/theatre)
 "nKZ" = (
-/obj/structure/table/wood,
-/obj/item/drinkable_bloodpack,
-/obj/item/drinkable_bloodpack,
-/obj/item/drinkable_bloodpack,
-/obj/item/drinkable_bloodpack,
-/obj/item/drinkable_bloodpack,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
 /area/vtm/sewer/nosferatu_town)
 "nLa" = (
 /obj/structure/table/wood/fancy/black,
@@ -50460,6 +54437,12 @@
 /obj/structure/vamptree/pine,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/old)
+"nLm" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "nLv" = (
 /obj/effect/decal/shadow{
 	pixel_y = -32
@@ -50553,6 +54536,22 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/giovanni)
+"nLU" = (
+/obj/effect/decal/graffiti,
+/obj/structure/bed/maint{
+	pixel_x = 14;
+	pixel_y = 8
+	},
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nLV" = (
 /obj/structure/vampdoor/wood/jazz_club{
 	dir = 4
@@ -50624,6 +54623,16 @@
 /obj/item/vamp/keys/techstore,
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/interior/glasswalker)
+"nMT" = (
+/obj/effect/decal/graffiti,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "nMW" = (
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/asphalt,
@@ -50640,6 +54649,13 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/financialdistrict)
+"nNb" = (
+/obj/structure/vampfence/rich{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "nNc" = (
 /obj/structure/table,
 /obj/item/screwdriver,
@@ -50723,6 +54739,17 @@
 	},
 /turf/open/floor/plating/vampdirt,
 /area/vtm/graveyard)
+"nOJ" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 2
+	},
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "nOK" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -50823,8 +54850,15 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
 "nQv" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating/rough,
+/obj/effect/decal/pallet{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/woodfancy,
 /area/vtm/sewer/nosferatu_town)
 "nQw" = (
 /obj/machinery/grill,
@@ -50916,6 +54950,23 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"nRg" = (
+/obj/structure/vampipe{
+	icon_state = "piping3";
+	pixel_y = 32
+	},
+/obj/structure/vampipe{
+	icon_state = "piping32";
+	pixel_y = 17
+	},
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "nRh" = (
 /obj/machinery/light/prince{
 	dir = 8
@@ -50991,6 +55042,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/banu)
+"nSc" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "nSh" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -51003,13 +55060,8 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/financialdistrict/construction)
 "nSm" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 16
-	},
-/obj/structure/closet/secure_closet/freezer,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer)
 "nSp" = (
 /obj/structure/pole,
 /mob/living/carbon/human/npc/stripper,
@@ -51042,6 +55094,11 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/strip/elysium)
+"nSQ" = (
+/obj/effect/decal/litter,
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "nSX" = (
 /obj/structure/chair/sofa/left{
 	dir = 8
@@ -51103,6 +55160,16 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/church)
+"nUb" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "nUf" = (
 /obj/effect/landmark/npcbeacon/directed{
 	dir = 1
@@ -51145,6 +55212,11 @@
 /obj/structure/stairs/north,
 /turf/open/floor/plating/vampplating/stone,
 /area/vtm/interior/bianchiBank)
+"nUW" = (
+/obj/structure/table/wood,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "nUX" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8;
@@ -51218,8 +55290,9 @@
 /turf/open/floor/plating/vampplating/stone,
 /area/vtm/interior/bianchiBank)
 "nWC" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/plating/vampcanalplating,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
 /area/vtm/interior)
 "nWD" = (
 /obj/structure/railing{
@@ -51318,6 +55391,10 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/financialdistrict)
+"nXj" = (
+/obj/item/chair/plastic,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "nXl" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/landmark/npcwall,
@@ -51362,6 +55439,14 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf/lower)
+"nXL" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "nXS" = (
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
@@ -51528,6 +55613,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/fishermanswharf/ghetto)
+"oat" = (
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "oaw" = (
 /obj/machinery/light/prince{
 	dir = 1;
@@ -51708,6 +55799,12 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
+"odV" = (
+/obj/effect/decal/trash{
+	icon_state = "trash8"
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "oeg" = (
 /turf/open/floor/plating/granite,
 /area/vtm/cabaret/basement)
@@ -51953,6 +56050,18 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior)
+"ohj" = (
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_nature";
+	layer = 4.2;
+	pixel_y = 12
+	},
+/obj/effect/decal/trash,
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "ohk" = (
 /obj/effect/turf_decal/weather/dirt{
 	dir = 9
@@ -52081,6 +56190,17 @@
 "oiT" = (
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
+"oje" = (
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	color = "#50C878"
+	},
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "ojj" = (
 /obj/structure/rack,
 /turf/open/floor/plating/vampplating,
@@ -52103,6 +56223,14 @@
 /obj/item/drinkable_bloodpack,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
+"ojy" = (
+/obj/structure/railing{
+	layer = 4
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "ojC" = (
 /obj/structure/roadsign/busstop,
 /turf/open/floor/plating/sidewalk,
@@ -52250,6 +56378,15 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/techshop)
+"olG" = (
+/obj/effect/decal/wallpaper/paper/low,
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/closed/wall/vampwall/junk/low/window,
+/area/vtm/interior)
 "olO" = (
 /obj/structure/sink{
 	pixel_y = 16;
@@ -52447,6 +56584,20 @@
 	},
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/staff)
+"ool" = (
+/obj/structure/table,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
+"ooz" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "ooH" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -52526,6 +56677,14 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
 /area/vtm/anarch)
+"opV" = (
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "oqb" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 1;
@@ -52539,10 +56698,9 @@
 /turf/open/floor/plating/circled,
 /area/vtm/interior/setite/basement)
 "oqj" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
-/turf/open/floor/plating/rough,
+/obj/structure/table/wood,
+/obj/item/reagent_containers/glass/bowl,
+/turf/closed/wall/vampwall/bar/low,
 /area/vtm/interior)
 "oqp" = (
 /obj/machinery/light/prince{
@@ -53004,6 +57162,11 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict)
+"owl" = (
+/obj/structure/flora/junglebush/b,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "owm" = (
 /obj/structure/railing{
 	dir = 8
@@ -53045,6 +57208,12 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/chinatown)
+"owE" = (
+/obj/structure/closet/crate/large,
+/obj/item/kirbyplants/random,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "owH" = (
 /obj/structure/table/glass,
 /obj/vampire_computer{
@@ -53094,6 +57263,10 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/techshop)
+"oxb" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/plating/vampcarpet,
+/area/vtm/interior)
 "oxc" = (
 /obj/machinery/vending/snack/green,
 /turf/open/floor/plating/concrete,
@@ -53374,11 +57547,11 @@
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/laundromat)
 "oAK" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/effect/mob_spawn/human/citizen,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "oAM" = (
 /obj/structure/table/wood,
 /obj/structure/mirror{
@@ -53394,6 +57567,10 @@
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/techshop)
+"oAR" = (
+/obj/structure/table,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "oAU" = (
 /obj/structure/flora/ausbushes,
 /obj/structure/flora/ausbushes/sparsegrass{
@@ -53637,6 +57814,10 @@
 /obj/structure/vamptree/pine,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/graveyard)
+"oEd" = (
+/obj/structure/bed/dogbed,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer)
 "oEe" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -53692,6 +57873,13 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/ventrue)
+"oEO" = (
+/obj/effect/decal/trash,
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "oEV" = (
 /obj/effect/decal/bordur,
 /obj/structure/table/wood,
@@ -53738,13 +57926,10 @@
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
 "oFr" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
+/obj/effect/decal/bordur,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
 	},
-/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "oFv" = (
 /obj/manholeup,
@@ -53773,6 +57958,11 @@
 /obj/item/clothing/mask/vampire/venetian_mask,
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"oFM" = (
+/obj/structure/flora/junglebush/b,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "oFN" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/stone,
@@ -53788,6 +57978,14 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"oFX" = (
+/obj/structure/table{
+	color = "#CD5C5C"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "oGc" = (
 /obj/structure/table/wood,
 /obj/item/drinkable_bloodpack,
@@ -53860,12 +58058,10 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/bianchiBank)
 "oHg" = (
-/obj/structure/table/wood,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
 	},
+/obj/structure/coclock,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "oHp" = (
@@ -53923,6 +58119,16 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"oHJ" = (
+/obj/structure/closet/crate/coffin,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/structure/coclock,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "oHO" = (
 /obj/structure/hydrant,
 /obj/effect/landmark/npcactivity,
@@ -53968,6 +58174,13 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/tzimisce_manor)
+"oIu" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "oIw" = (
 /obj/structure/foodrack{
 	dir = 4
@@ -54001,6 +58214,20 @@
 /obj/effect/landmark/start/strip,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/strip)
+"oIJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
+"oIO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "oIQ" = (
 /obj/structure/lamppost/one{
 	dir = 1
@@ -54249,6 +58476,12 @@
 	},
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/staff)
+"oMy" = (
+/obj/structure/toilet{
+	pixel_y = 16
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "oMH" = (
 /obj/machinery/light{
 	dir = 4
@@ -54389,6 +58622,19 @@
 /obj/structure/bricks,
 /turf/open/floor/plating/concrete,
 /area/vtm/supply)
+"oNZ" = (
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "oOa" = (
 /obj/structure/table,
 /obj/item/dice/d20,
@@ -54432,6 +58678,17 @@
 "oOD" = (
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior)
+"oOK" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/flora/junglebush/large,
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "oOM" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plating/parquetry,
@@ -54837,6 +59094,13 @@
 /obj/effect/decal/wallpaper/gold/low,
 /turf/closed/wall/vampwall/rich/low/window/reinforced,
 /area/vtm/interior/millennium_tower/ventrue)
+"oTn" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "oTt" = (
 /obj/structure/vampdoor/wood/old{
 	desc = "It give you a mad vibes... Be careful!";
@@ -54849,8 +59113,14 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic/haven)
 "oTy" = (
-/obj/structure/table/wood,
-/turf/open/floor/carpet/black,
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/obj/effect/decal/asphaltline/alt{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
 /area/vtm/sewer/nosferatu_town)
 "oTA" = (
 /obj/structure/vampdoor/setite{
@@ -54917,6 +59187,15 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/setite)
+"oUf" = (
+/obj/machinery/light/small/pink{
+	dir = 1;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "oUn" = (
 /obj/structure/fluff/hedge,
 /obj/structure/railing{
@@ -55156,6 +59435,10 @@
 /obj/item/drinkable_bloodpack/elite,
 /turf/open/indestructible/necropolis/air,
 /area/vtm/sewer)
+"oXJ" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "oXN" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -55258,6 +59541,14 @@
 /obj/food_cart,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/park)
+"oZv" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/effect/decal/trash,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "oZw" = (
 /obj/structure/big_vamprocks,
 /turf/open/floor/plating/vampgrass,
@@ -55312,6 +59603,17 @@
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/vampwood,
 /area/vtm/northbeach)
+"paM" = (
+/obj/structure/vampdoor/old{
+	dir = 8;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "paQ" = (
 /obj/effect/decal/cardboard,
 /obj/structure/table/wood,
@@ -55386,13 +59688,13 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/banu/haven)
 "pbF" = (
-/obj/structure/table/wood,
-/obj/item/vamp/keys/nosferatu,
-/obj/item/vamp/keys/nosferatu,
-/obj/item/vamp/keys/nosferatu,
-/obj/item/vamp/keys/nosferatu,
-/obj/item/vamp/keys/nosferatu,
-/turf/open/floor/plating/parquetry/old,
+/obj/machinery/light/small/pink{
+	dir = 1;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial5"
+	},
 /area/vtm/sewer/nosferatu_town)
 "pbI" = (
 /obj/machinery/light/small{
@@ -55430,10 +59732,16 @@
 /turf/open/floor/carpet/black,
 /area/vtm/interior/tzimisce_manor)
 "pbZ" = (
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
 	},
-/turf/open/floor/plating/parquetry/old,
+/area/vtm/sewer/nosferatu_town)
+"pcf" = (
+/obj/structure/bed/dogbed,
+/mob/living/simple_animal/mouse/white,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "pcj" = (
 /obj/structure/fluff/hedge,
@@ -55491,9 +59799,26 @@
 /obj/item/camera/detective,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/police)
+"pcR" = (
+/obj/machinery/microwave{
+	pixel_y = 9
+	},
+/obj/structure/rack/bubway/horizontal,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/interior)
 "pcT" = (
 /turf/open/floor/plating/vampdirt,
 /area/vtm/pacificheights/forest)
+"pcX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "pdi" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/pacificheights)
@@ -55628,6 +59953,18 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/giovanni/outside)
+"pfl" = (
+/obj/effect/decal/litter,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/graffiti,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "pfv" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 9
@@ -55645,6 +59982,16 @@
 /obj/weapon_showcase,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/shop)
+"pfA" = (
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "pfE" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/concrete,
@@ -55856,10 +60203,9 @@
 /turf/open/floor/plating/vampwood,
 /area/vtm/interior/oldchurch)
 "piv" = (
-/obj/structure/railing{
-	dir = 5
-	},
-/turf/open/floor/plating/shit,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "pix" = (
 /obj/structure/rack,
@@ -56021,6 +60367,18 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights/forest)
+"pkQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/machinery/vamp/atm{
+	dir = 8;
+	pixel_x = 10
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "pld" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -56161,6 +60519,13 @@
 /obj/effect/decal/bordur/corner,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
+"pnb" = (
+/obj/structure/railing,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/item/fishing_rod,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "png" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -56196,6 +60561,15 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/jazzclub)
+"pnI" = (
+/obj/effect/decal/cleanable/oil/streak,
+/obj/item/restraints/handcuffs/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "pnK" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 8
@@ -56212,6 +60586,14 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"poe" = (
+/obj/structure/table/wood,
+/obj/effect/decal/litter,
+/obj/structure/showcase/machinery/tv{
+	pixel_y = 12
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "poh" = (
 /obj/structure/big_vamprocks,
 /turf/open/floor/plating/rough/cave,
@@ -56350,6 +60732,12 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"ppb" = (
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "ppd" = (
 /obj/item/flashlight/lantern{
 	on = 14;
@@ -56390,6 +60778,11 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/pacificheights/forest)
+"ppM" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/chair/pew/left,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "ppP" = (
 /obj/machinery/light,
 /turf/closed/wall/vampwall/city,
@@ -56412,6 +60805,16 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/laundromat)
+"pqm" = (
+/obj/structure/rack/bubway/east,
+/obj/structure/closet/mini_fridge,
+/obj/item/drinkable_bloodpack,
+/obj/item/drinkable_bloodpack,
+/obj/item/food/pizzaslice/moldy,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/interior)
 "pqq" = (
 /obj/structure/closet/crate,
 /obj/effect/decal/pallet,
@@ -56521,6 +60924,14 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"prW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "prY" = (
 /obj/effect/decal/trash,
 /turf/open/floor/plating/concrete,
@@ -56561,8 +60972,11 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/interior/shop)
 "psA" = (
-/obj/structure/closet/crate/coffin,
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/vampipe{
+	icon_state = "piping5";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "psB" = (
 /obj/effect/turf_decal/siding/brown{
@@ -56780,9 +61194,13 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/unionsquare)
 "pvs" = (
-/obj/structure/chair/wood,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/closed/wall/vampwall/rustbad,
+/area/vtm/sewer/nosferatu_town)
 "pvu" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -56990,6 +61408,11 @@
 	},
 /turf/open/floor/carpet/black,
 /area/vtm/hotel)
+"pyh" = (
+/obj/structure/table/wood,
+/obj/machinery/mineral/equipment_vendor/fastfood/costumes,
+/turf/closed/wall/vampwall/wood/low,
+/area/vtm/sewer/nosferatu_town)
 "pyi" = (
 /obj/structure/bed,
 /obj/item/bedsheet/random,
@@ -57069,6 +61492,13 @@
 /obj/effect/decal/wallpaper/grey,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/strip)
+"pzh" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "pzt" = (
 /obj/structure/table,
 /obj/item/weedseed,
@@ -57309,6 +61739,13 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/sewer/tzimisce_sanctum)
+"pCj" = (
+/obj/structure/flora/junglebush/large,
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "pCm" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/weather/dirt{
@@ -57647,6 +62084,12 @@
 /obj/structure/coclock,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/clinic/haven)
+"pGV" = (
+/obj/structure/vampfence/rich{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "pGW" = (
 /obj/structure/vampdoor/simple{
 	dir = 8
@@ -57712,6 +62155,13 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/endron_facility)
+"pHv" = (
+/obj/effect/decal/rugs,
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "pHA" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/beer/vampire,
@@ -57734,12 +62184,9 @@
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
 "pHJ" = (
-/obj/machinery/light/small/red{
-	dir = 8;
-	pixel_x = 16
-	},
+/obj/effect/decal/bordur,
 /turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "pHK" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -57781,6 +62228,17 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/pacificheights/forest)
+"pIj" = (
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/effect/decal/pallet{
+	pixel_x = 3;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/woodfancy,
+/area/vtm/sewer/nosferatu_town)
 "pIs" = (
 /obj/structure/closet/crate/freezer/fridge,
 /obj/item/drinkable_bloodpack/elite,
@@ -57883,6 +62341,16 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch)
+"pJL" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/obj/effect/decal/asphaltline/alt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "pJP" = (
 /obj/structure/table,
 /turf/open/floor/plating/parquetry/old,
@@ -57964,6 +62432,16 @@
 /obj/item/pushbroom,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/vjanitor)
+"pKw" = (
+/obj/effect/decal/trash,
+/obj/structure/chair/sofa/corp/right{
+	dir = 4;
+	color = "#50C878"
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "pKz" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/vending/boozeomat/all_access,
@@ -58135,6 +62613,10 @@
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
+"pMa" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "pMc" = (
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/plating/parquetry/old,
@@ -58229,6 +62711,25 @@
 	},
 /turf/open/floor/wood,
 /area/vtm/church/interior/haven)
+"pMX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
+"pNe" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "pNp" = (
 /turf/open/floor/carpet,
 /area/vtm/interior/chantry/basement)
@@ -58301,6 +62802,13 @@
 	},
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
+"pOA" = (
+/obj/effect/decal/trash,
+/obj/machinery/camera/directional/south,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
 /area/vtm/sewer/nosferatu_town)
 "pOE" = (
 /obj/structure/bricks{
@@ -58479,13 +62987,16 @@
 /turf/closed/wall/vampwall/city/low/window,
 /area/vtm/hotel)
 "pRa" = (
-/obj/structure/railing{
+/obj/structure/vampdoor/wood{
+	lock_id = "nosferatu";
+	lockpick_difficulty = 8;
 	dir = 8
 	},
-/obj/machinery/light/small/red{
-	pixel_y = 24
+/obj/effect/decal/rugs,
+/obj/effect/decal/bordur{
+	dir = 4
 	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "pRj" = (
 /obj/machinery/light/small{
@@ -58620,10 +63131,8 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/baali)
 "pTe" = (
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
-/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/structure/chair/sofa/corner,
+/obj/structure/coclock,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "pTu" = (
@@ -58781,6 +63290,11 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/hotel)
+"pVy" = (
+/obj/structure/table,
+/obj/item/vtm_artifact/rand,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "pVB" = (
 /mob/living/simple_animal/pet/cat/vampire,
 /turf/open/floor/plating/parquetry/old,
@@ -58818,10 +63332,9 @@
 /turf/closed/wall/vampwall/rich/low/window,
 /area/vtm/interior/millennium_tower)
 "pVO" = (
-/obj/effect/decal/pallet{
-	pixel_y = -3
-	},
-/turf/open/floor/plating/shit,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/item/bailer,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "pWf" = (
 /obj/structure/window/reinforced/tinted{
@@ -58836,6 +63349,23 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/anarch)
+"pWq" = (
+/obj/structure/bed/maint{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/structure/bed/maint{
+	pixel_x = 14;
+	pixel_y = 8
+	},
+/obj/effect/decal/cardboard,
+/obj/structure/trashbag,
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "pWs" = (
 /obj/structure/bricks{
 	pixel_x = -3;
@@ -59025,6 +63555,12 @@
 /obj/item/storage/box/donkpockets/donkpocketteriyaki,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/laundromat)
+"pYD" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "pYF" = (
 /obj/structure/table,
 /obj/item/gun/ballistic/automatic/vampire/sniper,
@@ -59085,10 +63621,17 @@
 /obj/structure/lamppost/sidewalk,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/financialdistrict)
+"pZO" = (
+/obj/effect/decal/wallpaper/paper/low,
+/obj/structure/sign/poster/contraband/kish,
+/turf/closed/wall/vampwall/junk,
+/area/vtm/sewer/nosferatu_town)
 "qab" = (
-/obj/structure/table/wood,
-/obj/item/vamp/keys/nosferatu,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "qah" = (
 /obj/machinery/light/small{
@@ -59103,8 +63646,16 @@
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/strip)
 "qam" = (
-/obj/structure/vampdoor/wood/giovanni,
-/turf/closed/wall/vampwall/rock,
+/obj/structure/table/wood/bar,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/item/flashlight/lamp/green{
+	pixel_x = -5;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "qau" = (
 /obj/structure/chair/pew/right{
@@ -59154,6 +63705,12 @@
 /obj/structure/vampstatue/angel,
 /turf/open/water,
 /area/vtm/sewer/cappadocian)
+"qaZ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "qbh" = (
 /obj/structure/window/reinforced/indestructable{
 	alpha = 0
@@ -59272,6 +63829,20 @@
 	},
 /turf/open/openspace,
 /area/vtm)
+"qcL" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/decal/asphaltline/alt{
+	dir = 8
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "qcO" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights)
@@ -59288,9 +63859,23 @@
 /obj/structure/vamptree/pine,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/old)
+"qcZ" = (
+/obj/structure/railing,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "qdb" = (
 /turf/open/water,
 /area/vtm/financialdistrict/construction)
+"qde" = (
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "qdi" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/carpet,
@@ -59340,6 +63925,12 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"qdN" = (
+/obj/effect/decal/trash,
+/turf/closed/wall/vampwall/rock{
+	density = 0
+	},
+/area/vtm/sewer)
 "qdZ" = (
 /obj/structure/chair/comfy/shuttle,
 /obj/structure/extinguisher_cabinet{
@@ -59439,6 +64030,12 @@
 /obj/structure/vampdoor/food_pantry,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/cog/pantry)
+"qfx" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/graffiti,
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "qfD" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/white{
@@ -59477,8 +64074,10 @@
 /turf/closed/wall/vampwall/rust,
 /area/vtm/interior/millennium_tower/f3)
 "qfW" = (
-/obj/effect/decal/wallpaper/paper/darkgreen,
-/turf/closed/wall/vampwall/junk/alt,
+/obj/structure/weedshit,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial9"
+	},
 /area/vtm/sewer/nosferatu_town)
 "qgf" = (
 /obj/structure/trashbag,
@@ -59620,6 +64219,19 @@
 /obj/effect/decal/rugs,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/baali)
+"qhl" = (
+/obj/structure/vampdoor/wood/old{
+	dir = 8;
+	lock_id = "nosferatu"
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial5"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qhp" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/bordur{
@@ -59816,6 +64428,17 @@
 /obj/machinery/washing_machine,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"qka" = (
+/obj/effect/decal/trash,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/machinery/camera{
+	dir = 4
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "qkb" = (
 /obj/structure/bed/maint{
 	pixel_y = 2
@@ -59969,6 +64592,11 @@
 "qmj" = (
 /turf/closed/wall/vampwall/bar/low/window,
 /area/vtm/interior/techshop)
+"qmr" = (
+/obj/structure/chair/plastic,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "qmO" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -60085,6 +64713,20 @@
 /obj/weapon_showcase,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"qnY" = (
+/obj/effect/decal/pallet{
+	layer = 2
+	},
+/obj/structure/trashbag{
+	pixel_x = -9
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "qof" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/vampire/top,
@@ -60169,6 +64811,17 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/financialdistrict)
+"qpL" = (
+/obj/structure/chair/sofa/corner{
+	dir = 4
+	},
+/obj/effect/decal/litter,
+/obj/item/toy/plush/lizardplushie/space,
+/obj/fusebox,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qpS" = (
 /obj/effect/decal/litter,
 /obj/item/melee/skateboard/pro,
@@ -60282,10 +64935,27 @@
 	},
 /turf/open/floor/plating/vampdirt,
 /area/vtm/pacificheights/forest)
+"qrp" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qrr" = (
-/obj/effect/decal/bordur,
-/obj/effect/decal/litter,
-/turf/open/floor/plating/rough/cave,
+/obj/effect/decal/pallet,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
+"qrt" = (
+/obj/structure/chair/comfy/black{
+	dir = 4;
+	color = "#CD5C5C"
+	},
+/obj/item/toy/plush/pkplush,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
 /area/vtm/sewer/nosferatu_town)
 "qrE" = (
 /obj/effect/turf_decal/siding/wood{
@@ -60476,6 +65146,19 @@
 /obj/item/storage/fancy/nugget_box,
 /turf/open/floor/plating/vampbeach,
 /area/vtm/northbeach)
+"quu" = (
+/obj/structure/closet/secure_closet/freezer,
+/obj/effect/decal/litter,
+/obj/machinery/light/small{
+	pixel_y = 32
+	},
+/obj/item/drinkable_bloodpack,
+/obj/item/drinkable_bloodpack,
+/obj/item/kitchen/knife,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/interior)
 "quw" = (
 /obj/structure/hydrant,
 /turf/open/floor/plating/sidewalk,
@@ -60717,6 +65400,11 @@
 /obj/effect/landmark/start/strip,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/strip)
+"qwR" = (
+/obj/structure/table,
+/obj/item/vamp/keys/hack,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "qwT" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/plating/vampwood,
@@ -60767,9 +65455,10 @@
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/haven)
 "qxF" = (
-/obj/structure/closet/crate/coffin,
-/obj/structure/curtain/bounty,
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "qxL" = (
 /obj/structure/table,
@@ -60786,6 +65475,16 @@
 	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower/f2)
+"qyc" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/obj/structure/vampipe{
+	icon_state = "piping5";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "qyp" = (
 /obj/structure/lamppost/one{
 	dir = 4
@@ -60982,6 +65681,15 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower/f4)
+"qAy" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qAC" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -61124,6 +65832,12 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/trujah)
+"qCp" = (
+/obj/structure/closet/crate/large,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qCA" = (
 /obj/item/bailer,
 /turf/open/floor/plating/rough/cave,
@@ -61177,6 +65891,13 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/wyrm_corrupted)
+"qDI" = (
+/obj/structure/table/wood,
+/obj/structure/coclock,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/interior)
 "qDL" = (
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/plating/rough/cave,
@@ -61340,9 +66061,11 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/giovanni/outside)
 "qFX" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
 	},
+/obj/structure/flora/rock/jungle,
+/obj/structure/railing,
 /turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "qFZ" = (
@@ -61516,6 +66239,12 @@
 "qIU" = (
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/techshop)
+"qIV" = (
+/obj/structure/bookcase/random/nonfiction,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qIW" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -61546,13 +66275,11 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
 "qJo" = (
-/obj/machinery/shower{
-	dir = 4;
-	pixel_x = 8;
-	pixel_y = 5
+/obj/structure/vampipe{
+	icon_state = "piping40"
 	},
-/obj/structure/curtain,
-/turf/open/floor/plating/vampcanalplating,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "qJt" = (
 /obj/structure/table/wood,
@@ -61710,6 +66437,17 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/pacificheights/forest)
+"qKF" = (
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "qKG" = (
 /obj/machinery/light{
 	dir = 1
@@ -61750,6 +66488,10 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/financialdistrict)
+"qLm" = (
+/obj/item/clothing/head/cone,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "qLn" = (
 /obj/structure/table/wood,
 /obj/structure/table/wood,
@@ -61871,6 +66613,16 @@
 "qMr" = (
 /turf/closed/wall/vampwall/old/low/window/reinforced,
 /area/vtm/interior/tzimisce_manor)
+"qMu" = (
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/obj/effect/decal/trash,
+/obj/structure/barrels{
+	icon_state = "barrels9"
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "qMA" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -61926,6 +66678,11 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
+"qNy" = (
+/turf/open/floor/plating/grate{
+	icon_state = "lattice_new_dirt"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qNA" = (
 /obj/item/kirbyplants/random,
 /obj/effect/turf_decal/siding/white{
@@ -61959,6 +66716,14 @@
 /obj/manholeup,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/giovanni/basement)
+"qNW" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plating/grate{
+	icon_state = "lattice_new_dirt"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qOh" = (
 /obj/structure/vampdoor/reinf{
 	dir = 1;
@@ -61981,6 +66746,13 @@
 	},
 /turf/open/floor/plating/granite,
 /area/vtm/interior/millennium_tower)
+"qOD" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "qOE" = (
 /obj/structure/coclock,
 /turf/open/floor/plating/saint,
@@ -62114,6 +66886,15 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/cog/pantry)
+"qQh" = (
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qQo" = (
 /obj/effect/decal/pallet,
 /obj/structure/railing{
@@ -62148,6 +66929,13 @@
 /obj/structure/roadsign/speedlimit25,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights)
+"qQR" = (
+/obj/structure/bookcase/random/nonfiction,
+/obj/structure/coclock,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qQX" = (
 /obj/structure/window/reinforced/indestructable{
 	alpha = 0
@@ -62227,8 +67015,11 @@
 /turf/closed/wall/vampwall/painted/low,
 /area/vtm/interior/bianchiBank)
 "qRt" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plating/rough/cave,
+/obj/structure/vampfence/rich{
+	dir = 4
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "qRv" = (
 /obj/effect/turf_decal/weather/sand{
@@ -62249,8 +67040,8 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/park)
 "qRA" = (
-/obj/effect/decal/litter,
-/turf/open/floor/plating/parquetry/old,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "qRD" = (
 /obj/effect/turf_decal/siding/white{
@@ -62345,6 +67136,16 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/police/fed)
+"qSq" = (
+/obj/structure/vampdoor/old{
+	dir = 8;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "qSr" = (
 /obj/structure/chair/sofa/corp/left{
 	dir = 1
@@ -62570,6 +67371,18 @@
 /obj/structure/curtain,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/chantry)
+"qVf" = (
+/obj/structure/bed/maint{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/effect/decal/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qVg" = (
 /obj/effect/turf_decal/siding/white/corner,
 /turf/open/floor/plating/vampplating,
@@ -62596,12 +67409,21 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/millennium_tower/f5)
 "qVo" = (
-/obj/machinery/light/small{
+/obj/structure/vampipe{
+	icon_state = "piping7";
 	pixel_y = 32
 	},
-/obj/structure/toilet,
-/turf/open/floor/plating/vampcanalplating,
-/area/vtm/interior)
+/obj/effect/decal/cardboard,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/vampdoor/old{
+	dir = 8;
+	locked = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "qVv" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -62732,6 +67554,16 @@
 /obj/structure/big_vamprocks,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/old)
+"qWX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/decal/trash,
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "qWZ" = (
 /obj/structure/stairs/west,
 /turf/open/floor/plating/rough/cave,
@@ -62804,6 +67636,11 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/supply)
+"qYl" = (
+/obj/structure/flora/rock/pile/largejungle,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "qYn" = (
 /obj/effect/landmark/npcbeacon,
 /obj/effect/landmark/npcability,
@@ -62874,6 +67711,10 @@
 /obj/structure/toilet,
 /turf/open/floor/plating/toilet,
 /area/vtm/church/interior/staff)
+"qYX" = (
+/obj/effect/decal/wallpaper,
+/turf/closed/wall/vampwall/bar,
+/area/vtm/sewer/nosferatu_town)
 "qZa" = (
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/asphalt,
@@ -62957,6 +67798,15 @@
 /obj/structure/table,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/f2)
+"qZS" = (
+/obj/structure/bed/maint,
+/obj/structure/bed/maint{
+	pixel_y = 2
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/coclock,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "qZU" = (
 /obj/structure/coclock,
 /turf/open/floor/plating/parquetry/old,
@@ -63104,8 +67954,13 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/unionsquare)
 "rcj" = (
-/obj/structure/closet,
-/obj/item/vamp/keys/nosferatu,
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/effect/decal/kopatich{
+	pixel_x = -20;
+	pixel_y = -20
+	},
 /turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "rct" = (
@@ -63179,9 +68034,15 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/anarch)
 "rdg" = (
-/obj/structure/coclock,
-/obj/structure/chair/sofa/left,
-/turf/open/floor/plating/rough,
+/obj/structure/table/wood,
+/obj/item/bong,
+/obj/item/lighter,
+/obj/machinery/camera{
+	dir = 4
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
 /area/vtm/sewer/nosferatu_town)
 "rdh" = (
 /obj/structure/vampipe{
@@ -63264,6 +68125,12 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/cog/pantry)
+"reu" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "rev" = (
 /obj/structure/table/wood,
 /obj/item/vamp/keys/hunter,
@@ -63338,6 +68205,18 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights/community)
+"rfL" = (
+/obj/structure/table,
+/obj/vampire_computer,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
+"rfR" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "rfY" = (
 /turf/closed/wall/vampwall/rich/low/window/reinforced,
 /area/vtm/interior/baali)
@@ -63402,7 +68281,7 @@
 /area/vtm/church/interior/staff)
 "rhq" = (
 /obj/matrix,
-/turf/open/floor/plating/rough/cave,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "rhs" = (
 /obj/effect/decal/pallet,
@@ -63466,17 +68345,14 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
 "rhW" = (
-/obj/structure/railing{
-	dir = 10;
-	pixel_y = -13
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 2
 	},
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "rhX" = (
 /obj/structure/bed/maint,
@@ -63585,6 +68461,15 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/bianchiBank)
+"riv" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/rock/jungle,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "riw" = (
 /obj/machinery/light/prince{
 	dir = 8
@@ -63664,6 +68549,17 @@
 /obj/item/gun/ballistic/automatic/vampire/m1911,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f4)
+"rjw" = (
+/obj/structure/railing{
+	layer = 4
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/effect/decal/trash,
+/obj/structure/roadblock/alt,
+/turf/open/floor/plating/grate,
+/area/vtm/sewer/nosferatu_town)
 "rjy" = (
 /obj/effect/decal/litter,
 /obj/effect/landmark/npcbeacon,
@@ -63706,10 +68602,9 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/cog/caern)
 "rjV" = (
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
-/obj/structure/table/wood,
+/obj/structure/coclock,
+/obj/structure/bed,
+/obj/item/bedsheet/dorms,
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "rjX" = (
@@ -63725,6 +68620,12 @@
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/financialdistrict/library)
+"rkb" = (
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "rkf" = (
 /obj/structure/pole{
 	pixel_y = 16
@@ -63742,13 +68643,16 @@
 /turf/open/floor/plating/bacotell,
 /area/vtm/clinic/haven)
 "rko" = (
-/obj/structure/vampdoor/wood/old{
-	dir = 4;
+/obj/structure/vampdoor/wood{
 	lock_id = "nosferatu";
-	locked = 1;
-	lockpick_difficulty = 8
+	lockpick_difficulty = 8;
+	dir = 8
 	},
-/turf/open/floor/plating/rough/cave,
+/obj/effect/decal/rugs,
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "rks" = (
 /obj/effect/turf_decal/siding/white{
@@ -63953,6 +68857,20 @@
 /obj/item/vamp/keys/malkav,
 /turf/open/floor/carpet/lone,
 /area/vtm/clinic/haven)
+"rnq" = (
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
+/area/vtm/sewer/nosferatu_town)
+"rnw" = (
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/junglebush/b,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "rny" = (
 /obj/effect/decal/bordur/corner{
 	dir = 1
@@ -64034,10 +68952,10 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/restricted)
 "rot" = (
-/obj/structure/chair/comfy{
-	dir = 8
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "rov" = (
 /obj/effect/landmark/npcactivity,
@@ -64268,6 +69186,18 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/church)
+"rqU" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/effect/decal/trash,
+/obj/structure/closet/crate/large,
+/obj/item/flashlight/lantern{
+	light_color = "#013220";
+	pixel_y = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "rqW" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -64369,6 +69299,11 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/ghetto)
+"rsk" = (
+/obj/structure/flora/junglebush/b,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "rsp" = (
 /obj/effect/decal/litter,
 /obj/effect/decal/litter,
@@ -64446,11 +69381,13 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/tzimisce_manor)
 "rtf" = (
-/obj/structure/closet/crate/coffin,
-/obj/machinery/light/small{
-	pixel_y = 32
+/obj/machinery/light/small/pink{
+	dir = 4;
+	pixel_x = -16
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "rti" = (
 /obj/machinery/mineral/equipment_vendor/fastfood/coffeevendor{
@@ -64526,17 +69463,10 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/chinatown)
 "rtZ" = (
-/obj/structure/vampdoor/wood/old{
-	dir = 1;
-	lock_id = "nosferatu1";
-	locked = 1;
-	lockpick_difficulty = 6;
-	name = "house-1"
-	},
-/obj/effect/decal/bordur{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/sewer/nosferatu_town)
 "rub" = (
 /obj/effect/decal/trash,
@@ -64545,6 +69475,15 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch/basement)
+"rud" = (
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "ruf" = (
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto/old)
@@ -64562,6 +69501,13 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/open/floor/plating/vampcrossableocean,
 /area/vtm/forest)
+"ruq" = (
+/obj/effect/decal/trash,
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "ruw" = (
 /obj/structure/table/wood/poker,
 /obj/item/gun/ballistic/vampire/revolver,
@@ -64689,6 +69635,10 @@
 /obj/item/flashlight/lamp,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/supply)
+"rvZ" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "rwa" = (
 /obj/effect/decal/pallet,
 /obj/effect/decal/cardboard,
@@ -64770,6 +69720,16 @@
 /obj/item/card/id/hunter,
 /turf/open/floor/plating/vampwood,
 /area/vtm/hotel)
+"rwZ" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_y = 12
+	},
+/obj/structure/glowshroom,
+/obj/machinery/camera{
+	dir = 8
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "rxa" = (
 /turf/open/floor/plating/toilet,
 /area/vtm/graveyard/interior)
@@ -64914,6 +69874,19 @@
 /obj/structure/cable/layer1,
 /turf/open/floor/plating/vampcanal,
 /area/vtm/interior/glasswalker)
+"rzP" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	pixel_y = 12
+	},
+/obj/effect/decal/pallet{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "rzV" = (
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
@@ -65122,6 +70095,20 @@
 /obj/structure/pole,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/wyrm_corrupted)
+"rCW" = (
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/decal/trash,
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "rCX" = (
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/techshop)
@@ -65271,6 +70258,14 @@
 	},
 /turf/open/floor/plating/vampcarpet,
 /area/vtm/interior/techshop)
+"rFm" = (
+/obj/structure/table/wood,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_analog";
+	pixel_y = 12
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "rFs" = (
 /obj/structure/table/wood,
 /obj/item/newspaper{
@@ -65366,6 +70361,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"rGi" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "rGm" = (
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/laundromat)
@@ -65374,6 +70375,16 @@
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
+"rGr" = (
+/obj/structure/closet,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
+"rGt" = (
+/obj/effect/decal/carpet,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "rGw" = (
 /turf/open/floor/plating/roofwalk,
 /area/vtm/interior/oldchurch)
@@ -65421,6 +70432,12 @@
 	},
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/ghetto/old)
+"rHa" = (
+/obj/structure/closet/cabinet,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "rHh" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/effect/decal/bordur,
@@ -65754,10 +70771,9 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/giovanni/outside)
 "rLy" = (
-/obj/structure/chair/plastic{
-	dir = 4
-	},
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/flora/junglebush/c,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "rLC" = (
 /obj/structure/rack,
@@ -65804,6 +70820,15 @@
 "rMf" = (
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/strip/toreador)
+"rMl" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
+"rMm" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/effect/decal/cardboard,
+/turf/open/floor/plating/stone,
+/area/vtm/sewer)
 "rMn" = (
 /obj/structure/bed,
 /obj/effect/turf_decal/siding/wood{
@@ -66009,6 +71034,19 @@
 "rOK" = (
 /turf/open/floor/plating/toilet,
 /area/vtm/clinic)
+"rOP" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
+"rOQ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "rOZ" = (
 /obj/structure/fluff/hedge,
 /obj/structure/railing,
@@ -66284,6 +71322,15 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/vampcanalplating,
 /area/vtm/interior/glasswalker)
+"rSr" = (
+/obj/structure/vampipe{
+	icon_state = "piping6";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "rSu" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -66522,6 +71569,12 @@
 /obj/item/reagent_containers/food/drinks/meth/cocaine,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/millennium_tower/ventrue)
+"rVy" = (
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "rVz" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating/parquetry,
@@ -66641,9 +71694,13 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
 "rWU" = (
-/obj/effect/decal/pallet,
-/obj/effect/decal/cardboard,
-/turf/open/floor/plating/shit,
+/obj/structure/chair/plastic{
+	pixel_y = 4
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
 /area/vtm/sewer/nosferatu_town)
 "rWY" = (
 /obj/machinery/light{
@@ -66794,6 +71851,16 @@
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/park)
+"rYs" = (
+/obj/effect/decal/pallet,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/railing{
+	dir = 1;
+	layer = 4;
+	pixel_y = 16
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "rYy" = (
 /obj/structure/table,
 /obj/item/vamp/keys/brujah,
@@ -66862,6 +71929,12 @@
 /obj/effect/decal/support,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower/ventrue)
+"rZa" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "rZc" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/drinkable_bloodpack,
@@ -67028,6 +72101,13 @@
 	},
 /turf/open/floor/plating/vampwood,
 /area/vtm/hotel)
+"saH" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "saJ" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -67119,6 +72199,15 @@
 /obj/effect/landmark/npcactivity,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/construction)
+"sbF" = (
+/obj/structure/table{
+	color = "#CD5C5C"
+	},
+/obj/item/reagent_containers/spray,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "sbK" = (
 /obj/structure/vampdoor/children_of_gaia{
 	dir = 4
@@ -67163,6 +72252,19 @@
 /obj/structure/glowshroom/single,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/gnawer)
+"scw" = (
+/obj/item/reagent_containers/food/drinks/meth/cocaine,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer)
+"scJ" = (
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/obj/structure/barricade/wooden/crude,
+/turf/closed/wall/vampwall/rustbad,
+/area/vtm/sewer/nosferatu_town)
 "scR" = (
 /turf/open/floor/plating/bacotell,
 /area/vtm/interior/shop)
@@ -67200,13 +72302,18 @@
 /obj/structure/chair/plastic,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/tzimisce_manor)
-"sdF" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/washing_machine,
-/turf/open/floor/plating/rough,
+"sdE" = (
+/obj/structure/fireplace,
+/turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior)
+"sdF" = (
+/obj/structure/vampdoor/simple,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "sdJ" = (
 /obj/structure/table,
 /obj/machinery/mineral/equipment_vendor/fastfood/smoking,
@@ -67374,6 +72481,10 @@
 /obj/item/clothing/suit/apron/chef,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/setite)
+"sfW" = (
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "sgp" = (
 /obj/effect/decal/litter,
 /turf/open/floor/plating/parquetry/old,
@@ -67441,6 +72552,11 @@
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/church)
+"shr" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "shs" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/vampirebook/noddist,
@@ -67508,6 +72624,14 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/asphalt,
 /area/vtm/fishermanswharf)
+"sim" = (
+/obj/effect/decal/rugs,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/vampwood{
+	alpha = 0;
+	icon_state = "woodd12"
+	},
+/area/vtm/sewer/nosferatu_town)
 "sip" = (
 /obj/machinery/light/dim{
 	pixel_y = 32
@@ -67559,6 +72683,15 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/police)
+"sjd" = (
+/obj/structure/chair/sofa/corp{
+	color = "#50C878"
+	},
+/obj/structure/coclock,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "sjh" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/parquetry/old,
@@ -67670,6 +72803,16 @@
 	},
 /turf/open/floor/plating/circled,
 /area/vtm/clinic)
+"skt" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "sku" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 4
@@ -67790,6 +72933,15 @@
 /obj/item/weedseed,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"slM" = (
+/obj/structure/vampdoor/simple{
+	dir = 8
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
+/area/vtm/interior)
 "slQ" = (
 /obj/structure/closet/secure_closet/freezer,
 /obj/item/drinkable_bloodpack,
@@ -67802,6 +72954,10 @@
 /obj/item/drinkable_bloodpack/elite,
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower)
+"slT" = (
+/obj/effect/decal/wallpaper/paper/low,
+/turf/closed/wall/vampwall/junk/alt,
+/area/vtm/sewer/nosferatu_town)
 "slV" = (
 /obj/structure/chair/sofa/corp/right{
 	dir = 4
@@ -67816,6 +72972,10 @@
 /obj/structure/railing/metal/corner,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/police/morgue)
+"smh" = (
+/obj/structure/table/wood,
+/turf/closed/wall/vampwall/junk/alt/low,
+/area/vtm/interior)
 "smm" = (
 /obj/machinery/light{
 	dir = 4
@@ -67873,6 +73033,16 @@
 /obj/structure/railing,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"snf" = (
+/obj/structure/chair/sofa{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "sng" = (
 /obj/structure/stairs/east,
 /turf/open/floor/plating/rough,
@@ -68037,6 +73207,13 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/supply)
+"spA" = (
+/obj/structure/coclock,
+/obj/machinery/computer/operating,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "spD" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -68391,6 +73568,12 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/chinatown)
+"stI" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "stS" = (
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry/old,
@@ -68460,6 +73643,14 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/chinatown)
+"suQ" = (
+/obj/structure/table/wood/poker,
+/obj/effect/decal/litter,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "suV" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -68600,6 +73791,19 @@
 	},
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/millennium_tower/ventrue)
+"swK" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 5;
+	pixel_x = -14
+	},
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 5;
+	pixel_x = -14
+	},
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "swL" = (
 /obj/structure/vampipe{
 	pixel_y = 32
@@ -68700,6 +73904,13 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/concrete,
 /area/vtm)
+"sya" = (
+/obj/structure/bookcase/random/nonfiction,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "syh" = (
 /obj/structure/trashbag,
 /obj/effect/decal/trash,
@@ -69078,6 +74289,12 @@
 /obj/structure/small_vamprocks,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/financialdistrict/construction)
+"sDR" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/stone,
+/area/vtm/sewer)
 "sDV" = (
 /obj/fusebox,
 /turf/open/floor/carpet,
@@ -69152,12 +74369,16 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
 "sEZ" = (
-/obj/effect/turf_decal/siding/white{
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/obj/structure/vampdoor/simple,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/structure/vampipe{
+	icon_state = "piping3";
+	pixel_y = 32
+	},
+/obj/effect/decal/cleanable/oil/streak,
+/turf/open/floor/plating/stone,
+/area/vtm/sewer)
 "sFf" = (
 /obj/structure/table/wood,
 /obj/item/police_radio,
@@ -69184,8 +74405,15 @@
 /turf/open/floor/carpet/black,
 /area/vtm/cabaret)
 "sFp" = (
-/obj/structure/closet,
-/turf/open/floor/plating/rough,
+/obj/effect/decal/pallet{
+	layer = 2
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/woodfancy,
 /area/vtm/sewer/nosferatu_town)
 "sFr" = (
 /mob/living/carbon/human/npc/guard,
@@ -69523,6 +74751,9 @@
 	},
 /turf/open/floor/plating/church,
 /area/vtm/church/interior)
+"sKI" = (
+/turf/closed/wall/vampwall/rustbad,
+/area/vtm/sewer/nosferatu_town)
 "sKZ" = (
 /obj/machinery/light/prince{
 	pixel_y = 32
@@ -69538,6 +74769,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/mansion)
+"sLn" = (
+/obj/structure/chair/plastic,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "sLr" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/effect/turf_decal/weather/dirt{
@@ -69551,6 +74786,20 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/graveyard)
+"sLA" = (
+/obj/structure/table/wood/bar,
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/machinery/light/small/pink{
+	dir = 1;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "sLH" = (
 /obj/transfer_point_vamp{
 	icon = 'icons/obj/stairs.dmi';
@@ -69628,6 +74877,10 @@
 /obj/structure/bloodextractor,
 /turf/open/floor/plating/toilet,
 /area/vtm/clinic/haven)
+"sMP" = (
+/mob/living/simple_animal/hostile/retaliate/frog,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "sMQ" = (
 /obj/structure/chair{
 	dir = 1
@@ -69690,29 +74943,16 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
 "sNT" = (
-/obj/effect/decal/pallet,
-/obj/machinery/light/small{
-	dir = 1
+/obj/structure/railing{
+	layer = 4
 	},
-/turf/open/floor/plating/shit,
+/obj/structure/roadblock/alt,
+/turf/open/floor/plating/grate,
 /area/vtm/sewer/nosferatu_town)
 "sNZ" = (
-/obj/structure/table/wood,
-/obj/item/vamp/keys/hack,
-/obj/item/weedpack{
-	desc = "Green and smelly... It's a special one, maybe costs hundreds of dollars...";
-	name = "Unique green package"
-	},
-/obj/item/weedpack{
-	desc = "Green and smelly... It's a special one, maybe costs hundreds of dollars...";
-	name = "Unique green package"
-	},
-/obj/item/weedpack{
-	desc = "Green and smelly... It's a special one, maybe costs hundreds of dollars...";
-	name = "Unique green package"
-	},
-/turf/open/floor/plating/parquetry/old,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/decal/wallpaper/paper/low,
+/turf/closed/wall/vampwall/junk,
+/area/vtm/interior)
 "sOa" = (
 /obj/structure/railing{
 	dir = 4
@@ -69738,11 +74978,9 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto/old)
 "sOG" = (
-/obj/item/kirbyplants/random,
-/obj/machinery/light/small{
-	pixel_y = 32
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
 	},
-/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "sOK" = (
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -69880,6 +75118,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/bacotell,
 /area/vtm/interior/shop)
+"sRz" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "sRB" = (
 /obj/structure/roadsign/warningtrafficlight,
 /turf/open/floor/plating/sidewalk,
@@ -69955,10 +75200,13 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/banu/haven)
 "sTa" = (
-/obj/structure/chair/wood{
-	dir = 8
+/obj/structure/sink{
+	dir = 8;
+	pixel_x = 10
 	},
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
 /area/vtm/interior)
 "sTi" = (
 /obj/effect/decal/bordur{
@@ -69969,13 +75217,13 @@
 /area/vtm/hotel)
 "sTl" = (
 /obj/machinery/light/small{
-	dir = 1
+	dir = 8;
+	pixel_x = 16
 	},
-/obj/structure/closet/secure_closet/freezer{
-	locked = 0
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
 	},
-/turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "sTw" = (
 /obj/structure/vampdoor/wood/cappadocian,
 /turf/open/floor/plating/rough/cave,
@@ -70100,6 +75348,23 @@
 /obj/structure/stairs/east,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/bianchiBank)
+"sUV" = (
+/obj/structure/table/wood/bar,
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/effect/decal/trash,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "sUY" = (
 /obj/structure/sign/poster/random,
 /turf/closed/wall/vampwall/rich/old,
@@ -70352,14 +75617,18 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
-"sYZ" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 16
+"sYY" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/vampipe{
+	icon_state = "piping38"
 	},
-/obj/structure/table/wood,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
+"sYZ" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/rough,
-/area/vtm/interior)
+/area/vtm/sewer/nosferatu_town)
 "sZe" = (
 /mob/living/carbon/human/species/vamp_mannequin/conquestador,
 /turf/open/floor/plating/vampplating/mono,
@@ -70468,6 +75737,15 @@
 "taP" = (
 /turf/open/floor/plating/vampwood,
 /area/vtm/hotel)
+"taR" = (
+/obj/structure/table{
+	color = "#CD5C5C"
+	},
+/obj/item/storage/backpack/duffelbag/med/surgery,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "taU" = (
 /obj/structure/vampdoor/simple,
 /obj/effect/turf_decal/siding/white,
@@ -70490,6 +75768,12 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior/millennium_tower/f5)
+"taX" = (
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tbc" = (
 /obj/effect/turf_decal/weather/sand{
 	dir = 10
@@ -70583,8 +75867,9 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/cog/caern)
 "tcb" = (
-/obj/effect/decal/trash,
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/railing,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "tcf" = (
 /obj/structure/vampfence/corner,
@@ -70699,6 +75984,32 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower/f3)
+"tds" = (
+/obj/structure/vampipe{
+	icon_state = "piping38"
+	},
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
+"tdu" = (
+/obj/structure/vampdoor/old{
+	dir = 8;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "tdK" = (
 /obj/effect/decal/litter,
 /obj/effect/turf_decal/siding/white{
@@ -70734,6 +76045,11 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/bianchiBank)
+"tdW" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cardboard,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "tec" = (
 /obj/effect/decal/bordur/corner{
 	dir = 8
@@ -70800,6 +76116,17 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
+"teJ" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/obj/effect/decal/graffiti,
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "teK" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -70854,6 +76181,16 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/wyrm_corrupted)
+"tfp" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/interior)
 "tft" = (
 /obj/effect/decal/cardboard,
 /turf/open/floor/plating/rough,
@@ -70867,12 +76204,32 @@
 /obj/structure/bookcase/random/fiction,
 /turf/open/floor/carpet,
 /area/vtm/church/interior/haven)
+"tfI" = (
+/obj/machinery/light/small/red{
+	dir = 4;
+	pixel_x = -16
+	},
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tfV" = (
 /obj/effect/turf_decal/siding/brown{
 	dir = 6
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/clinic)
+"tfZ" = (
+/obj/effect/decal/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tgb" = (
 /obj/structure/chair/office/light,
 /obj/effect/landmark/start/vdoctor,
@@ -70895,6 +76252,14 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/strip/toreador)
+"tgp" = (
+/obj/structure/chair/sofa/right{
+	dir = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tgs" = (
 /obj/structure/railing{
 	dir = 1;
@@ -70930,14 +76295,19 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"tgL" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "tgP" = (
-/obj/structure/closet/crate,
-/obj/item/drinkable_bloodpack/elite,
-/obj/item/drinkable_bloodpack/elite,
-/obj/item/drinkable_bloodpack/elite,
-/obj/item/drinkable_bloodpack/elite,
-/obj/item/drinkable_bloodpack/elite,
-/turf/open/floor/plating/parquetry/old,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "tgY" = (
 /obj/effect/decal/wallpaper/grey,
@@ -71166,6 +76536,30 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plasteel/dark,
 /area/vtm/pacificheights/old)
+"tkj" = (
+/obj/structure/showcase/machinery/tv{
+	pixel_y = 12
+	},
+/obj/structure/table,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_analog";
+	pixel_y = 29
+	},
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
+"tks" = (
+/obj/item/kirbyplants/random,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tku" = (
 /obj/effect/decal/wallpaper/grey,
 /obj/effect/decal/wallpaper,
@@ -71215,6 +76609,14 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/chantry)
+"tla" = (
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tld" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/vampdoor/simple,
@@ -71230,6 +76632,19 @@
 /obj/item/paperplane,
 /turf/open/floor/plating/bacotell,
 /area/vtm/clinic/haven)
+"tlu" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "tlx" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 1
@@ -71244,6 +76659,13 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/hotel)
+"tlB" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/structure/chair/pew/left,
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "tlC" = (
 /obj/structure/table,
 /turf/open/floor/plating/parquetry/old,
@@ -71414,12 +76836,18 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/park)
 "tnZ" = (
-/obj/machinery/light/small/red{
-	pixel_y = 24
+/obj/structure/table,
+/obj/effect/decal/rugs,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_analog";
+	pixel_y = 12
 	},
-/obj/effect/decal/trash,
-/obj/effect/decal/graffiti,
-/turf/open/floor/plating/rough/cave,
+/obj/structure/showcase/machinery/tv{
+	pixel_y = 29
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
 /area/vtm/sewer/nosferatu_town)
 "tod" = (
 /obj/effect/decal/trash{
@@ -71485,11 +76913,9 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
 "toL" = (
-/obj/structure/coclock,
 /obj/structure/table/wood,
-/obj/effect/decal/graffiti,
-/turf/open/floor/plating/parquetry/old,
-/area/vtm/sewer/nosferatu_town)
+/turf/closed/wall/vampwall/junk/low,
+/area/vtm/interior)
 "toM" = (
 /obj/structure/table/wood/fancy/black,
 /obj/item/candle,
@@ -71510,6 +76936,13 @@
 /mob/living/simple_animal/pet/cat/vampire,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/fishermanswharf/ghetto)
+"tpt" = (
+/obj/effect/decal/cleanable/blood/splatter,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "tpw" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -71564,6 +76997,19 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"tqj" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/decal/asphaltline/alt{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "tql" = (
 /obj/elevator_button_down{
 	id = 3;
@@ -71804,6 +77250,17 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
+"tsX" = (
+/obj/structure/vampdoor/old{
+	dir = 1;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "tta" = (
 /obj/structure/vampstatue/angel{
 	pixel_y = 8
@@ -72097,10 +77554,8 @@
 /turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
 "txd" = (
-/obj/structure/toilet{
-	dir = 8
-	},
-/turf/open/floor/plating/vampcanalplating,
+/obj/effect/decal/wallpaper,
+/turf/closed/wall/vampwall/junk,
 /area/vtm/interior)
 "txe" = (
 /obj/machinery/light{
@@ -72128,6 +77583,18 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"txw" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/structure/vampipe{
+	icon_state = "piping38"
+	},
+/mob/living/simple_animal/hostile/retaliate/frog,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "txy" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/fluff/hedge,
@@ -72301,6 +77768,13 @@
 "tzP" = (
 /turf/open/floor/plating/saint,
 /area/vtm/church/interior)
+"tzU" = (
+/obj/effect/decal/graffiti,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "tAd" = (
 /obj/effect/decal/bordur{
 	dir = 8
@@ -72338,10 +77812,24 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/rough,
 /area/vtm/sewer)
+"tAB" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = -12;
+	pixel_y = 2
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "tAC" = (
 /obj/effect/decal/wallpaper/light,
 /turf/closed/wall/vampwall/old,
 /area/vtm/interior/techshop)
+"tAI" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tAP" = (
 /obj/structure/vampdoor{
 	dir = 4
@@ -72450,6 +77938,13 @@
 /obj/item/argemia,
 /turf/open/floor/plating/vampcarpet,
 /area/vtm/interior/techshop)
+"tCu" = (
+/obj/structure/chair/wood{
+	dir = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "tCy" = (
 /obj/effect/turf_decal/siding/white,
 /obj/structure/curtain/bounty,
@@ -72553,6 +78048,16 @@
 /obj/structure/closet/cardboard,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/church)
+"tDO" = (
+/obj/machinery/shower{
+	dir = 4;
+	pixel_y = 5
+	},
+/obj/item/soap,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tDU" = (
 /obj/structure/bookcase/random/religion{
 	density = 0
@@ -72651,6 +78156,16 @@
 	},
 /turf/open/floor/plating/circled,
 /area/vtm/interior/wyrm_corrupted)
+"tEH" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/flora/junglebush/c,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "tEQ" = (
 /obj/structure/chair/plastic,
 /turf/open/floor/plating/sidewalk/poor,
@@ -72660,6 +78175,15 @@
 /obj/structure/tank_holder/extinguisher,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/ventrue)
+"tFk" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tFl" = (
 /turf/closed/wall/vampwall/painted/low/window,
 /area/vtm/clinic)
@@ -72703,6 +78227,10 @@
 /obj/machinery/griddle,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"tGs" = (
+/obj/structure/closet/crate/maint,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "tGv" = (
 /obj/structure/clothingrack/rand{
 	dir = 1
@@ -72730,13 +78258,10 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic/haven)
 "tGI" = (
-/obj/structure/vampdoor/reinf{
-	lock_id = "primNosferatu";
-	locked = 1;
-	lockpick_difficulty = 16;
-	name = "primogen hideout"
+/obj/structure/lamppost/sidewalk,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
 	},
-/turf/open/floor/plating/parquetry/old,
 /area/vtm/sewer/nosferatu_town)
 "tGJ" = (
 /obj/structure/table/wood,
@@ -72814,11 +78339,9 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior)
 "tHD" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/closet/secure_closet/freezer{
-	locked = 0
+/obj/structure/table/wood,
+/obj/effect/decal/bordur{
+	dir = 8
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
@@ -72861,6 +78384,16 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/anarch/basement)
+"tIC" = (
+/obj/effect/decal/asphaltline/alt{
+	dir = 8;
+	pixel_y = 15
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "tIT" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/red{
@@ -73036,6 +78569,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/financialdistrict/library)
+"tKt" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tKT" = (
 /obj/structure/mirror{
 	pixel_y = 32
@@ -73121,6 +78660,10 @@
 /obj/item/vamp/keys/lasombra,
 /turf/open/floor/plating/church,
 /area/vtm/church/interior/haven)
+"tLZ" = (
+/obj/structure/closet/crate/coffin,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "tMd" = (
 /obj/structure/coclock,
 /turf/open/floor/plating/parquetry/old,
@@ -73130,6 +78673,17 @@
 /obj/item/melee/vampirearms/katana/kosa,
 /turf/open/floor/plating/concrete,
 /area/vtm/graveyard/interior)
+"tMv" = (
+/obj/structure/table/wood,
+/obj/effect/decal/pallet,
+/obj/item/flashlight/lamp{
+	light_color = "#FFA500";
+	light_range = 3;
+	pixel_x = -8;
+	pixel_y = 11
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "tMC" = (
 /obj/effect/decal/support,
 /obj/machinery/light/prince/broken{
@@ -73369,9 +78923,10 @@
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
 "tQn" = (
-/obj/effect/decal/wallpaper/gold/alt,
-/obj/effect/decal/wallpaper/gold/alt,
-/turf/closed/wall/vampwall/junk/alt,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
 /area/vtm/sewer/nosferatu_town)
 "tQp" = (
 /obj/structure/vampdoor/glass/clerk{
@@ -73437,6 +78992,16 @@
 	},
 /turf/open/floor/plating/vampdirt,
 /area/vtm/pacificheights/forest)
+"tRn" = (
+/obj/structure/table,
+/obj/item/flashlight/lamp{
+	pixel_y = 13;
+	pixel_x = -11
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tRv" = (
 /obj/structure/table,
 /obj/machinery/button/door{
@@ -73463,6 +79028,13 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/pacificheights/community)
+"tRQ" = (
+/obj/structure/chair/plastic{
+	dir = 4;
+	pixel_y = 7
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "tRR" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/machinery/light/small/red{
@@ -73503,6 +79075,12 @@
 /obj/structure/table,
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/jazzclub)
+"tSt" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "tSy" = (
 /obj/item/storage/box/lights/mixed,
 /obj/item/wirecutters,
@@ -73588,6 +79166,14 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm)
+"tUg" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 8;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "tUl" = (
 /obj/effect/decal/shadow,
 /obj/effect/decal/coastline{
@@ -73639,6 +79225,19 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/unionsquare)
+"tUJ" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 1;
+	lock_id = "nosferatu2";
+	lockpick_difficulty = 6;
+	name = "house-2"
+	},
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "tUK" = (
 /obj/structure/vampdoor/police/secure{
 	color = "#466a72";
@@ -73722,11 +79321,20 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/tzimisce_manor)
+"tVB" = (
+/obj/effect/decal/trash,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "tVQ" = (
-/obj/structure/railing{
-	pixel_y = -4
+/obj/structure/chair/sofa/corner{
+	dir = 8
 	},
-/turf/open/floor/plating/rough/cave,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/concrete,
 /area/vtm/sewer/nosferatu_town)
 "tVY" = (
 /obj/structure/flora/ausbushes/reedbush,
@@ -73736,6 +79344,12 @@
 /obj/effect/turf_decal/weather/dirt,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/interior/cog/caern)
+"tWb" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/vampgrass,
+/area/vtm/sewer)
 "tWg" = (
 /obj/effect/decal/crosswalk{
 	dir = 4
@@ -73986,10 +79600,25 @@
 /obj/structure/window/reinforced/tinted,
 /turf/open/floor/carpet,
 /area/vtm/interior/strip/elysium)
+"tZl" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/fire_barrel,
+/turf/open/floor/plating/stone,
+/area/vtm/sewer)
 "tZr" = (
 /obj/machinery/light/small,
 /turf/closed/wall/vampwall/rock,
 /area/vtm/interior/cog/caern)
+"tZH" = (
+/obj/structure/vampipe{
+	icon_state = "piping3";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "tZK" = (
 /obj/machinery/light{
 	pixel_y = 32
@@ -74002,10 +79631,11 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
 "tZN" = (
-/obj/structure/chair/greyscale{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
 	},
-/turf/open/floor/plating/rough/cave,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/vampdirt,
 /area/vtm/sewer/nosferatu_town)
 "tZO" = (
 /obj/structure/musician/piano{
@@ -74060,6 +79690,15 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/jazzclub)
+"uaF" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "uaG" = (
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/ghost/hostile,
@@ -74242,8 +79881,18 @@
 /turf/open/floor/plating/circled,
 /area/vtm/interior/laundromat)
 "udJ" = (
-/obj/effect/decal/wallpaper/paper/stripe,
-/turf/closed/wall/vampwall,
+/obj/structure/table/wood,
+/obj/vampire_computer,
+/obj/item/flashlight/lamp{
+	pixel_y = 13;
+	pixel_x = -11
+	},
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough,
 /area/vtm/interior)
 "udK" = (
 /obj/machinery/light/prince{
@@ -74303,6 +79952,10 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm/interior/oldchurch)
+"ueH" = (
+/obj/machinery/vending/boozeomat/all_access,
+/turf/open/floor/plating/industrial,
+/area/vtm/sewer/nosferatu_town)
 "ueK" = (
 /obj/structure/vampdoor/simple,
 /obj/effect/turf_decal/siding/white{
@@ -74339,6 +79992,10 @@
 	},
 /turf/open/floor/plating/vampcarpet,
 /area/vtm/interior/bianchiBank)
+"ueZ" = (
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "ufB" = (
 /obj/item/pizzabox/mushroom{
 	pixel_y = 10
@@ -74375,16 +80032,11 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
 "ufO" = (
-/obj/effect/decal/cardboard,
-/obj/structure/vampdoor/old{
-	dir = 8;
-	lock_id = "nosferatu";
-	locked = 1;
-	lockpick_difficulty = 8;
-	name = "old strange door"
-	},
-/turf/open/floor/plating/rough/cave,
-/area/vtm/sewer)
+/obj/item/bedsheet/orange,
+/obj/structure/bed,
+/obj/item/restraints/handcuffs/fake,
+/turf/open/floor/carpet/green,
+/area/vtm/sewer/nosferatu_town)
 "ugp" = (
 /obj/effect/decal/trash,
 /turf/open/floor/plating/rough/cave,
@@ -74478,6 +80130,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/vtm/interior/tzimisce_manor)
+"uht" = (
+/obj/item/reagent_containers/food/drinks/meth/cocaine,
+/obj/machinery/camera{
+	dir = 4
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer)
 "uhz" = (
 /obj/structure/vampdoor/wood{
 	lock_id = "primBanu";
@@ -74492,6 +80151,21 @@
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/parquetry,
 /area/vtm/clinic)
+"uhG" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/railing{
+	layer = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "uhH" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 6
@@ -74541,14 +80215,12 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/church/interior/staff)
 "uiE" = (
-/obj/structure/weedshit,
-/obj/machinery/light/small/pink{
-	dir = 4;
-	pixel_x = -16
+/obj/structure/barrels{
+	icon_state = "barrels9"
 	},
-/obj/effect/decal/graffiti,
-/obj/effect/decal/pallet,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
 /area/vtm/sewer/nosferatu_town)
 "uiG" = (
 /obj/structure/railing{
@@ -74749,6 +80421,26 @@
 /obj/structure/table,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
+"ulD" = (
+/obj/item/kirbyplants/random,
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/obj/effect/decal/litter,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_x = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
+"ulG" = (
+/obj/effect/decal/litter,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "ulT" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -74808,6 +80500,13 @@
 	},
 /turf/open/water,
 /area/vtm/interior/bianchiBank)
+"umr" = (
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "ums" = (
 /obj/item/candle/infinite,
 /turf/open/floor/plating/concrete,
@@ -74958,6 +80657,9 @@
 /obj/structure/filingcabinet/filingcabinet,
 /turf/open/floor/carpet,
 /area/vtm/hotel)
+"uol" = (
+/turf/open/floor/plating/stone,
+/area/vtm/sewer)
 "uon" = (
 /obj/effect/decal/bordur/corner,
 /obj/effect/landmark/npcbeacon/directed{
@@ -75014,11 +80716,9 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/interior/oldchurch)
 "uoI" = (
-/obj/structure/chair/wood{
-	dir = 1
-	},
-/turf/open/floor/plating/rough,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/decal/wallpaper/paper/green/low,
+/turf/closed/wall/vampwall/junk,
+/area/vtm/interior)
 "uoJ" = (
 /obj/structure/vamproofwall{
 	color = "#7c7c7c";
@@ -75098,22 +80798,18 @@
 	dir = 1;
 	lock_id = "nosferatu";
 	locked = 1;
-	lockpick_difficulty = 8;
+	lockpick_difficulty = 20;
 	name = "old strange door"
 	},
 /turf/open/floor/plating/rough/cave,
-/area/vtm/sewer)
+/area/vtm/sewer/nosferatu_town)
 "uqc" = (
 /obj/machinery/vending/boozeomat/all_access,
 /turf/open/floor/carpet,
 /area/vtm/interior/strip/elysium)
 "uqk" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	pixel_y = 32
-	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/large,
 /turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "uqq" = (
@@ -75140,10 +80836,17 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch)
 "uqL" = (
-/obj/effect/decal/pallet{
-	pixel_y = -7
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/turf/open/floor/plating/shit,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
+"uqP" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "uqQ" = (
 /obj/effect/decal/bordur,
@@ -75251,11 +80954,21 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/restricted)
 "urX" = (
-/obj/machinery/light/small{
-	dir = 8;
-	pixel_x = 16
+/obj/machinery/washing_machine,
+/obj/item/flashlight/lamp{
+	light_color = "#FFA500";
+	light_range = 3;
+	pixel_x = -8;
+	pixel_y = 11
 	},
-/turf/open/floor/plating/vampcanalplating,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
 /area/vtm/interior)
 "use" = (
 /obj/effect/decal/cleanable/blood/old,
@@ -75286,6 +80999,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/wood,
 /area/vtm/interior/oldchurch)
+"usB" = (
+/obj/structure/weedshit,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "usM" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8;
@@ -75329,13 +81048,14 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
 "uts" = (
-/obj/structure/railing{
-	dir = 4
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
 	},
-/obj/structure/railing{
-	dir = 4;
-	pixel_y = -10
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 10;
+	layer = 4.3
 	},
+/obj/structure/railing,
 /turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "utx" = (
@@ -75450,6 +81170,15 @@
 	},
 /turf/open/floor/plating/bacotell,
 /area/vtm/clinic/haven)
+"uuN" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 5
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uvn" = (
 /obj/structure/railing{
 	dir = 4
@@ -75468,6 +81197,15 @@
 	},
 /turf/open/floor/plating/vampcarpet,
 /area/vtm/interior/techshop)
+"uvz" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 6
+	},
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/turf/open/floor/plating/vampcarpet,
+/area/vtm/interior)
 "uvB" = (
 /obj/structure/fluff/hedge,
 /obj/effect/turf_decal/siding/wideplating/dark{
@@ -75700,6 +81438,12 @@
 /obj/effect/decal/trash,
 /turf/open/floor/plating/vampwood,
 /area/vtm/sewer/nosferatu_town)
+"uyi" = (
+/obj/structure/vampfence/rich{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "uyr" = (
 /turf/closed/wall/vampwall/rich,
 /area/vtm/interior/millennium_tower/f4)
@@ -75805,15 +81549,10 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f4)
 "uzY" = (
-/obj/machinery/light{
-	pixel_y = 32
+/obj/structure/clothinghanger,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
 	},
-/obj/structure/table/wood,
-/obj/item/vamp/keys/camarilla{
-	accesslocks = list("nosferatu","nosferatu1","nosferatu2","nosferatu3");
-	name = "Master key"
-	},
-/turf/open/floor/plating/parquetry/old,
 /area/vtm/sewer/nosferatu_town)
 "uAb" = (
 /obj/machinery/light/small{
@@ -75880,10 +81619,28 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/strip)
+"uAA" = (
+/obj/structure/curtain/cloth,
+/obj/item/soap,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_x = 1
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/interior)
 "uAD" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck,
-/turf/open/floor/plating/vampdirt,
+/obj/effect/decal/graffiti,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/decal/bordur{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "uAF" = (
 /obj/effect/decal/wallpaper/paper/rich,
@@ -76013,6 +81770,16 @@
 /obj/effect/landmark/npcwall,
 /turf/open/floor/plating/vampdirt,
 /area/vtm/pacificheights/old)
+"uCr" = (
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/structure/table,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uCs" = (
 /obj/effect/decal/cardboard,
 /turf/open/floor/plating/sidewalk/poor,
@@ -76103,6 +81870,13 @@
 /obj/item/stack/dollar/hundred,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/setite)
+"uDN" = (
+/obj/effect/decal/litter,
+/obj/machinery/camera{
+	dir = 8
+	},
+/turf/open/floor/plating/sidewalk/poor,
+/area/vtm/sewer/nosferatu_town)
 "uDS" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/vamptree,
@@ -76191,6 +81965,17 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"uEW" = (
+/obj/effect/decal/trash,
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uEY" = (
 /turf/open/floor/plating/vampacid,
 /area/vtm/interior/wyrm_corrupted)
@@ -76298,6 +82083,10 @@
 /obj/structure/chair/sofa/corp,
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/millennium_tower/f4)
+"uGH" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "uGK" = (
 /obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating/vampwood,
@@ -76351,6 +82140,19 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/sewer)
+"uHn" = (
+/obj/structure/vampipe{
+	icon_state = "piping5";
+	pixel_y = 32
+	},
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uHt" = (
 /obj/structure/chinesesign{
 	dir = 1
@@ -76621,6 +82423,12 @@
 /obj/item/melee/vampirearms/tire,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"uLh" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uLt" = (
 /obj/structure/table,
 /turf/open/floor/plating/granite/black,
@@ -76664,10 +82472,27 @@
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
 "uMr" = (
-/obj/structure/closet/secure_closet/freezer{
-	locked = 0
+/obj/structure/vampdoor/simple{
+	dir = 8
 	},
-/turf/open/floor/plating/rough,
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/industrial,
+/area/vtm/interior)
+"uMs" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
 /area/vtm/interior)
 "uMw" = (
 /obj/structure/chair/sofa/corp/corner{
@@ -76715,6 +82540,14 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/chantry)
+"uNc" = (
+/obj/structure/chair/greyscale{
+	dir = 4
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uNz" = (
 /obj/machinery/light/small/red{
 	pixel_y = 24
@@ -76751,6 +82584,20 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict)
+"uNV" = (
+/obj/structure/closet/crate/large,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_nature";
+	layer = 4.2;
+	pixel_y = 12
+	},
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 8
+	},
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uNY" = (
 /obj/effect/landmark/start/trujah,
 /turf/open/floor/plating/parquetry/old,
@@ -76923,14 +82770,27 @@
 /obj/fusebox,
 /turf/open/floor/plating/granite/black,
 /area/vtm/interior/museum)
+"uQE" = (
+/obj/effect/decal/rugs,
+/obj/structure/vampdoor/wood/old{
+	dir = 1;
+	lock_id = "nosferatu"
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uQF" = (
-/obj/structure/table/wood,
-/obj/item/clothing/mask/vampire/balaclava,
-/turf/open/floor/plating/parquetry/old,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "uQH" = (
 /turf/open/floor/plating/sidewalk,
 /area/vtm/ghetto/old)
+"uQJ" = (
+/obj/structure/closet,
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "uQS" = (
 /turf/open/floor/plating/toilet,
 /area/vtm/interior)
@@ -77102,13 +82962,22 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower/f2)
-"uTn" = (
-/obj/machinery/light/small{
-	dir = 1
+"uTg" = (
+/obj/structure/barrels{
+	icon_state = "barrels3"
 	},
-/obj/machinery/vending/boozeomat,
-/turf/open/floor/plating/rough,
+/obj/effect/decal/trash,
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
 /area/vtm/sewer/nosferatu_town)
+"uTn" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/glowshroom,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "uTo" = (
 /obj/structure/weedshit,
 /turf/open/floor/plating/parquetry/old,
@@ -77176,6 +83045,18 @@
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/vtm/anarch)
+"uTM" = (
+/obj/effect/decal/graffiti,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uTQ" = (
 /obj/structure/fluff/hedge,
 /obj/structure/railing{
@@ -77307,6 +83188,12 @@
 /obj/item/clothing/suit/apron/surgical,
 /turf/open/floor/plating/toilet,
 /area/vtm/sewer/tzimisce_sanctum)
+"uVE" = (
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "uVJ" = (
 /obj/machinery/mineral/equipment_vendor/fastfood/sodavendor/blue{
 	pixel_y = 20;
@@ -77600,6 +83487,15 @@
 /obj/structure/big_vamprocks,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/pacificheights/forest)
+"uYG" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	pixel_x = -2;
+	pixel_y = 12
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "uYJ" = (
 /obj/structure/chair/sofa/right{
 	dir = 8
@@ -77621,6 +83517,10 @@
 "uYT" = (
 /turf/closed/wall/vampwall/brick,
 /area/vtm/interior)
+"uYW" = (
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "uZb" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm)
@@ -77656,6 +83556,10 @@
 	},
 /turf/open/floor/plating/bacotell,
 /area/vtm/clinic/haven)
+"uZI" = (
+/obj/effect/decal/wallpaper/low,
+/turf/closed/wall/vampwall/junk/alt/low/window,
+/area/vtm/sewer/nosferatu_town)
 "uZV" = (
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/police)
@@ -77749,6 +83653,9 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plating/bacotell,
 /area/vtm/interior/cog/pantry)
+"vba" = (
+/turf/closed/wall/vampwall/junk/alt/low,
+/area/vtm/sewer/nosferatu_town)
 "vbd" = (
 /obj/effect/decal/litter,
 /obj/effect/decal/bordur{
@@ -77888,6 +83795,12 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"vdo" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "vdp" = (
 /obj/structure/coclock,
 /obj/structure/chair/sofa,
@@ -77981,11 +83894,26 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/giovanni/basement)
 "veG" = (
-/obj/structure/chair{
+/obj/effect/decal/pallet{
+	pixel_y = -3
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/trashbag{
+	pixel_y = 9
+	},
+/obj/structure/trashbag{
+	pixel_x = -3;
+	pixel_y = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
 	dir = 1
 	},
-/turf/open/floor/plating/rough/cave,
-/area/vtm/sewer/nosferatu_town)
+/obj/item/restraints/legcuffs/beartrap{
+	icon_state = "beartrap1";
+	armed = 1
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "veN" = (
 /obj/effect/decal/trash,
 /turf/open/floor/plating/rough,
@@ -78053,6 +83981,10 @@
 /obj/structure/vampdoor/camarilla,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
+"vfR" = (
+/obj/machinery/camera/directional/west,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer/nosferatu_town)
 "vfV" = (
 /obj/structure/chair/office,
 /turf/open/floor/plating/circled,
@@ -78075,6 +84007,17 @@
 /mob/living/simple_animal/hostile/retaliate/goose,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"vgn" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vgo" = (
 /obj/effect/decal/trash{
 	icon_state = "trash8"
@@ -78221,6 +84164,18 @@
 	},
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/pacificheights/forest)
+"vii" = (
+/obj/structure/vampipe{
+	icon_state = "piping32";
+	pixel_y = 17
+	},
+/obj/structure/vampipe{
+	icon_state = "piping32"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vip" = (
 /obj/machinery/computer/stockexchange{
 	density = 0;
@@ -78297,6 +84252,15 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/baali)
+"vjh" = (
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "vjk" = (
 /obj/effect/decal/cleanable/blood/drip,
 /turf/open/floor/plating/vampdirt,
@@ -78468,6 +84432,15 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/fishermanswharf/lower)
+"vlQ" = (
+/obj/structure/sink{
+	pixel_y = 16
+	},
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/industrial,
+/area/vtm/interior)
 "vlR" = (
 /obj/structure/filingcabinet/medical,
 /turf/open/floor/plating/vampwood,
@@ -78551,6 +84524,15 @@
 /turf/open/space/basic,
 /turf/closed/wall/vampwall/rich/old,
 /area/vtm/interior/cog/pantry)
+"vnv" = (
+/obj/effect/decal/bordur{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vnJ" = (
 /obj/structure/trad{
 	pixel_y = 32
@@ -78591,6 +84573,12 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/theatre)
+"vor" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "vot" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -78824,6 +84812,19 @@
 	},
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/police)
+"vrm" = (
+/obj/item/candle/infinite{
+	pixel_y = -8
+	},
+/obj/effect/decal/bordur,
+/obj/structure/vampipe{
+	icon_state = "piping7";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vrn" = (
 /obj/structure/vampfence/rich{
 	dir = 4
@@ -78881,16 +84882,31 @@
 /turf/open/floor/plating/asphalt,
 /area/vtm/financialdistrict)
 "vrU" = (
-/obj/machinery/light/small/red{
-	pixel_y = 24
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/chair/sofa/left,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 6
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/item/vtm_artifact/rand,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "vrV" = (
 /obj/effect/decal/bordur,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/fishermanswharf)
+"vrX" = (
+/obj/structure/chair/comfy/beige{
+	dir = 1
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vsr" = (
 /obj/structure/closet/crate/coffin,
 /turf/open/floor/carpet/lone,
@@ -78910,6 +84926,9 @@
 /area/vtm/cabaret)
 "vsE" = (
 /obj/structure/lamppost/sidewalk,
+/obj/effect/decal/bordur{
+	dir = 1
+	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/sewer/nosferatu_town)
 "vsG" = (
@@ -78918,6 +84937,13 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/banu/haven)
+"vth" = (
+/obj/structure/chair/sofa/left{
+	dir = 8
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "vto" = (
 /obj/effect/decal/rugs{
 	pixel_x = 2;
@@ -79070,8 +85096,9 @@
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/cog/caern)
 "vvq" = (
-/obj/effect/decal/wallpaper/paper/darkred,
-/turf/closed/wall/vampwall/junk/alt,
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "vvs" = (
 /obj/structure/chair/sofa/corp/left{
@@ -79279,6 +85306,13 @@
 /obj/manholeup,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/shop)
+"vxq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "vxt" = (
 /obj/effect/decal/wallpaper/paper/darkred,
 /obj/machinery/light/small{
@@ -79436,6 +85470,13 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior)
+"vAS" = (
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "vBa" = (
 /obj/structure/chair/plastic,
 /turf/open/floor/plating/parquetry,
@@ -79553,6 +85594,21 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"vCs" = (
+/obj/structure/vamprocks{
+	icon_state = "rock8"
+	},
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars";
+	pixel_y = 32
+	},
+/obj/machinery/light/blacklight{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "vCt" = (
 /obj/effect/turf_decal/siding/wood,
 /obj/machinery/light{
@@ -79560,6 +85616,13 @@
 	},
 /turf/open/floor/plating/parquetry,
 /area/vtm/interior/millennium_tower/f2)
+"vCw" = (
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/effect/decal/pallet,
+/turf/closed/wall/vampwall/junk,
+/area/vtm/sewer/nosferatu_town)
 "vCy" = (
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
@@ -79587,6 +85650,15 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict/construction)
+"vCX" = (
+/obj/effect/decal/asphaltline/alt{
+	pixel_x = -14
+	},
+/obj/effect/decal/asphaltline/alt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "vDe" = (
 /obj/structure/fluff/hedge,
 /turf/open/floor/plating/granite/black,
@@ -79718,6 +85790,18 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/cog/caern)
+"vEo" = (
+/obj/structure/clothingrack/rand{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "vEp" = (
 /obj/structure/chair/greyscale{
 	dir = 8
@@ -79821,8 +85905,15 @@
 /area/vtm/fishermanswharf/ghetto)
 "vFy" = (
 /obj/effect/decal/bordur,
-/turf/closed/wall/vampwall/junk,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/decal/wallpaper/paper/low,
+/obj/effect/decal/wallpaper/paper/green/low,
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/closed/wall/vampwall/junk/low/window,
+/area/vtm/interior)
 "vFE" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -79945,6 +86036,13 @@
 	name = "flesh floor"
 	},
 /area/vtm/sewer/tzimisce_sanctum)
+"vGS" = (
+/obj/effect/turf_decal/siding/wideplating/dark,
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vGT" = (
 /obj/machinery/light/small{
 	dir = 8;
@@ -79992,10 +86090,14 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior)
 "vHF" = (
-/obj/structure/railing{
+/obj/structure/vampdoor/wood{
+	lock_id = "nosferatu";
+	lockpick_difficulty = 8;
 	dir = 8
 	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial5"
+	},
 /area/vtm/sewer/nosferatu_town)
 "vHG" = (
 /obj/structure/lamppost/three,
@@ -80042,6 +86144,22 @@
 /obj/item/drinkable_bloodpack,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/baali)
+"vIh" = (
+/obj/effect/decal/litter,
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
+"vIk" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "vIq" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -80126,6 +86244,11 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/restricted)
+"vJh" = (
+/obj/structure/vampdoor/simple,
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "vJj" = (
 /obj/effect/decal/painting/third{
 	pixel_y = 32
@@ -80136,6 +86259,13 @@
 	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower)
+"vJm" = (
+/obj/effect/decal/pallet{
+	pixel_x = -3;
+	pixel_y = -4
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "vJn" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/plating/parquetry,
@@ -80154,6 +86284,13 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/supply)
+"vJx" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "vJD" = (
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/gnawer)
@@ -80252,6 +86389,10 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/chantry)
+"vLk" = (
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "vLl" = (
 /obj/machinery/light/small{
 	pixel_y = 32
@@ -80297,6 +86438,14 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/millennium_tower/ventrue)
+"vMg" = (
+/obj/structure/vampfence/rich{
+	dir = 4;
+	layer = 5;
+	name = "window bars"
+	},
+/turf/closed/wall/vampwall/bar/low/window,
+/area/vtm/sewer/nosferatu_town)
 "vMo" = (
 /obj/structure/railing{
 	dir = 1;
@@ -80481,6 +86630,14 @@
 	},
 /turf/open/floor/carpet/cyan,
 /area/vtm/hotel)
+"vPh" = (
+/obj/structure/chair/plastic{
+	dir = 4;
+	pixel_y = 7
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "vPj" = (
 /obj/structure/bed,
 /turf/open/floor/plating/parquetry/old,
@@ -80527,6 +86684,14 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/financialdistrict)
+"vPU" = (
+/obj/structure/barrels{
+	icon_state = "barrel6"
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vPX" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -80547,6 +86712,12 @@
 	},
 /turf/open/floor/carpet/royalblue,
 /area/vtm/clinic)
+"vQg" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial6"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vQj" = (
 /obj/effect/turf_decal/siding/white{
 	dir = 8
@@ -80718,6 +86889,12 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/millennium_tower/f4)
+"vSm" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "vSn" = (
 /turf/open/floor/plating/granite/black,
 /area/vtm/cabaret/basement)
@@ -80830,10 +87007,15 @@
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
 "vUi" = (
-/obj/structure/chair/old/tzimisce{
-	dir = 1
+/obj/structure/flora/ausbushes/sparsegrass{
+	icon_state = "reedbush_4"
 	},
-/turf/open/floor/plating/vampdirt,
+/obj/effect/decal/bordur{
+	dir = 4
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "vUm" = (
 /obj/effect/turf_decal/weather/dirt{
@@ -80891,6 +87073,24 @@
 /obj/structure/chair/stool/bar,
 /turf/open/floor/plating/parquetry,
 /area/vtm/jazzclub)
+"vUE" = (
+/obj/effect/decal/graffiti,
+/obj/structure/table/wood,
+/obj/item/kirbyplants/dead{
+	desc = "It doesn't look very healthy...";
+	name = "dead plant";
+	pixel_y = 7
+	},
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vUF" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -80916,6 +87116,17 @@
 /obj/vampire_computer,
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/chantry)
+"vUQ" = (
+/obj/effect/decal/trash,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/toilet{
+	dir = 8;
+	pixel_y = 6
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating2"
+	},
+/area/vtm/sewer/nosferatu_town)
 "vUV" = (
 /obj/machinery/light/cold{
 	dir = 8
@@ -81033,6 +87244,28 @@
 /obj/item/clothing/ears/fake_p25radio,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/setite/basement)
+"vWH" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/decal/pallet,
+/obj/structure/bed/maint{
+	pixel_x = 12;
+	pixel_y = 2
+	},
+/obj/structure/bed/maint{
+	pixel_x = 14;
+	pixel_y = 8
+	},
+/obj/structure/vampipe{
+	icon_state = "piping9";
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampbeach,
+/area/vtm/sewer)
 "vWI" = (
 /obj/effect/decal/litter,
 /obj/structure/fluff/hedge,
@@ -81202,6 +87435,19 @@
 /obj/effect/landmark/npcbeacon/directed,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf)
+"vYD" = (
+/obj/effect/decal/pallet{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/turf/open/floor/plating/woodfancy,
+/area/vtm/sewer/nosferatu_town)
+"vYL" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "vYU" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -81311,6 +87557,19 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
+"wae" = (
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	pixel_x = -2;
+	pixel_y = 12
+	},
+/obj/effect/decal/pallet,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/machinery/light/small/blacklight{
+	pixel_y = 25
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "waf" = (
 /obj/structure/vampipe{
 	icon_state = "piping31"
@@ -81329,6 +87588,20 @@
 /obj/elevator_door/start_closed,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/millennium_tower)
+"waq" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "wav" = (
 /obj/structure/vampdoor/wood{
 	lock_id = "banuhaqim";
@@ -81464,6 +87737,14 @@
 /obj/structure/dresser,
 /turf/open/floor/carpet/red,
 /area/vtm/interior/millennium_tower/f2)
+"wch" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wcl" = (
 /obj/machinery/light/prince{
 	dir = 1
@@ -81651,6 +87932,12 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/church/interior/haven)
+"weL" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "weN" = (
 /obj/effect/decal/bordur,
 /obj/effect/landmark/npcwall,
@@ -81683,6 +87970,10 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/mansion)
+"wfG" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "wfV" = (
 /obj/item/newspaper,
 /obj/structure/table/wood/fancy/green,
@@ -81869,11 +88160,20 @@
 /turf/open/floor/plating/roofwalk,
 /area/vtm/pacificheights/forest)
 "wiz" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/item/flashlight/lamp{
+	pixel_x = -9;
+	pixel_y = 11
 	},
-/turf/open/floor/plating/vampcanalplating,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/decal/litter,
+/obj/structure/table/wood,
+/obj/structure/showcase/machinery/tv{
+	icon_state = "tv_analog";
+	pixel_x = 10;
+	pixel_y = 13
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/vampcarpet,
+/area/vtm/interior)
 "wiA" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/plating/parquetry,
@@ -81950,6 +88250,13 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/cog/caern)
+"wjN" = (
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/turf/open/floor/plating/rough{
+	icon_state = "carpet_black"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wjS" = (
 /obj/structure/trashcan,
 /obj/manholedown,
@@ -81989,10 +88296,12 @@
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic)
 "wku" = (
-/obj/machinery/light/small/pink{
+/obj/machinery/light/dim{
 	pixel_y = 32
 	},
-/turf/open/floor/plating/rough/cave,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "wky" = (
 /obj/structure/table/wood,
@@ -82112,10 +88421,8 @@
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/fishermanswharf/lower)
 "wmq" = (
-/obj/structure/chair/greyscale{
-	dir = 1
-	},
-/turf/open/floor/plating/rough,
+/obj/effect/decal/wallpaper/grey/low,
+/turf/closed/wall/vampwall/junk,
 /area/vtm/sewer/nosferatu_town)
 "wmA" = (
 /obj/machinery/shower{
@@ -82162,6 +88469,13 @@
 /obj/structure/vampfence/rich,
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/financialdistrict)
+"wmY" = (
+/obj/structure/chair/plastic,
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "wnk" = (
 /obj/structure/roadsign/busstop,
 /obj/effect/landmark/npcactivity,
@@ -82296,6 +88610,16 @@
 	},
 /turf/open/floor/carpet/purple,
 /area/vtm/interior/millennium_tower/ventrue)
+"wpe" = (
+/obj/structure/chair/sofa/corp/corner{
+	dir = 4;
+	color = "#50C878"
+	},
+/obj/item/vamp/keys/nosferatu,
+/obj/effect/decal/graffiti,
+/obj/fusebox,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "wpo" = (
 /obj/effect/decal/bordur,
 /obj/item/vamp/phone/street{
@@ -82370,11 +88694,25 @@
 /obj/structure/table/wood,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/chantry)
+"wqn" = (
+/obj/structure/chair/comfy/black{
+	dir = 4
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "wqu" = (
 /obj/effect/decal/bordur/corner,
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/unionsquare)
+"wqv" = (
+/obj/structure/closet/crate/coffin,
+/obj/machinery/light/small/pink{
+	dir = 1;
+	pixel_y = -17
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "wqz" = (
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/sewer)
@@ -82567,6 +88905,11 @@
 	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/forest)
+"wtj" = (
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wtl" = (
 /obj/effect/decal/bordur/corner{
 	dir = 8
@@ -82597,6 +88940,12 @@
 	},
 /turf/open/floor/plating/parquetry/rich,
 /area/vtm/interior/millennium_tower/f4)
+"wtG" = (
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wtH" = (
 /obj/machinery/light/prince{
 	dir = 4;
@@ -82604,6 +88953,19 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/tzimisce_manor)
+"wtI" = (
+/obj/effect/decal/bordur/corner,
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer/nosferatu_town)
+"wtL" = (
+/obj/machinery/light/small{
+	pixel_y = 32
+	},
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "wuj" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
@@ -82653,6 +89015,16 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/cog/caern)
+"wvo" = (
+/obj/structure/closet,
+/obj/item/vampire_flamethrower{
+	masquerade_violating = 0
+	},
+/obj/item/gas_can/full,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wvw" = (
 /obj/structure/table,
 /obj/item/police_radio,
@@ -82885,6 +89257,24 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/police/fed)
+"wyd" = (
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
+"wyq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "wyr" = (
 /obj/effect/decal/rugs,
 /obj/structure/sink{
@@ -82924,6 +89314,14 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/chantry)
+"wyZ" = (
+/obj/structure/chair/greyscale{
+	dir = 4
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wzt" = (
 /obj/structure/railing{
 	layer = 4;
@@ -83380,6 +89778,13 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/interior/ghetto)
+"wFc" = (
+/obj/machinery/light/small{
+	dir = 1;
+	pixel_y = -16
+	},
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
 "wFk" = (
 /obj/structure/stalagmite,
 /obj/effect/decal/cleanable/blood/old,
@@ -83557,12 +89962,19 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/sewer)
-"wHH" = (
-/obj/effect/decal/pallet{
-	pixel_x = -3;
-	pixel_y = -5
+"wHF" = (
+/obj/structure/clothinghanger,
+/obj/effect/decal/litter,
+/obj/effect/decal/graffiti,
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
 	},
-/turf/open/floor/plating/shit,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
+"wHH" = (
+/obj/effect/decal/rugs,
+/turf/open/floor/plating/rough/cave,
 /area/vtm/sewer/nosferatu_town)
 "wHQ" = (
 /obj/item/kirbyplants/dead{
@@ -83610,6 +90022,15 @@
 "wIg" = (
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/interior/shop)
+"wIh" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "wIj" = (
 /turf/closed/wall/vampwall/brick/low/window,
 /area/vtm/supply)
@@ -83622,6 +90043,12 @@
 	},
 /turf/open/floor/plating/roofwalk,
 /area/vtm)
+"wIl" = (
+/obj/machinery/light/dim{
+	dir = 8
+	},
+/turf/open/floor/plating/dirt,
+/area/vtm/sewer/nosferatu_town)
 "wIm" = (
 /obj/structure/chair/comfy{
 	dir = 8
@@ -83702,6 +90129,16 @@
 	},
 /turf/open/floor/plating/rough/cave,
 /area/vtm/sewer)
+"wJS" = (
+/obj/item/kirbyplants/dead{
+	desc = "It doesn't look very healthy...";
+	name = "dead plant";
+	pixel_y = 7
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal1"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wJT" = (
 /obj/structure/table,
 /obj/american_flag{
@@ -83749,6 +90186,10 @@
 /obj/effect/turf_decal/stripes/red/full,
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower/f4)
+"wKq" = (
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/concrete,
+/area/vtm/sewer/nosferatu_town)
 "wKy" = (
 /mob/living/carbon/human/npc/guard,
 /turf/open/floor/plating/concrete,
@@ -83876,11 +90317,8 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/interior/oldchurch)
 "wLI" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/obj/item/vamp/keys/nosferatu,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/shit,
 /area/vtm/sewer/nosferatu_town)
 "wLO" = (
 /obj/effect/turf_decal/siding/white{
@@ -83939,6 +90377,11 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/banu)
+"wMB" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "wMM" = (
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/pacificheights/community)
@@ -84049,6 +90492,12 @@
 /obj/effect/decal/asphaltline,
 /turf/open/floor/plating/asphalt,
 /area/vtm/pacificheights)
+"wOJ" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "wOK" = (
 /obj/structure/trashcan,
 /obj/effect/decal/garou_glyph/hive,
@@ -84071,6 +90520,21 @@
 /obj/effect/landmark/npcability,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/unionsquare)
+"wOZ" = (
+/obj/structure/flora/ausbushes/sparsegrass{
+	icon_state = "lavendergrass_3"
+	},
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
+"wPe" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/structure/flora/rock/pile/largejungle,
+/obj/structure/flora/junglebush/large,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "wPf" = (
 /mob/living/carbon/human/npc/guard,
 /obj/structure/chair/office{
@@ -84178,9 +90642,15 @@
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/police/upstairs)
 "wQk" = (
-/obj/structure/closet/crate/bin,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/effect/decal/bordur{
+	dir = 1
+	},
+/obj/effect/decal/bordur{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating/sidewalk/old,
+/area/vtm/sewer/nosferatu_town)
 "wQm" = (
 /obj/effect/decal/litter,
 /obj/item/cigbutt,
@@ -84295,11 +90765,8 @@
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/graveyard)
 "wSF" = (
-/obj/structure/chair/comfy/beige,
-/obj/effect/landmark/start/citizen{
-	name = "Primogen Nosferatu"
-	},
-/turf/open/floor/carpet/black,
+/obj/effect/decal/wallpaper,
+/turf/closed/wall/vampwall/junk,
 /area/vtm/sewer/nosferatu_town)
 "wSJ" = (
 /obj/machinery/light/prince{
@@ -84307,6 +90774,11 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/interior/giovanni)
+"wSL" = (
+/obj/structure/table/wood,
+/obj/item/kirbyplants/dead,
+/turf/closed/wall/vampwall/bar/low,
+/area/vtm/interior)
 "wSS" = (
 /obj/effect/decal/bordur{
 	dir = 1
@@ -84317,6 +90789,15 @@
 "wSW" = (
 /turf/open/floor/plating/stone,
 /area/vtm/interior/endron_facility/forest)
+"wSZ" = (
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/obj/machinery/camera/directional/east,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wTa" = (
 /turf/open/floor/plating/asphalt,
 /area/vtm/interior/giovanni/outside)
@@ -84356,11 +90837,13 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/shop)
 "wTx" = (
-/obj/machinery/light/small{
-	dir = 4;
-	pixel_x = -16
+/obj/effect/decal/trash,
+/obj/structure/closet/crate/large,
+/obj/structure/closet/crate/large{
+	pixel_x = -2;
+	pixel_y = 12
 	},
-/turf/open/floor/plating/rough/cave,
+/turf/open/floor/plating/rough,
 /area/vtm/sewer/nosferatu_town)
 "wTz" = (
 /mob/living/simple_animal/butterfly,
@@ -84500,6 +90983,10 @@
 "wVS" = (
 /turf/open/floor/plating/sidewalk/old,
 /area/vtm/sewer/tzimisce_sanctum)
+"wVY" = (
+/obj/effect/decal/bordur,
+/turf/closed/wall/vampwall/junk,
+/area/vtm/interior)
 "wWd" = (
 /obj/structure/flora/ausbushes/ywflowers{
 	layer = 4.3
@@ -84636,6 +91123,14 @@
 	},
 /turf/open/floor/carpet,
 /area/vtm/anarch)
+"wXK" = (
+/obj/effect/turf_decal/siding/wideplating/dark{
+	dir = 1
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial5"
+	},
+/area/vtm/sewer/nosferatu_town)
 "wXM" = (
 /obj/structure/fluff/hedge,
 /turf/open/floor/plating/parquetry,
@@ -84769,6 +91264,11 @@
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/financialdistrict/library)
+"wZK" = (
+/obj/structure/flora/rock/jungle,
+/obj/structure/flora/ausbushes/sparsegrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer)
 "wZM" = (
 /obj/structure/flora/ausbushes/sparsegrass{
 	pixel_y = 12
@@ -84802,6 +91302,12 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/fishermanswharf)
+"xae" = (
+/mob/living/simple_animal/hostile/bear/wod13{
+	name = "Bear-ba-yaga"
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer)
 "xaf" = (
 /obj/structure/railing{
 	dir = 8;
@@ -84812,6 +91318,12 @@
 	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/strip/toreador)
+"xaq" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "xav" = (
 /turf/closed/wall/vampwall/bar,
 /area/vtm/sewer)
@@ -84877,6 +91389,17 @@
 	},
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch)
+"xaR" = (
+/obj/vampire_computer{
+	pixel_y = 3;
+	pixel_x = 4
+	},
+/obj/structure/table,
+/obj/effect/decal/litter,
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_concrete"
+	},
+/area/vtm/sewer/nosferatu_town)
 "xaW" = (
 /obj/structure/rack/bubway/south,
 /obj/item/gun/ballistic/shotgun/vampire,
@@ -84905,6 +91428,16 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/laundromat)
+"xbr" = (
+/obj/structure/flora/rock/jungle,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/shit/border,
+/area/vtm/sewer)
 "xbv" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -84972,6 +91505,18 @@
 "xcc" = (
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/endron_facility/forest)
+"xci" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = 2;
+	pixel_y = 3
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "xcm" = (
 /obj/structure/table/wood,
 /obj/machinery/light/prince/broken{
@@ -85082,6 +91627,10 @@
 /obj/effect/decal/cardboard,
 /turf/open/floor/plating/rough/cave,
 /area/vtm/interior/gnawer)
+"xdI" = (
+/obj/machinery/camera/directional/west,
+/turf/open/floor/carpet/black,
+/area/vtm/sewer/nosferatu_town)
 "xdS" = (
 /obj/effect/decal/cardboard,
 /obj/effect/decal/litter,
@@ -85158,6 +91707,12 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/northbeach)
+"xeX" = (
+/obj/machinery/griddle,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
+	},
+/area/vtm/interior)
 "xeZ" = (
 /obj/structure/table/wood,
 /obj/machinery/chem_dispenser/drinks/fullupgrade,
@@ -85319,6 +91874,13 @@
 	},
 /turf/open/floor/plating/vampplating,
 /area/vtm/interior/millennium_tower/f2)
+"xgG" = (
+/obj/effect/turf_decal/weather/dirt,
+/obj/structure/railing{
+	layer = 4
+	},
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "xgL" = (
 /obj/structure/fluff/hedge{
 	pixel_y = 6
@@ -85346,10 +91908,9 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/millennium_tower/f4)
 "xgR" = (
-/obj/effect/turf_decal/siding/wood,
-/obj/effect/decal/trash,
-/turf/open/floor/plating/vampwood,
-/area/vtm/sewer/nosferatu_town)
+/obj/effect/decal/wallpaper/paper/stripe/low,
+/turf/closed/wall/vampwall/bar,
+/area/vtm/interior)
 "xhg" = (
 /obj/effect/decal/rugs,
 /turf/open/floor/plating/vampcanalplating,
@@ -85492,6 +92053,10 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/plating/vampgrass,
 /area/vtm/forest)
+"xiU" = (
+/obj/effect/decal/trash,
+/turf/open/floor/plating/woodfancy,
+/area/vtm/sewer/nosferatu_town)
 "xiV" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/effect/landmark/npcwall,
@@ -85510,9 +92075,10 @@
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/strip/toreador)
 "xjq" = (
-/obj/effect/decal/graffiti,
-/obj/structure/chair/sofa/left,
-/turf/open/floor/plating/rough,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
 /area/vtm/sewer/nosferatu_town)
 "xjt" = (
 /obj/effect/decal/wallpaper/paper/stripe/low,
@@ -85639,7 +92205,9 @@
 /area/vtm/anarch)
 "xlF" = (
 /obj/machinery/griddle,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial2"
+	},
 /area/vtm/interior)
 "xlJ" = (
 /obj/structure/vampfence/rich{
@@ -85802,6 +92370,11 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/open/floor/plating/rough,
 /area/vtm/anarch)
+"xnC" = (
+/obj/structure/stalagmite,
+/obj/structure/flora/rock/jungle,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "xnF" = (
 /obj/effect/decal/rugs,
 /obj/effect/decal/pallet,
@@ -85927,6 +92500,25 @@
 /obj/item/reagent_containers/food/drinks/beer/vampire,
 /turf/open/floor/plating/parquetry/old,
 /area/vtm/anarch)
+"xpO" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 9
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/structure/flora/junglebush/c,
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "xpQ" = (
 /obj/machinery/light{
 	pixel_y = 32
@@ -85948,11 +92540,14 @@
 /turf/open/floor/plating/rough,
 /area/vtm/interior/glasswalker)
 "xpW" = (
-/obj/machinery/light/small{
-	dir = 1
+/obj/effect/decal/pallet{
+	layer = 2
 	},
-/obj/structure/closet,
-/turf/open/floor/plating/rough,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/turf/open/floor/plating/woodrough,
 /area/vtm/sewer/nosferatu_town)
 "xqb" = (
 /obj/structure/table,
@@ -86038,6 +92633,16 @@
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/fishermanswharf)
+"xrk" = (
+/obj/structure/railing{
+	layer = 4
+	},
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ywflowers{
+	pixel_y = 2
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "xrm" = (
 /obj/effect/turf_decal/siding/wood{
 	dir = 8
@@ -86104,6 +92709,13 @@
 	},
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/millennium_tower/f4)
+"xrX" = (
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/grate{
+	icon_state = "lattice_new_dirt"
+	},
+/area/vtm/sewer/nosferatu_town)
 "xrZ" = (
 /obj/effect/decal/bordur{
 	dir = 4
@@ -86134,6 +92746,10 @@
 /obj/structure/vampdoor/npc,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/interior/shop)
+"xsz" = (
+/obj/structure/barricade/wooden/crude,
+/turf/closed/wall/vampwall/junk/alt/low/window,
+/area/vtm/sewer/nosferatu_town)
 "xsF" = (
 /obj/elevator_button_down{
 	pixel_y = 24;
@@ -86342,6 +92958,14 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/chantry)
+"xvS" = (
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "xvU" = (
 /obj/structure/curtain/bounty,
 /turf/open/floor/carpet/red,
@@ -86507,6 +93131,12 @@
 /obj/structure/fluff/hedge,
 /turf/open/floor/plating/vampwood,
 /area/vtm/hotel)
+"xyP" = (
+/obj/effect/turf_decal/weather/dirt,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "xyQ" = (
 /obj/machinery/light/prince{
 	pixel_y = 32;
@@ -86550,12 +93180,33 @@
 	},
 /turf/open/floor/plating/vampacid,
 /area/vtm/forest)
+"xzz" = (
+/obj/structure/vampipe{
+	pixel_y = 32
+	},
+/obj/effect/decal/litter,
+/obj/effect/decal/pallet,
+/obj/structure/barrels{
+	icon_state = "barrels3"
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "xzP" = (
 /obj/structure/lamppost/one{
 	dir = 1
 	},
 /turf/open/floor/plating/sidewalk,
 /area/vtm/pacificheights)
+"xzW" = (
+/obj/effect/decal/wallpaper/paper/stripe,
+/turf/closed/wall/vampwall/bar,
+/area/vtm/interior)
 "xAc" = (
 /obj/structure/closet,
 /obj/item/clothing/under/vampire/police,
@@ -86679,6 +93330,15 @@
 /obj/machinery/mineral/equipment_vendor/fastfood/sodavendor,
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/clinic/haven)
+"xAZ" = (
+/obj/effect/decal/bordur{
+	dir = 8
+	},
+/obj/effect/decal/graffiti,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone4"
+	},
+/area/vtm/sewer/nosferatu_town)
 "xBf" = (
 /obj/structure/closet/crate,
 /obj/item/drinkable_bloodpack,
@@ -86795,6 +93455,14 @@
 	},
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/giovanni/outside)
+"xCl" = (
+/obj/effect/decal/bordur{
+	dir = 9
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "xCr" = (
 /obj/effect/landmark/start/giovanni,
 /obj/structure/railing,
@@ -86966,6 +93634,18 @@
 /obj/effect/decal/wallpaper/paper,
 /turf/closed/wall/vampwall/junk/alt,
 /area/vtm/interior)
+"xET" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 4;
+	pixel_x = -2
+	},
+/obj/effect/decal/trash,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "xEU" = (
 /obj/structure/railing{
 	dir = 1;
@@ -87074,6 +93754,11 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/vtm/interior/millennium_tower/f4)
+"xFS" = (
+/obj/machinery/chem_dispenser/drinks/beer/fullupgrade,
+/obj/structure/rack/bubway/horizontal,
+/turf/open/floor/plating/industrial,
+/area/vtm/sewer/nosferatu_town)
 "xFT" = (
 /obj/effect/decal/graffiti,
 /turf/open/floor/plating/sidewalk/poor,
@@ -87152,6 +93837,13 @@
 	},
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"xGX" = (
+/obj/structure/vampipe{
+	icon_state = "piping38"
+	},
+/obj/effect/decal/trash,
+/turf/open/floor/plating/rough/cave,
+/area/vtm/sewer)
 "xGZ" = (
 /obj/structure/table/wood,
 /obj/machinery/fax/endron,
@@ -87314,6 +94006,18 @@
 	},
 /turf/open/floor/plating/vampgrass,
 /area/vtm/interior/cog/caern)
+"xJf" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/railing{
+	dir = 1;
+	pixel_y = 9
+	},
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 8
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "xJh" = (
 /obj/machinery/light/warm{
 	dir = 8
@@ -87365,6 +94069,15 @@
 	},
 /turf/open/floor/carpet/green,
 /area/vtm/interior/millennium_tower/f3)
+"xJH" = (
+/obj/effect/landmark/npcwall,
+/obj/structure/big_vamprocks{
+	icon_state = "rock3";
+	density = 0
+	},
+/obj/manholedown,
+/turf/open/floor/plating/vampdirt,
+/area/vtm/northbeach)
 "xJL" = (
 /obj/effect/landmark/npcbeacon,
 /turf/open/floor/plating/sidewalk/rich,
@@ -87478,12 +94191,10 @@
 /turf/open/floor/plating/vampcarpet,
 /area/vtm/interior/police/upstairs)
 "xKR" = (
-/obj/structure/curtain,
-/obj/machinery/shower{
-	pixel_y = 13
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial8"
 	},
-/turf/open/floor/plating/vampcanalplating,
-/area/vtm/sewer/nosferatu_town)
+/area/vtm/interior)
 "xKS" = (
 /turf/open/floor/plating/vampplating/stone,
 /area/vtm/interior/techshop)
@@ -87539,6 +94250,18 @@
 	},
 /turf/open/floor/plating/vampplating/mono,
 /area/vtm/interior/wyrm_corrupted)
+"xLB" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/effect/decal/pallet,
+/obj/effect/decal/carpet{
+	pixel_x = -14;
+	pixel_y = -13
+	},
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "xLD" = (
 /obj/structure/railing{
 	dir = 1;
@@ -87552,14 +94275,13 @@
 /turf/open/floor/plating/sidewalk/rich,
 /area/vtm/interior/giovanni/outside)
 "xLL" = (
-/obj/structure/table/wood,
-/obj/effect/decal/litter,
-/obj/structure/trashbag{
-	pixel_x = -9;
-	pixel_y = 8
+/obj/effect/decal/rugs,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
 	},
-/obj/structure/trashbag,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
 /area/vtm/sewer/nosferatu_town)
 "xLM" = (
 /obj/machinery/light/small{
@@ -87638,8 +94360,23 @@
 /turf/open/floor/mineral/plastitanium,
 /area/vtm/interior/tzimisce_manor)
 "xMT" = (
-/obj/structure/curtain/bounty,
-/turf/open/floor/plating/rough,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/vampdoor/old{
+	dir = 8;
+	lock_id = "nosferatu";
+	locked = 1;
+	lockpick_difficulty = 20;
+	name = "old strange door"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = 5467;
+	max_integrity = 3500;
+	name = "Warrens";
+	dir = 8
+	},
+/turf/open/floor/plating/grate,
 /area/vtm/sewer/nosferatu_town)
 "xMU" = (
 /obj/structure/table/wood,
@@ -88017,6 +94754,14 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/sidewalkalt,
 /area/vtm/chinatown)
+"xTJ" = (
+/obj/structure/table/wood,
+/obj/effect/decal/pallet,
+/obj/machinery/light/dim{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/vampcanalplating,
+/area/vtm/sewer/nosferatu_town)
 "xTK" = (
 /obj/effect/decal/asphaltline,
 /turf/closed/wall/vampwall/painted,
@@ -88556,6 +95301,18 @@
 /obj/effect/decal/litter,
 /turf/open/floor/plating/sidewalk,
 /area/vtm/ghetto/old)
+"xZJ" = (
+/obj/effect/decal/trash,
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/rough/cave{
+	icon_state = "stone8"
+	},
+/area/vtm/sewer/nosferatu_town)
 "xZU" = (
 /obj/machinery/light{
 	pixel_y = 32
@@ -88611,6 +95368,10 @@
 	},
 /turf/open/floor/plating/rough,
 /area/vtm/interior)
+"ybd" = (
+/obj/structure/table/wood/poker,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "ybf" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
 	req_access = list(0)
@@ -88779,9 +95540,9 @@
 /turf/open/floor/plating/concrete,
 /area/vtm/supply)
 "ydB" = (
-/obj/structure/table/wood,
-/obj/item/kirbyplants/random,
-/turf/open/floor/plating/rough,
+/turf/open/floor/plating/industrial{
+	icon_state = "industrial7"
+	},
 /area/vtm/sewer/nosferatu_town)
 "ydC" = (
 /obj/structure/chair/office{
@@ -88790,16 +95551,8 @@
 /turf/open/floor/plating/vampcarpet,
 /area/vtm/interior/bianchiBank)
 "ydF" = (
-/obj/effect/turf_decal/siding/white{
-	dir = 4
-	},
-/obj/effect/decal/bordur{
-	dir = 9
-	},
-/obj/structure/vampdoor/npc{
-	dir = 8
-	},
-/turf/open/floor/plating/sidewalk/poor,
+/obj/effect/turf_decal/siding/wideplating/dark,
+/turf/open/floor/plating/vampcarpet,
 /area/vtm/interior)
 "ydH" = (
 /obj/structure/curtain,
@@ -88922,6 +95675,9 @@
 "yeS" = (
 /obj/effect/decal/litter,
 /obj/effect/decal/litter,
+/obj/effect/decal/bordur{
+	dir = 1
+	},
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/sewer/nosferatu_town)
 "yeU" = (
@@ -89032,6 +95788,20 @@
 	},
 /turf/open/floor/carpet/lone,
 /area/vtm/interior/tzimisce_manor)
+"ygk" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/plating/rough,
+/area/vtm/interior)
+"ygq" = (
+/obj/machinery/light/small/red{
+	dir = 8;
+	pixel_x = 16
+	},
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer)
 "ygs" = (
 /obj/structure/trashcan,
 /turf/open/floor/plating/asphalt,
@@ -89047,6 +95817,19 @@
 /obj/structure/stairs/north,
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
+"ygM" = (
+/obj/structure/table/wood/bar,
+/obj/structure/showcase/machinery/tv{
+	pixel_y = 13
+	},
+/obj/structure/noticeboard{
+	desc = "A board with pamphlets of Saint John's Community Health Clinic.";
+	icon_state = "nboard05";
+	pixel_y = 32
+	},
+/obj/effect/decal/pallet,
+/turf/open/floor/plating/rough,
+/area/vtm/sewer/nosferatu_town)
 "yhf" = (
 /turf/open/floor/plating/concrete,
 /area/vtm/interior/police)
@@ -89118,9 +95901,11 @@
 /turf/open/floor/carpet,
 /area/vtm/interior/oldchurch)
 "yic" = (
-/obj/machinery/washing_machine,
-/turf/open/floor/plating/rough,
-/area/vtm/interior)
+/obj/effect/turf_decal/weather/dirt{
+	dir = 4
+	},
+/turf/open/floor/plating/vampdirt,
+/area/vtm/sewer/nosferatu_town)
 "yid" = (
 /obj/item/clothing/head/vampire/skull,
 /obj/effect/decal/cleanable/blood/old,
@@ -89335,10 +96120,26 @@
 /obj/item/newspaper,
 /turf/open/floor/plating/sidewalk/poor,
 /area/vtm/ghetto)
+"ykY" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/turf/open/floor/plating/shit{
+	icon_state = "blood"
+	},
+/area/vtm/sewer)
 "ylc" = (
 /obj/structure/chair,
 /turf/open/floor/plating/rough,
 /area/vtm/sewer)
+"yld" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 10
+	},
+/obj/structure/flora/junglebush/c,
+/obj/effect/decal/trash,
+/turf/open/floor/plating/shit,
+/area/vtm/sewer/nosferatu_town)
 "yle" = (
 /obj/effect/decal/wallpaper/paper/stripe,
 /turf/closed/wall/vampwall/old,
@@ -89387,6 +96188,14 @@
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plating/toilet,
 /area/vtm/interior/baali)
+"ylX" = (
+/obj/effect/turf_decal/weather/dirt{
+	dir = 1
+	},
+/turf/open/floor/plating/vampcanalplating{
+	icon_state = "canal_plating3"
+	},
+/area/vtm/sewer/nosferatu_town)
 "yme" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/plating/vampdirt,
@@ -90454,13 +97263,13 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+tiZ
 dhc
 dhc
 dhc
@@ -90711,16 +97520,16 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+uuF
+uuF
+uuF
+uuF
+uuF
+nYS
+nYS
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -90968,16 +97777,16 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+uuF
+spA
+msO
+sbF
+uuF
+uuF
+uuF
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -91225,16 +98034,16 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+uuF
+maP
+nBs
+taR
+uuF
+rWU
+bAX
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -91475,23 +98284,23 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+uuF
+vgn
+lZK
+fLi
+uuF
+jPs
+tQn
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -91732,23 +98541,23 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+mJo
+mJo
+mJo
+uuF
+rWU
+tQn
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -91989,25 +98798,25 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+uuF
+nRg
+vii
+lTF
+btc
+tds
+gUB
+uuF
+bbD
+nIG
+lZK
+lZK
+lZK
+nHT
+uuF
+tiZ
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -92243,28 +99052,28 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+uuF
+btZ
+iGX
+dHx
+wtI
+nKZ
+oFX
+uuF
+tUg
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -92499,29 +99308,29 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nxc
+nxc
+nxc
+uuF
+axQ
+dHx
+dHx
+dHx
+awg
+nKZ
+uuF
+eqs
+jxW
+aOV
+mnw
+nAr
+nKZ
+oAK
+cxZ
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -92755,30 +99564,30 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nxc
+nxc
+uQF
+rsk
+uuF
+jzH
+dHx
+dHx
+dHx
+iBO
+nKZ
+lMW
+nKZ
+fut
+iFD
+nAr
+wyd
+nKZ
+nKZ
+nAr
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -93007,35 +99816,35 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+nxc
+nxc
+cSf
+kGp
+qRA
+uuF
+vrm
+dHx
+dHx
+dHx
+awg
+nKZ
+uuF
+nKZ
+nKZ
+uuF
+uuF
+uuF
+uuF
+jJq
+jJq
+uuF
+nYS
 dhc
 dhc
 dhc
@@ -93263,6 +100072,38 @@ dhc
 dhc
 dhc
 dhc
+nYS
+nYS
+dxU
+dxU
+dxU
+dxU
+dxU
+dxU
+pCj
+qYl
+cSf
+tVB
+uuF
+rSr
+mNn
+dHx
+msL
+nKZ
+oFX
+uuF
+hTH
+nKZ
+ddy
+qVf
+fBs
+uEW
+pYD
+cai
+uuF
+nYS
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -93277,46 +100118,14 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -93520,6 +100329,39 @@ dhc
 dhc
 dhc
 dhc
+nYS
+dxU
+qYX
+wvo
+ipz
+gKh
+ool
+dxU
+tZH
+sMP
+cSf
+uQF
+uuF
+uHn
+fut
+wSZ
+nKZ
+qQh
+gUB
+uuF
+lLP
+jJq
+uuF
+pnI
+nAr
+gnU
+nKZ
+pYD
+uuF
+nxc
+nxc
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -93527,55 +100369,22 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+snI
+snI
+snI
+snI
+snI
+snI
+nYS
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -93777,62 +100586,62 @@ dhc
 dhc
 dhc
 dhc
+nYS
+qYX
+iaP
+ecc
+ydB
+ecc
+ydB
+dxU
+oEO
+hKn
+cSf
+kPe
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+nKZ
+nKZ
+uuF
+uuF
+uuF
+hzy
+taX
+pYD
+uuF
+mnA
+nxc
+nxc
+nYS
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+uuF
+nxc
+nxc
+nxc
+nxc
+snI
+snI
+xaq
+isZ
+isZ
+isZ
+snI
+snI
+snI
+nYS
 dhc
 dhc
 dhc
@@ -94034,64 +100843,64 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+qYX
+cVH
+ecc
+lZK
+wSr
+wSr
+dxU
+iZx
+cSf
+jeX
+oZv
+uuF
+oAR
+fut
+ppb
+nKZ
+jJq
+jJq
+lMW
+nKZ
+fut
+ddy
+arm
+kZo
+gnU
+pYD
+nAr
+uuF
+vAS
+eIy
+nxc
+nYS
+nYS
+nYS
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+iCR
+upW
+cmQ
+iCc
+ooz
+snI
+xaq
+snI
+snI
+owT
+isZ
+isZ
+snI
+nYS
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -94291,65 +101100,65 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nYS
+qYX
+lbv
+lZK
+ydB
+tLZ
+wSr
+dxU
+psA
+xgG
+rqU
+fUT
+uuF
+oAR
+pbZ
+cqN
+pbZ
+nKZ
+lLe
+uuF
+mLN
+uVE
+uuF
+saH
+vUQ
+cxi
+nAr
+wJS
+uuF
+ceO
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+xpO
+waq
+biS
+luo
+yld
+uuF
+tdu
 nxc
 nxc
 nxc
-nxc
+esD
+snI
+jiI
+snI
+owT
+isZ
+snI
+snI
+snI
+snI
+snI
 nYS
 nYS
-nYS
-tiZ
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 dhc
 dhc
 dhc
@@ -94548,67 +101357,67 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-nxc
-fZO
-fZO
-nxc
-nxc
-nxc
-nxc
-tiZ
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+dxU
+qYX
+buc
+ecc
+wSr
+mxJ
+dxU
+eii
+luh
+vYL
+lMH
+uuF
+mpy
+pbZ
+tRn
+pbZ
+nKZ
+uuF
+uuF
+paM
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+emj
+wmq
+eIK
+hGS
+wmq
+tDO
+wJn
+jss
+qNy
+dsc
+xET
+wLI
+xJf
+fIP
+snI
+cwM
+isZ
+isZ
+snI
+xaq
+snI
+snI
+snI
+snI
+sLN
+sLN
+sLN
+snI
+snI
 nYS
 nYS
 nYS
-nYS
-nYS
-nYS
-nYS
-tiZ
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 dhc
 dhc
 dhc
@@ -94805,70 +101614,70 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
 nYS
-nxc
-fZO
-fZO
-fZO
-cSf
-cSf
-cSf
-nxc
-nYS
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-tiZ
-nYS
-nYS
-nYS
-nYS
-nYS
+dxU
+dxU
+iKz
+dxU
+dxU
+dxU
+dxU
+dxU
+pNe
+bBa
 uuF
+rGr
+pbZ
+kox
+pbZ
+fut
 uuF
-uuF
-uuF
-uuF
-uuF
+qMu
+hqL
+hqL
+tgL
+vCs
+sNT
+hLu
+wIh
+qJo
+txw
+pbZ
+wmq
+oMy
+jJq
+hUd
+lZK
+wJn
+niB
+pbZ
+bVc
+eWh
+oTn
+qKF
+sim
+snI
+fmP
+snI
+mdF
+snI
+lIB
+isZ
+dnc
+wMB
+uGH
+sLN
+snI
+sLN
+sLN
+snI
+snI
+snI
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -95063,71 +101872,71 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
 nYS
-nYS
-nxc
-nxc
+qYX
+dEl
+wSr
+xdI
+qwR
+wSr
+hHb
+vMg
+mLY
+tgP
+uuF
+uQJ
+fut
+nbr
+jJq
+ioV
+uuF
+sfW
+hqL
+hqL
+cPB
+jza
+rjw
+uQF
 cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-nxc
-nxc
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-tiZ
-uuF
-uuF
-uuF
-uuF
-uuF
-nYS
-nYS
-uuF
-uuF
-uuF
-uuF
-eKD
-qkc
-eir
+ivO
+wOZ
+qWX
+wmq
+hmx
+jJq
+lRT
+lZK
+wJn
+gZJ
+nqS
+fZO
+aAm
+rot
 gle
 sFp
-uuF
+snI
+xaq
+snI
+owT
+snI
+snI
+hZl
+snI
+mdF
+snI
+sLN
+snI
+snI
+sLN
+sLN
+sLN
+snI
+snI
+snI
+snI
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
 dhc
 dhc
 nYS
@@ -95320,72 +102129,72 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-nxc
-nYS
-dhc
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-vvq
-kFZ
-hNk
-eir
-uuF
-nYS
-nYS
-eKD
+qYX
+flT
+wSr
+wSr
+pVy
+wSr
 ydB
-kFZ
-cpS
-eKD
-jVA
-hgL
-bCv
-cpS
+dxU
+eqQ
+pbZ
 uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+xAZ
+tla
+tla
+xCl
+ojy
+fJP
+cSf
+qRA
+vvq
+iwH
+wJn
+wJn
+wmq
+coG
+wJn
+wJn
+wJn
+wJn
+wJn
+vUE
+cNI
+hgL
+uQF
+cpS
+snI
+mRb
+qnY
+bao
+fvN
+snI
+xaq
+snI
+owT
+snI
+sLN
+sLN
+snI
+snI
+snI
+dDW
+uTn
+snI
+qxs
+snI
+snI
+snI
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
 dhc
 dhc
 nYS
@@ -95577,72 +102386,72 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-nxc
-nYS
-nYS
-nYS
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-vvq
-kpW
-nbr
+qYX
+tkj
+wSr
+dQJ
+bMw
+iIK
+jVO
+cAu
+hEW
+pbZ
+vfR
+bAk
+bAk
+wIl
+bBa
+bBa
+hVh
+pbZ
+pbZ
+fZO
+emx
+lbS
+qab
+wJn
+wJn
+wJn
+wJn
+wmq
+teJ
+uNc
 eir
-uuF
-nxc
-nxc
-eKD
+bua
+wXK
 rtf
-eir
-eir
-eir
-eir
+xFS
+wJn
+kpW
+pbZ
 fsi
-bCv
-eir
-uuF
+rot
+nQv
+snI
+xbr
+vJm
+ldr
+una
+snI
+xaq
+snI
+snI
+snI
+snI
+sLN
+sLN
+sLN
+snI
+dDW
+snI
+snI
+sLN
+bEz
+deB
+snI
+snI
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 dhc
 dhc
 dhc
@@ -95833,73 +102642,73 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-nxc
-nxc
-nxc
-nxc
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-vvq
-jVA
-bCv
-bCv
-uuF
-cSf
-cSf
-eKD
+nYS
+qYX
+maY
+wSr
+rfL
+jZz
+wSr
+lZK
+dxU
+nEU
+pbZ
+mLG
+mLG
+mLG
+mLG
+pbZ
+fZO
+fZO
+fZO
+fZO
+jpk
+rMl
+frr
+rot
+wmq
+wpe
+azN
+oje
+wmq
+suQ
+dtr
+sOG
+sfd
+hqO
 ydB
 kFZ
-cpS
+aOV
 eKD
-eir
-eir
+fZO
+pnb
 rot
-eir
-uuF
+xpW
+snI
+snI
+owT
+snI
+rzP
+snI
+xaq
+snI
+vdo
+isZ
+snI
+snI
+snI
+sLN
+snI
+iqh
+snI
+fnv
+sLN
+hQw
+fgS
+dnU
+snI
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 dhc
 dhc
 dhc
@@ -96088,75 +102897,75 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-nYS
 nYS
 nYS
 nxc
+nxc
+qYX
+byY
+wSr
+wSr
+wSr
+mxJ
+fKo
+vMg
+pbZ
+pbZ
+fZO
+fZO
+nqS
+nqS
+nqS
+nqS
+fZO
+fZO
+mRp
+rMl
+xrk
+kKP
 cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-uuF
-uuF
-uuF
-uuF
-uuF
-cSf
-cSf
-uuF
-uuF
+wmq
+sjd
+eir
 iWE
-uuF
-uuF
-uuF
-uuF
-cSf
-uuF
-jXo
-jXo
-jXo
-eKD
-dHx
+wmq
+jqU
+qrp
 eir
-eir
+uLh
+dES
+wtj
+fis
+aOV
+eFt
+mLG
+cmJ
+rot
 nQv
-uuF
+snI
+veG
+kDR
+snI
+xaq
+snI
+xaq
+snI
+snI
+isZ
+isZ
+snI
+sLN
+sLN
+snI
+dDW
+snI
+dKp
+gMM
+sLN
+snI
+pfl
+snI
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 dhc
 dhc
 dhc
@@ -96345,81 +103154,81 @@ dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-lJn
-lJn
-uuF
-uuF
-uuF
-uuF
-uuF
-uuF
-vaV
-jXo
-uuF
-uuF
-uuF
-uuF
-cSf
-cSf
-cSf
-uuF
-qfW
-aEg
+nYS
+nxc
+nxc
+dvm
+dxU
+dxU
+dxU
+dxU
+dxU
+dxU
+dxU
+dxU
+wku
+pbZ
+fZO
+jpk
+rbl
+nXL
+bNH
+rbl
+rtZ
+fZO
+xyP
 qxF
-aEg
-uuF
-uuF
-cSf
-vvq
+gFA
+wPe
+aRd
+wmq
+aNU
 sOG
 eir
-eir
+wmq
 mrS
 rcj
-uuF
-cSf
-cSf
-cSf
-cSf
-kKP
-eKD
+sOG
+sfd
+dES
+jVO
+ueH
+aOV
+eFt
 xjq
-eir
-eir
+chG
+rot
 xpW
-uuF
+snI
+aAw
+bOJ
+snI
+jbG
+wOJ
+isZ
+kXS
+snI
+sLN
+snI
+snI
+sLN
+snI
+snI
+dDW
+snI
+snI
+snI
+lNw
+snI
+ulG
+snI
 nYS
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+nYS
+nYS
+nYS
 dhc
 dhc
 nYS
@@ -96600,84 +103409,84 @@ dhc
 "}
 (29,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-lJn
-uuF
+nYS
+nYS
+nYS
+nxc
+hsB
+qRA
+cSf
 aDb
 uQF
-sNZ
-byn
-aDb
+cSf
+xci
+uhG
 aEg
+vjh
+mLG
+pbZ
 byn
-cvP
-qRA
-dQT
-bOo
-uuF
-cSf
-cSf
-cSf
-qfW
-hFL
-byn
-byn
-byn
-rLy
-uuF
-cSf
-vvq
-eDO
-eir
-eir
-eir
-eir
-jXo
-cSf
-cSf
-cSf
-fNj
-rWU
+rbl
+fPN
+hZN
+qFX
+swK
 rtZ
+mLG
+iUa
+mvr
+cDy
+rLy
+wLI
+wmq
+faK
 eir
+sOG
+bZV
 eir
+sOG
 eir
-bCv
-uuF
+uLh
+iaQ
+aJy
+fNj
+wJn
+rtZ
+hxn
+laK
+cSf
+pIj
+snI
+tzU
+sLN
+snI
+snI
+snI
+xaq
+gRl
+snI
+sLN
+qdN
+dnU
+sLN
+snI
+rYs
+eWY
+snI
+fVO
+snI
+cEQ
+snI
+dDW
+snI
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
+nYS
+snI
+snI
+kfi
+nYS
+nYS
 dhc
 dhc
 dhc
@@ -96857,88 +103666,88 @@ dhc
 "}
 (30,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-lJn
+nYS
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+fhF
+rbl
 fUT
-nqS
-byn
-byn
-byn
-fUT
-bHG
-wSr
-nHT
-wSr
+bBa
+eFt
+mLG
+pbZ
 byn
 kMq
-uuF
+qOD
 uqk
 uts
+ppM
+rtZ
+mLG
+pbZ
+bBa
+hZN
 cSf
-qfW
-joI
-erZ
-byn
-byn
-dyB
-uuF
-cSf
-vvq
+ebx
+wmq
+ivT
 rdg
 eir
-eir
+wmq
 kvt
-eir
-jXo
-cSf
-cSf
+vOl
+sOG
+sfd
+dES
 mHr
-hdT
-sNT
-eKD
+wJn
+wJn
+etP
 eWh
 qab
-bCv
-bCv
-uuF
+uQF
+esJ
+snI
+eVR
+sLN
+sLN
+rwZ
+snI
+brf
+snI
+snI
+sLN
+snI
+snI
+sLN
+snI
+rYs
+snI
+snI
+oEd
+xae
+xqR
+snI
+ioc
+snI
+snI
+snI
+snI
+snI
+jsf
+snI
+snI
+oIa
 nYS
 nYS
 nYS
 nYS
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 tiZ
 nYS
 nYS
@@ -97114,88 +103923,88 @@ dhc
 "}
 (31,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-lJn
-fUT
-uzY
-mMW
-byn
-byn
-tGI
-byn
-wSF
+nYS
 msg
-wSr
+hNk
+bOG
+pKw
+oFr
+pHv
+uzY
+wJn
+rbl
+fUT
+tGI
+bBa
+eKD
+mLG
+fZO
 byn
 tcb
 aQk
 kPe
 hQm
 eYU
-qfW
-toL
-byn
-byn
+rtZ
+pbZ
+stI
+hZN
 qRA
 edn
-uuF
-cSf
-vvq
-bCv
-vOl
-eir
-bCv
+fJZ
+wJn
+wJn
+wmq
+qhl
+wJn
+wJn
 wmq
 jXo
-cSf
-cSf
+gQs
+lrG
 ctI
-hdT
+wJn
 bbU
+cNI
+tEH
+cSf
+lwV
+mMW
 uuF
 uuF
 uuF
+qSq
 uuF
-uuF
-uuF
-uuF
-uuF
-uuF
-lJn
-dWx
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+snI
+snI
+snI
+sLN
+sLN
+sLN
+snI
+dnU
+snI
+mCX
+dsY
+snI
+snI
+uht
+scw
+snI
+eWY
+cIr
+isZ
+mRx
+nSQ
+snI
+vWH
+kYJ
+snI
+snI
+snI
+snI
+snI
+nYS
 dhc
 dhc
 nYS
@@ -97371,88 +104180,88 @@ dhc
 "}
 (32,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-lJn
+nYS
+msg
+fdO
+dFd
+ecc
+nBA
 tQn
-pbF
-byn
-byn
-byn
-fUT
-byn
+lZK
+hjE
+uqL
+bBa
+bBa
+tgP
 mLG
-oTy
-wSr
+pbZ
+fZO
 byn
-byn
-uuF
+iha
+umr
 rhW
 pVO
-piv
-qfW
-aEg
-tcb
-byn
-byn
-ioV
-uuF
-cSf
-vvq
-cZu
-eir
-eir
+kEc
+fZO
+heU
+rbl
+hWF
+fhw
+rbl
+bBa
+ueZ
+tfI
+wmq
+bbD
+gDu
 hyt
-eir
-uuF
-cSf
+wmq
+poe
+hqL
 nxz
-hdT
-deB
-cSf
-eZa
-qkc
+gGk
+aOV
+eFt
+cNI
+qab
 wLI
 eXk
-eir
-eZa
+lKQ
+uuF
 uiE
 jxW
-uuF
-lJn
-dWx
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+fut
+vPU
+snI
+sLN
+sLN
+sLN
+snI
+snI
+snI
+snI
+snI
+snI
+nMT
+sLN
+snI
+snI
+snI
+snI
+dsY
+hXj
+pMK
+iaq
+vxq
+snI
+sEZ
+rMm
+joI
+snI
+rGi
+gMi
+snI
+nYS
 dhc
 dhc
 dhc
@@ -97628,88 +104437,88 @@ dhc
 "}
 (33,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-lJn
-uuF
-aDb
-psA
+nYS
+msg
+lgV
+duF
+ecc
+lZK
+wJn
+wJn
+wJn
 bBa
 tgP
-aDb
+cfJ
 pbZ
-byn
-byn
-byn
-aKy
-cCs
-uuF
+pbZ
+fZO
+fZO
+fZO
 cSO
-uqL
-hdT
-uuF
-uuF
-uuF
+cfJ
+cSO
+cSO
+fZO
+wtG
+kHq
+mEO
 fUz
-uuF
-uuF
-uuF
-cSf
-uuF
-uuF
-uuF
+kcM
+kHq
+vYD
+qAy
+pbZ
+wmq
+iqO
 ecc
-uuF
-uuF
-uuF
+usB
+wmq
+hgJ
 hqL
 hQo
-hdT
+rkb
 aOV
-cSf
-eZa
-hil
+rtZ
+jHs
+rot
 bLN
-eir
-eir
-lrG
-eir
-eir
+cNY
+rbl
 uuF
-lJn
-dWx
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+opV
+jJq
+jJq
+snI
+snI
+sLN
+snI
+snI
+snI
+gFP
+hPa
+snI
+joI
+snI
+snI
+pMX
+wyq
+wyq
+cIr
+fGv
+lTA
+hXj
+xzz
+sLN
+cIr
+sYY
+tZl
+jVv
+ldr
+mRx
+tWb
+cfe
+snI
+nYS
 dhc
 dhc
 dhc
@@ -97885,88 +104694,88 @@ dhc
 "}
 (34,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-lJn
-lJn
-uuF
-uuF
-uuF
-uuF
-uuF
-uuF
-vaV
-jXo
-uuF
-uuF
-uuF
-uuF
-cSf
-iBO
-wHH
-hZO
-fZO
-fZO
-rSe
-fZO
-kHq
-cSf
-cSf
-nxc
-sRH
-uuF
+nYS
+wJn
+wJn
+kIb
 lZK
-uuF
-kEc
-nxc
-hZO
-fZO
-tVQ
-cSf
-cSf
-eZa
-vrU
-eir
-eir
+hCT
+wJn
+myh
+nkr
 cfJ
-eZa
-gSn
-aUm
+pbZ
+lRF
+lRF
+lRF
+lRF
+lRF
+lRF
+pbZ
+fZO
+fZO
+fZO
+wHH
+xiU
+fUz
+mEO
+fUz
+nrG
+kHq
+krB
+pbZ
+pbZ
+wmq
+fXj
+lZK
+qfW
+wmq
+wHF
+hqL
+htK
+tVQ
+wJn
+jOg
+eVW
+vrU
+piv
+tgP
+cfJ
 uuF
-lJn
-dWx
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+gSn
+jJq
+jJq
+snI
+sLN
+sLN
+snI
+gFP
+gFP
+gFP
+snI
+snI
+dnc
+nUb
+snI
+snI
+snI
+snI
+snI
+snI
+dyB
+hXj
+lLx
+vor
+snI
+sDR
+uol
+uol
+sDR
+ghG
+jDh
+bbZ
+snI
+nYS
 dhc
 dhc
 dhc
@@ -98142,88 +104951,88 @@ dhc
 "}
 (35,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nYS
-nYS
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-nxc
-nxc
-nxc
-uuF
-nxc
-fZO
-sRH
-fZO
+msg
+ufO
+gJD
+rnq
+kgp
+aOV
+imW
+cKY
+pbZ
+heU
+bBa
+lFI
+lFI
+lFI
+lFI
+lFI
+oIJ
+lRF
+pbZ
 hZO
+fZO
+pbZ
+lbf
+cxX
+eTH
+fro
 piv
-qFX
-nxc
-nxc
-sRH
-wTx
-fZO
-fZO
-jrx
-hjE
-fZO
-fZO
-fgS
-cSf
-cSf
-eZa
-ivT
-eir
-eir
-bCv
+eFt
+pbZ
+mLG
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+rko
+wJn
+wJn
+wJn
+nLU
+mRp
+rbl
+rbl
+eFt
+xyP
 uuF
-uuF
-uuF
-uuF
-lJn
-dWx
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+gSn
+jJq
+jJq
+snI
+sLN
+snI
+snI
+bLu
+snI
+gFP
+snI
+dnU
+sLN
+sLN
+dnU
+snI
+sLN
+kLi
+kqY
+snI
+dTS
+hXj
+nDa
+snI
+snI
+snI
+owl
+wMB
+snI
+snI
+snI
+snI
+snI
+nYS
 dhc
 dhc
 dhc
@@ -98399,83 +105208,83 @@ nYS
 "}
 (36,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-nxc
-tsB
-fdO
-cIr
-nxc
-nxc
+msg
+ebq
+gJD
+lJn
+gjA
+wJn
+nOJ
+rtZ
+jpk
+lbf
+geb
+rMl
+rMl
+shr
+rMl
+rMl
+dWx
+lFI
+esw
+pbZ
 fZO
-fZO
-fZO
-hZO
-fZO
-nxc
-fZO
-fZO
-fZO
-fZO
-hZO
-fZO
-fZO
-fZO
-fZO
-nxc
-nxc
-cSf
-eZa
-qkc
-eir
-pHJ
-bCv
+pbZ
 uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+pbZ
+mLG
+vfR
+fZO
+nNb
+iIW
+hGL
+gNI
+wtG
+ege
+xrX
+uyi
+oIJ
+lRF
+cfJ
+pcX
+fZO
+jpk
+uuF
+xTJ
+jJq
+cxZ
+snI
+sLN
+snI
+rZa
+wOJ
+snI
+bfV
+snI
+sLN
+snI
+snI
+sLN
+jNk
+jtT
+snI
+uYW
+hgY
+akv
+hXj
+cdE
+snI
 nYS
-nYS
-nYS
-nYS
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-dhc
-dhc
-dhc
-dhc
+snI
+snI
+snI
+snI
 nYS
 nYS
 nYS
@@ -98655,78 +105464,78 @@ mHl
 mHl
 "}
 (37,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-uuF
+nYS
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+uTM
+mLG
+lRr
+wJn
+wJn
+wJn
+wJn
+wJn
+ihV
+bwr
+lka
+tsB
 eOE
 eFt
-veG
-fZO
-uuF
+pbZ
+pbZ
+hqb
 tnZ
+jvA
+mSO
+sOG
+uuF
+uuN
 fZO
 fZO
-fZO
-sRH
-fZO
-fZO
-fZO
-fZO
-fZO
-fZO
-fZO
-fZO
-fZO
-fZO
-fZO
-nxc
+lRF
+lRF
+mLG
+mLG
+mLG
+pbZ
+dWO
+rbl
 uuF
 uuF
-uuF
+hDF
+eZa
 xMT
+lxw
 uuF
 uuF
-uuF
-uuF
-uuF
-uuF
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-kfi
-nYS
-nYS
+fut
+fut
+iXh
+snI
+sLN
+sLN
+sLN
+sLN
+sLN
+snI
+snI
+sLN
+snI
+rVy
+sLN
 snI
 snI
 snI
 snI
 snI
-snI
-snI
-snI
+hXj
+hXj
+qVo
 snI
 nYS
 nYS
@@ -98912,78 +105721,78 @@ cIc
 mHl
 "}
 (38,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
 nxc
 nxc
-nxc
-cSf
-cSf
-cSf
-nxc
-nxc
-nxc
-nxc
-lIB
+dvJ
+idr
+vPh
+eaO
+dKf
+mLG
+mLG
+lRr
+wSF
+rHa
+mkY
+sLA
+wJn
+cYB
+hDF
+hDF
+wJn
+wJn
 uAD
 vUi
-sRH
-rSe
-fZO
-fZO
-fZO
-fZO
-hZO
-nxc
+pbZ
+hqb
+aMz
+lIY
+gzN
+sOG
 uuF
+owE
+oIJ
 lRF
 tZN
 qRt
-nxc
-hOo
-hOo
+pkQ
+pbZ
 fZO
-sRH
-fZO
-fZO
-eZa
+mLG
+pbZ
+cfJ
+bgW
+aOV
 hfi
-eir
-eir
-sfd
-mrS
-heU
-eir
-qkc
+eqi
+jJq
+fut
+fbp
 uuF
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
+uuF
+uuF
+uuF
 snI
 snI
 snI
 snI
+sLN
+sLN
+snI
+gkv
+sLN
+snI
+eMq
 sLN
 dnU
+cIr
+dnU
 sLN
-sLN
-sLN
-sLN
-sLN
+pMK
+iuI
+xGX
+auN
 snI
 snI
 snI
@@ -99169,79 +105978,79 @@ wqI
 mHl
 "}
 (39,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
-nYS
 nxc
 nxc
-nxc
-nxc
-nxc
-lJn
-lJn
-nxc
+rOP
+blX
+gxc
 rbl
+oIO
+bBa
+bBa
+bBa
+bBa
+wSF
+qCp
+ecc
+bHG
+wSF
+dFK
+lZK
+lJn
+lZK
+tUJ
 enM
-rbl
-rbl
-nxc
+hEW
 fZO
-fZO
-hZO
-nxc
-nxc
+hqb
+dlX
+jvA
+ecL
+sOG
+uuF
 uuF
 pRa
-vHF
-vHF
-vHF
 uuF
 uuF
 uuF
 uuF
-rvR
+cEH
 fZO
-fZO
+mLG
+mLG
+pbZ
+jsH
 eZa
 iub
-eir
-eir
-sfd
-bCv
-eir
-eir
-uTn
+jJq
+jJq
+jJq
+hqo
 uuF
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
-kfi
+mYH
+nKZ
+pOA
+snI
+fDY
+fDY
 snI
 sLN
+snI
+snI
+snI
+sLN
+snI
+snI
+snI
+snI
+snI
+pMK
+nmf
+pMK
+nmf
 sLN
 sLN
-sLN
-sLN
-sLN
-sLN
-sLN
-sLN
-sLN
-sLN
+snI
 sLN
 sLN
 sLN
@@ -99426,75 +106235,75 @@ ihq
 mHl
 "}
 (40,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-tiZ
-nYS
-tiZ
-nYS
-nYS
 nxc
-nxc
-nxc
-nxc
+fxS
+tfZ
+rbl
+rbl
+rbl
+lwU
+odV
+oIO
+bBa
+bBa
+wSF
+oHJ
+fFR
+lJn
+uQE
+lZK
+rnq
+ecc
+oUf
+wJn
+hqL
+hEW
+pbZ
 uuF
-mRx
-vHF
-nxc
 uuF
-cSf
+uuF
+hqb
 vHF
-vHF
-vHF
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-eZa
+uuF
+nCI
+hqL
+nUW
+slT
+dhx
+hxh
 xLL
 jsH
-hQw
-rvR
 fZO
 fZO
-eZa
-rdg
-eir
-eir
-sfd
-bCv
-eir
-eir
-nKZ
+fZO
+pbZ
+jIO
+jJq
+jJq
+vba
+jJq
+rvZ
 uuF
-nYS
-dhc
-dhc
-dhc
-nYS
-nYS
-nYS
-kfi
+lmE
+nKZ
+nKZ
+snI
+fDY
+snI
+snI
+sLN
+snI
+qde
 snI
 sLN
 sLN
 sLN
+dnU
+sLN
+cIr
 sLN
 sLN
-sLN
-sLN
-sLN
+pGV
 sLN
 sLN
 sLN
@@ -99683,73 +106492,73 @@ ihq
 mHl
 "}
 (41,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
-nYS
-tiZ
 nxc
-nxc
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-eZa
-bCv
-iIW
-uuF
-uuF
-wku
-rSe
+dRi
+rbl
+aUm
+pfA
+lvY
+lvY
+lvY
+lvY
+tIC
+bBa
+wSF
+kFI
+aWH
+uqP
+wSF
+cJB
+wJn
+wSF
+kJT
+wJn
+lEp
+lla
+dUQ
+hqb
+qpL
+jTi
+tgp
+lJn
+nBA
+hqL
+hqL
+nxz
+slT
+cMA
+nIX
+xZJ
+lRF
+fZO
+fZO
+fZO
+mLG
 cUN
-eir
-eir
-eir
-sfd
-bCv
-eir
-eir
-oFr
-uuF
-oIa
-dhc
-dhc
-nYS
-nYS
-kfi
+jJq
+jJq
+vba
+jJq
+hru
+lAD
+tFk
+nKZ
+nKZ
 snI
 snI
+snI
+nmf
 sLN
+snI
+riv
+snI
 sLN
-sLN
-sLN
-sLN
-sLN
-sLN
+mSo
+snI
+snI
+snI
+snI
+snI
 sLN
 sLN
 sLN
@@ -99940,74 +106749,74 @@ ihq
 mHl
 "}
 (42,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
 nxc
-nxc
-nxc
-nxc
-cSf
-cSf
-cSf
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-nxc
-uuF
-mEO
-cSf
-cSf
-cSf
+lYu
+rbl
+qcL
+bBa
+ain
+rbl
+yic
+rbl
+vCX
+oIu
+wJn
+wJn
+wJn
+wJn
+wSF
+lZK
+wSF
+sya
+lZK
+wJn
+wJn
+wJn
+qNW
+eQf
+fXO
+gZD
+dDe
+lZK
+fJk
+mdO
 uuF
 uuF
+slT
+goQ
 uuF
-uuF
-uuF
-iMh
+guW
+rbl
+oIJ
+mLG
+mLG
 fZO
-eZa
+cUN
 fut
-eir
-eir
-eir
-eir
-eir
-eir
-mnA
+jJq
+jJq
+jJq
+jjS
 uuF
-nYS
-nYS
-nYS
-tiZ
-kfi
-kfi
+ylX
+nKZ
+auQ
 sLN
-dnU
 sLN
-snI
-snI
-snI
-dnU
-snI
-snI
 sLN
+nmf
+snI
+snI
+eeM
+snI
+nmf
+snI
+snI
+isZ
+cCs
+hLt
+snI
+aEL
 snI
 sLN
 sLN
@@ -100197,72 +107006,72 @@ mHl
 mHl
 "}
 (43,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
 nxc
-nxc
-cSf
-cSf
-cSf
-cSf
-nxc
-nxc
-nxc
-nYS
-nYS
-nYS
-tiZ
-tiZ
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nxc
-nxc
-cSf
-cSf
-cSf
-nxc
-lJn
-lJn
+lYu
+rbl
+oTy
+oIO
+iQn
+rbl
+qaZ
+rbl
+reu
+jQm
+uTg
+wSF
+sUV
+vrX
+ecc
+ydB
+wSF
+qQR
+ydB
+aJe
+fvr
+aOV
+ipQ
+hqb
+baL
+jZK
+rnq
+jZK
+jZK
+bZB
+slT
+eDO
+nDc
 lJn
 uuF
-fZO
-hZO
+dOo
+xvS
+rbl
+hKk
+mLG
+jsH
 eZa
 jVA
-sfd
-eir
-sfd
+gAu
+fWA
+aKy
 gTY
 uuF
-uuF
-uuF
-uuF
-nYS
-snI
-snI
-snI
-snI
-snI
-snI
+oNZ
+nKZ
+tKt
+hBQ
+vor
 sLN
 sLN
 snI
-jFF
+vLk
+vLk
 snI
-sLN
-sLN
+dyB
+snI
+uaF
+isZ
+snI
+wZK
 snI
 snI
 snI
@@ -100454,74 +107263,74 @@ mHl
 nYS
 "}
 (44,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
 nxc
-nxc
-cSf
-cSf
-nxc
-nxc
-nxc
-nxc
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-lJn
-nxc
-nxc
-nxc
-nxc
-nxc
-lJn
-lJn
-lJn
-nxc
-fZO
-fZO
-eZa
-hfi
-eir
-eir
-eir
-eir
+dQK
+rbl
+pJL
+rbl
+rbl
+rbl
+rbl
+rbl
+reu
+tIC
+kCC
+uZI
+qam
+ecc
+lZK
+fKo
+wSF
+uNV
+fFR
+gDQ
+mDZ
+aOV
+rCW
+hqb
+uCr
+gBb
+cQa
+jIG
+jZK
+ydB
+mnE
+bZB
+lZK
+lZK
 uuF
-nYS
-nYS
-nYS
+eWw
+qcZ
+meE
+piv
+oIJ
+jsH
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
+uuF
 snI
 snI
 sLN
-sLN
-sLN
-sLN
 snI
 snI
 sLN
 snI
 snI
+dTS
 snI
-sLN
+qrr
+isZ
 snI
 snI
-nYS
+snI
+jFF
 jFF
 jFF
 jFF
@@ -100711,71 +107520,71 @@ mHl
 nYS
 "}
 (45,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
 nxc
-nxc
-cSf
-cSf
-nxc
-nxc
-nYS
-nYS
-nYS
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
-nxc
-nxc
-nxc
-nYS
-nYS
+qmr
+rbl
+tqj
+lvY
+lvY
+lvY
+lvY
+rud
+gMN
+rfR
+eQj
+uZI
+jDK
+hFL
+hFL
+gPy
+wSF
+ley
+tAI
+lZK
 lJn
-lJn
-lJn
-lJn
-lJn
-lJn
-lJn
-lJn
-lJn
-nxc
-fZO
-nxc
-uuF
-uuF
-uuF
+wJn
+iwH
+hqb
+xaR
+jIG
+gLM
+daP
+lZK
+gRp
+slT
+mbs
+xLB
+hHb
+bZs
+lYJ
+aDb
+gZz
+snI
+snI
+snI
+snI
+sLN
+sLN
 hgu
-uuF
-uuF
-uuF
-nYS
+skt
+nSm
 snI
+nSm
 snI
+vdo
+dnc
 snI
-sLN
-sLN
-snI
-sLN
-sLN
-sLN
-snI
-sLN
+nmf
+vor
 snI
 sLN
 sLN
 sLN
+qxs
+vJx
+vLk
+kyX
+wMB
 snI
 nYS
 jcc
@@ -100968,34 +107777,34 @@ mHl
 nYS
 "}
 (46,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
 nxc
-nxc
-cSf
-cSf
-nxc
-nxc
-nYS
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nxc
-nxc
-fZO
-nxc
+qmr
+rbl
+pJL
+rbl
+rbl
+bBa
+tpt
+bBa
+reu
+rfR
+bBa
+wSF
+beV
+wjN
+aoy
+vGS
+wSF
+ljM
+tAI
+lZK
+tks
+wJn
+qyc
+uuF
+uuF
+uuF
+uuF
 nxc
 nxc
 gbO
@@ -101007,21 +107816,19 @@ nxc
 caS
 gfD
 nxc
-nxc
-rko
-nxc
-nYS
-eZa
-iDb
-jJq
-uuF
-nYS
-nYS
-tiZ
 snI
 sLN
+dnU
+cIr
 sLN
-sLN
+snI
+snI
+snI
+nSm
+nSm
+iOP
+qxs
+rZa
 snI
 snI
 sLN
@@ -101033,6 +107840,8 @@ snI
 sLN
 snI
 snI
+snI
+cIr
 snI
 nYS
 twu
@@ -101225,35 +108034,35 @@ mHl
 nYS
 "}
 (47,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
 nxc
-cSf
-cSf
+dQK
+rbl
+pJL
+rbl
+rbl
+rbl
+bBa
+rbl
+reu
+ibU
+pbZ
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+rnw
 nxc
-nxc
-nYS
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nYS
-nYS
+rhq
 nxc
 fZO
 fZO
-fZO
-aml
 yeS
 aZd
 vcn
@@ -101262,30 +108071,30 @@ oDj
 txM
 tjf
 quA
-wkU
+sRH
 upW
 sLN
 sLN
 snI
-nYS
-eZa
-ksB
-wiz
-uuF
-nYS
-dhc
-nYS
-snI
-sLN
 snI
 snI
 snI
 sLN
+snI
+nSm
+nSm
+snI
+snI
+qxs
+snI
+qxs
 sLN
 snI
-sLN
-sLN
-sLN
+lpt
+snI
+cIr
+snI
+snI
 snI
 sLN
 sLN
@@ -101482,36 +108291,36 @@ mHl
 mHl
 "}
 (48,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
 nxc
-cSf
+weL
+rbl
+lvY
+rfR
+rbl
+rbl
+bBa
+rbl
+dZg
+jsY
+jsY
+vnv
+fxp
+qRA
+aDb
 nxc
-nxc
-nYS
-nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
 nYS
+dLo
+dLo
+dLo
 nxc
+oOK
 nxc
+bXn
 nxc
 fZO
-fZO
-fZO
-qrr
-rrB
+sRH
+yhk
 anr
 tjf
 tjf
@@ -101523,26 +108332,26 @@ nxc
 nxc
 jFI
 dnU
-snI
-nYS
-uuF
-uuF
-xKR
-uuF
-nYS
-nYS
-nYS
-snI
 sLN
-snI
-sLN
+ean
+cIr
 sLN
 sLN
 snI
 snI
+iOP
+qxs
+snI
+qxs
+snI
+mlQ
+qxs
+snI
+bci
+wOJ
+ygq
+vor
 sLN
-snI
-snI
 snI
 snI
 snI
@@ -101739,35 +108548,35 @@ kGC
 mHl
 "}
 (49,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
 nxc
+dRi
+weL
+rbl
+fJL
+ksB
+hXz
+ksB
+ksB
+pbZ
+nSc
+hqL
+wKq
+wJn
 cSf
+hsB
 nxc
 nYS
-nYS
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
+dLo
 nxc
 nxc
-fZO
-fZO
-fZO
+nxc
+nxc
 fZO
 sRH
-qrr
+sRH
 vsE
 aZd
 vcn
@@ -101782,25 +108591,25 @@ cIv
 ean
 snI
 snI
-nYS
+snI
+snI
+sLN
+sLN
+snI
+qxs
+vIk
+ykY
+qxs
+snI
+jwI
 uuF
 uuF
 uuF
-nYS
-nYS
-snI
-snI
-sLN
-snI
-sLN
-snI
-snI
-snI
-sLN
-sLN
-snI
-jFF
-jFF
+uuF
+uuF
+sKI
+ioc
+dcn
 snI
 sLN
 sLN
@@ -101996,28 +108805,28 @@ xrJ
 mHl
 "}
 (50,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
 nxc
-cSf
+nxc
+gUn
+cXI
+kXg
+uKn
+jqC
+uKn
+uKn
+lZQ
+ruq
+hqL
+wKq
+wJn
+aDb
+nxc
 nxc
 nYS
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nxc
+dLo
 rhq
 fZO
 fZO
@@ -102025,7 +108834,7 @@ fZO
 fZO
 fZO
 aml
-rrB
+yhk
 aZd
 tjf
 tjf
@@ -102038,25 +108847,25 @@ nxc
 snI
 sLN
 sLN
-snI
-snI
-nYS
-nYS
-nYS
-nYS
-snI
-snI
-sLN
-dnU
-snI
-sLN
-sLN
-sLN
 sLN
 sLN
 snI
 snI
+cJC
 snI
+snI
+snI
+rOQ
+ykY
+snI
+dnc
+uuF
+pWq
+tAB
+jIF
+jJq
+tsX
+gTG
 snI
 snI
 sLN
@@ -102253,36 +109062,36 @@ emW
 lWX
 "}
 (51,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 nYS
 nxc
-cSf
+cho
+qfx
+bMu
+cDI
+uDN
+deM
+qLm
+gJg
+nSc
+hqL
+lrX
+wJn
 nxc
+nxc
+nYS
 nYS
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
-nxc
-nxc
+dLo
+rhq
 fZO
-nxc
+fZO
 fZO
 fZO
 fZO
 sRH
-jBE
+dAR
 anr
 tjf
 tjf
@@ -102295,29 +109104,29 @@ nYS
 snI
 snI
 sLN
-sLN
-snI
-snI
-snI
-snI
-snI
-snI
-sLN
-sLN
-sLN
-snI
-snI
-sLN
-sLN
-sLN
-snI
 snI
 sLN
 sLN
 snI
 sLN
 sLN
+snI
+rOQ
+gFP
+snI
+snI
+isZ
+uuF
+jzd
+jJq
+nIi
+uuF
+uuF
+crp
+cIr
 sLN
+sLN
+fkV
 twu
 csL
 mkp
@@ -102510,33 +109319,33 @@ kGC
 lWX
 "}
 (52,1,1) = {"
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
+nYS
 nYS
 nxc
-cSf
-nxc
+wJn
+wJn
+hDF
+wJn
+wJn
+hDF
+hDF
+aBQ
+eSF
+wJn
+wJn
+nYS
+nYS
 nYS
 dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-nYS
+dLo
+nxc
+nxc
+nxc
 nxc
 fZO
-fZO
-nxc
-fZO
-sRH
 fZO
 fZO
 yhk
@@ -102545,7 +109354,7 @@ vcn
 tjf
 tjf
 tjf
-tjf
+dqh
 yhk
 nxc
 nYS
@@ -102553,26 +109362,26 @@ nYS
 snI
 qrL
 sLN
-dnU
-sLN
-ean
-snI
-sLN
-snI
 sLN
 sLN
 snI
 snI
 sLN
-sLN
-sLN
 snI
+tlu
+lII
 snI
-sLN
-sLN
-sLN
-sLN
-sLN
+qxs
+qxs
+uuF
+ohj
+qka
+nXj
+xsz
+bwz
+iEv
+snI
+mDT
 snI
 snI
 twu
@@ -102768,35 +109577,35 @@ mHl
 "}
 (53,1,1) = {"
 dhc
-dhc
-dhc
-dhc
-dhc
 nYS
 nYS
-nxc
-cSf
-nxc
+aBQ
+vQg
+lZK
+wyZ
+aBQ
+nLm
+buq
+pzh
+eir
+wqv
+wJn
+tiZ
 nYS
 dhc
 dhc
 dhc
 dhc
 dhc
-dhc
-dhc
-dhc
-dhc
-nYS
+dLo
+dLo
+dLo
 nxc
-nxc
-nxc
-nxc
-sRH
-sRH
+hOo
 fZO
 fZO
-pOz
+fZO
+yhk
 aZd
 tjf
 txM
@@ -102811,25 +109620,25 @@ snI
 snI
 sLN
 snI
-snI
-sLN
-snI
-snI
-snI
-sLN
-snI
-snI
 sLN
 sLN
 snI
-snI
-snI
-sLN
-sLN
 sLN
 snI
+eub
 snI
-sLN
+snI
+cIr
+snI
+uuF
+uuF
+uuF
+vaV
+uuF
+snI
+iUI
+snI
+cIr
 snI
 jFF
 twu
@@ -103026,32 +109835,32 @@ lWX
 (54,1,1) = {"
 dhc
 dhc
-dhc
-dhc
-dhc
 nYS
-nxc
-nxc
-cSf
-nxc
+aBQ
+hEs
+ecc
+egT
+aBQ
+gdH
+ybd
+eir
+eir
+qkc
+wJn
 nYS
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
-dhc
 dhc
 dhc
 nYS
 nYS
+dLo
+dLo
+dLo
+dLo
+dLo
 nxc
-rvR
+hOo
 fZO
-sRH
-fZO
-fZO
+mYA
 fZO
 yhk
 aZd
@@ -103067,24 +109876,24 @@ nYS
 snI
 dnU
 sLN
+snI
+snI
 sLN
+snI
+sLN
+snI
+snI
+snI
+sLN
+qxs
+cIr
+qxs
+cIr
+ldr
+qrr
+qrr
 snI
 dnU
-sLN
-snI
-dnU
-sLN
-snI
-sLN
-sLN
-snI
-snI
-sLN
-sLN
-sLN
-snI
-snI
-snI
 sLN
 sLN
 snI
@@ -103283,34 +110092,34 @@ nYS
 (55,1,1) = {"
 dhc
 dhc
+nYS
+pZO
+knT
+ecc
+nIr
+aBQ
+ygM
+eir
+eir
+eir
+iyw
+wJn
+nYS
 dhc
 dhc
-dhc
 nYS
-nxc
-cSf
-cSf
-nxc
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nYS
-nxc
-rvR
-rvR
-fZO
-sRH
-fZO
-fZO
-dth
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+vCw
 tcI
 tjf
 tjf
@@ -103320,29 +110129,29 @@ tjf
 pOz
 sbL
 snI
-aBQ
-ljf
-ljf
-ljf
-ljf
-snI
-sLN
-sLN
-snI
+mfd
+mfd
+mfd
+mfd
+mfd
+mfd
 sLN
 snI
-snI
 sLN
-snI
-snI
-sLN
-sLN
-sLN
+cIr
+dnU
+dnU
+dnU
 snI
 snI
-sLN
-sLN
-sLN
+qxs
+cIr
+chZ
+cIr
+fXM
+snI
+dnU
+snI
 snI
 snI
 nYS
@@ -103540,34 +110349,34 @@ nYS
 (56,1,1) = {"
 dhc
 dhc
+nYS
+aBQ
+aHq
+lZK
+lZK
+iiW
+eir
+bWM
+wJn
+wJn
+wJn
+wJn
+nYS
 dhc
 dhc
 nYS
-nYS
-nxc
-cSf
-nxc
-nxc
-nYS
-nYS
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
+wJn
+wae
+hzb
+tGs
+scJ
+lFs
+gjY
+wJn
+meL
+cul
+cBl
+wJn
 tcI
 lEs
 tjf
@@ -103579,26 +110388,26 @@ gJg
 aZd
 jYo
 iDb
-gLM
-qJo
-wJn
-sLN
-dnU
-snI
-snI
+aip
+lMe
+iik
+mfd
 sLN
 snI
-sLN
-sLN
+dpv
 snI
-sLN
-sLN
-sLN
+snI
+snI
 snI
 snI
 sLN
 sLN
-sLN
+snI
+snI
+snI
+ggA
+bkm
+mlQ
 sLN
 snI
 nYS
@@ -103797,34 +110606,34 @@ dhc
 (57,1,1) = {"
 dhc
 dhc
+nYS
+wJn
+wJn
+wJn
+wJn
+aBQ
+dLD
+eir
+mzz
+dPO
+pbF
+wJn
+nYS
 dhc
 dhc
 nYS
-nxc
-nxc
-cSf
-nxc
-nYS
-nYS
-nYS
-vui
-hBd
-hDF
-xEP
-yic
-lMe
-lMe
-lMe
-xEP
-fBX
+wJn
+eyG
+pMa
+eir
 pvs
-uth
-jqU
+oXJ
+eir
 gmj
-lMe
-lMe
-aip
-lFi
+gjY
+cGi
+bvC
+wJn
 aZd
 tjf
 tjf
@@ -103836,24 +110645,24 @@ rrB
 aZd
 jYo
 fhl
-jJq
-dxU
-wJn
+nBb
+lMe
+iik
+mfd
+sLN
+sLN
+sLN
+hil
+cIr
+sLN
+sLN
+sLN
+sLN
+xnC
 snI
-sLN
-snI
-sLN
-sLN
-snI
-sLN
-snI
-snI
-sLN
-sLN
-snI
-snI
-sLN
-sLN
+cAh
+bkm
+mlQ
 sLN
 snI
 snI
@@ -104054,34 +110863,34 @@ dhc
 (58,1,1) = {"
 dhc
 dhc
+nYS
+aBQ
+mhg
+lZK
+lJn
+iiW
+iFa
+eir
+aBQ
+nfG
+lZK
+wJn
+nYS
 dhc
 dhc
 nYS
-nxc
-cSf
-cSf
-nxc
-nYS
-dhc
-nYS
-vui
-qVo
-mUZ
-sEZ
-lMe
-lMe
-lMe
-lMe
-xEP
-lMe
-pvs
-iik
-iik
-gmj
-lMe
-lMe
-lMe
-lFi
+wJn
+vEo
+eir
+lWu
+pyh
+gwK
+eir
+wJn
+hXq
+cGi
+msE
+vJh
 aZd
 tjf
 tjf
@@ -104090,26 +110899,26 @@ tjf
 dqh
 dth
 ivF
-wJn
-wJn
-fzI
-wJn
-wJn
-wJn
-sLN
-sLN
-snI
-sLN
-snI
-snI
-sLN
+aZd
+jYo
+iDb
+lMe
+mFC
+iik
+mfd
 snI
 sLN
 sLN
 snI
 snI
 sLN
+snI
 sLN
+xnC
+snI
+snI
+sLN
+snI
 kfi
 kfi
 kfi
@@ -104311,34 +111120,34 @@ dhc
 (59,1,1) = {"
 dhc
 dhc
+nYS
+aBQ
+knT
+lZK
+edu
+wJn
+aBQ
+hoE
+aBQ
+knT
+lJn
+wJn
+nYS
 dhc
 dhc
 nYS
-nxc
-cSf
-nxc
-nxc
-nYS
-dhc
-nYS
-lFi
-lFi
-lFi
-xEP
-jRc
-lMe
-lMe
-lMe
-hPp
-lMe
-lMe
-lMe
-lMe
-lMe
-lMe
-lMe
-lMe
-khN
+wJn
+qZS
+nAb
+emX
+lFx
+gwK
+eir
+wJn
+eir
+cGi
+mBO
+vJh
 anr
 tjf
 vcn
@@ -104347,13 +111156,13 @@ tjf
 tjf
 dth
 ivF
-icG
-kFZ
-eir
-hNk
-kFZ
-wJn
-snI
+wVY
+mfd
+mfd
+bMx
+mfd
+mfd
+mfd
 sLN
 sLN
 sLN
@@ -104362,11 +111171,11 @@ sLN
 sLN
 snI
 sLN
-sLN
+snI
 snI
 sLN
 sLN
-sLN
+sRz
 kfi
 nYS
 nYS
@@ -104568,34 +111377,34 @@ dhc
 (60,1,1) = {"
 dhc
 dhc
+nYS
+aBQ
+fNY
+ecc
+pcf
+wJn
+tSt
+lZK
+ecc
+lZK
+ecc
+wJn
+nYS
 dhc
 dhc
 nYS
-nxc
-cSf
-nxc
-nYS
-nYS
-dhc
-nYS
-xEP
-iik
-lMe
-lMe
-lMe
-lMe
-lMe
-lMe
-xEP
-iik
-lMe
-lMe
-lMe
-lMe
-lMe
-lMe
+wJn
+wJn
+wJn
+pMa
+bOo
+eir
+eir
+cgo
+tdW
+cGi
 wQk
-lFi
+wJn
 aZd
 txM
 tjf
@@ -104604,13 +111413,13 @@ tjf
 tjf
 trM
 rrB
-icG
-jVA
-eir
-jqn
-eir
-wJn
-sLN
+bKy
+hKR
+wqn
+pHJ
+tfp
+pcR
+mfd
 vFM
 wJQ
 dnU
@@ -104619,7 +111428,7 @@ snI
 snI
 snI
 sLN
-sLN
+wMB
 snI
 sLN
 sLN
@@ -104825,34 +111634,34 @@ dhc
 (61,1,1) = {"
 dhc
 dhc
+nYS
+aBQ
+jLG
+wch
+erZ
+wJn
+qIV
+jtj
+aBQ
+aUx
+qrt
+wJn
+nYS
 dhc
 dhc
 nYS
-nxc
-cSf
-nxc
-nYS
-nYS
-nYS
-nYS
-xEP
-iik
-nxY
-oAK
-nIG
-lMe
-qRF
+wJn
 fBX
-xEP
+sdF
 sYZ
-oHg
-xlF
-iik
-nSm
-lMe
-lMe
-lMe
-lFi
+dQT
+eir
+jrx
+wJn
+hiE
+hxd
+mbw
+wJn
 npf
 tjf
 vcn
@@ -104861,19 +111670,19 @@ tjf
 tjf
 pOz
 rrB
-icG
-eir
-eir
-bCv
-bCv
-wJn
-snI
+vFy
+fSi
+jTE
+pHJ
+bhv
+pqm
+mfd
 snI
 snI
 sLN
-sLN
-dnU
-sLN
+cIr
+dnc
+qxs
 dnU
 sLN
 snI
@@ -105082,34 +111891,34 @@ dhc
 (62,1,1) = {"
 dhc
 dhc
+nYS
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+nYS
 dhc
 dhc
 nYS
-nxc
-cSf
-nxc
-nYS
-nxc
-nxc
-nxc
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
-lFi
+wJn
+wJn
+wJn
+fzI
+sKI
+sKI
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
 aZd
 tjf
 tjf
@@ -105119,24 +111928,24 @@ tjf
 dth
 rrB
 vFy
-wJn
-fzI
-wJn
-wJn
-wJn
-sLN
-sLN
+wfG
+nij
+pHJ
+bhv
+xlF
+mfd
+ldr
 snI
-ufO
+ean
 snI
-sLN
-sLN
+vLk
+qxs
 snI
 sLN
 snI
 jFF
 snI
-sLN
+cIr
 snI
 nYS
 wTq
@@ -105339,30 +112148,30 @@ dhc
 (63,1,1) = {"
 dhc
 dhc
-dhc
-dhc
 nYS
-nxc
-cSf
-nxc
 nYS
-nxc
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+nYS
+nYS
+nYS
+tiZ
+nYS
+nYS
+nYS
+nYS
+nYS
+nYS
+tiZ
+nYS
+nYS
+nYS
+wJn
+bCv
+mcH
+eir
+eir
+wTx
+wJn
+gGl
 tJH
 gSw
 hlP
@@ -105375,19 +112184,19 @@ dqh
 lEs
 dth
 rrB
-icG
+bKy
 jqn
-eir
-eir
-bCv
-wJn
-sLN
-sLN
+lMe
+lMe
+toL
+toL
+mfd
+qxs
 snI
 ean
 snI
 snI
-snI
+qxs
 snI
 snI
 snI
@@ -105598,27 +112407,27 @@ dhc
 dhc
 dhc
 dhc
+dhc
+dhc
+dhc
 nYS
 nxc
-cSf
 nxc
-nYS
-qam
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+nxc
+nxc
+nxc
+nxc
+nxc
+nxc
+nxc
+nxc
+wJn
+rFm
+rGt
+iPd
+eir
+uYG
+wJn
 cSf
 tJH
 uyd
@@ -105632,22 +112441,22 @@ tjf
 dqh
 yhk
 deM
-icG
-bCv
-uoI
-eir
+bKy
+wtL
+lMe
+lMe
 bLZ
-wJn
+bLZ
+mfd
+wkU
 sLN
-sLN
-snI
 wkU
 wkU
 sLN
-sLN
-snI
-sLN
-sLN
+dnU
+uaF
+ldr
+cIr
 sLN
 sLN
 sLN
@@ -105855,12 +112664,12 @@ dhc
 dhc
 dhc
 dhc
+dhc
+dhc
+dhc
 nYS
 nxc
 cSf
-nxc
-nYS
-nxc
 cSf
 cSf
 cSf
@@ -105869,13 +112678,13 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+wJn
+mNY
+eir
+hjI
+iWn
+kCH
+wJn
 cSf
 tJH
 cVp
@@ -105889,13 +112698,13 @@ tjf
 dqh
 yhk
 rrB
-icG
+bKy
 cZu
 uoI
-eir
-mnA
-wJn
-sLN
+slM
+mfd
+mfd
+mfd
 snI
 snI
 snI
@@ -105905,7 +112714,7 @@ sLN
 snI
 sLN
 snI
-snI
+gIU
 sLN
 sLN
 snI
@@ -106112,12 +112921,12 @@ dhc
 dhc
 dhc
 dhc
+dhc
+dhc
+dhc
 nYS
 nxc
 cSf
-nxc
-nxc
-nxc
 cSf
 cSf
 cSf
@@ -106126,13 +112935,13 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
-cSf
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
+wJn
 cSf
 tJH
 uyd
@@ -106148,21 +112957,21 @@ trM
 rrB
 icG
 iaW
-eir
-eir
-bCv
-wJn
+txd
+uMs
+bhv
+xKR
+mfd
 snI
+hil
+sLN
+hFb
 snI
 sLN
-sLN
-wkU
-snI
-sLN
-sLN
-sLN
+cIr
 sLN
 snI
+oat
 sLN
 sLN
 snI
@@ -106369,11 +113178,11 @@ dhc
 dhc
 dhc
 dhc
+dhc
+dhc
+dhc
 nYS
 nxc
-cSf
-cSf
-lvY
 cSf
 cSf
 cSf
@@ -106404,12 +113213,12 @@ tjf
 yhk
 rrB
 bKy
-eir
-eir
-eir
+lIM
+txd
+kbB
 sTl
-wJn
-cIv
+uAA
+mfd
 sLN
 wkU
 sLN
@@ -106421,7 +113230,7 @@ snI
 snI
 snI
 sLN
-sLN
+xnC
 snI
 nYS
 wTq
@@ -106626,10 +113435,10 @@ dhc
 dhc
 dhc
 dhc
+dhc
+dhc
+dhc
 nYS
-kfi
-nxc
-nxc
 nxc
 cSf
 cSf
@@ -106660,24 +113469,24 @@ dqh
 tjf
 yhk
 rrB
-vFy
-wJn
-wJn
-wJn
-wJn
-wJn
-snI
+wVY
+mfd
+mfd
+mfd
+mfd
+mfd
+mfd
 wkU
 sLN
 snI
-sLN
-sLN
-sLN
-sLN
-sLN
-sLN
-sLN
-sLN
+vor
+prW
+dBX
+hBQ
+dBX
+prW
+vor
+vor
 snI
 snI
 nYS
@@ -106883,9 +113692,9 @@ dhc
 dhc
 dhc
 dhc
-nYS
-nYS
-nYS
+dhc
+dhc
+dhc
 nYS
 nxc
 cSf
@@ -106925,13 +113734,13 @@ snI
 sLN
 sLN
 sLN
-sLN
+hil
 snI
 snI
 snI
-sLN
-sLN
-sLN
+oFM
+uaF
+fEO
 snI
 snI
 snI
@@ -107165,7 +113974,7 @@ cSf
 tJH
 gSw
 krV
-yhk
+tlB
 aZd
 tjf
 dqh
@@ -107181,9 +113990,9 @@ snI
 sLN
 dnU
 sLN
-kfi
-kfi
-kfi
+snI
+snI
+snI
 nYS
 snI
 snI
@@ -107422,7 +114231,7 @@ cSf
 tJH
 gSw
 krV
-yhk
+bFg
 aZd
 dqh
 tjf
@@ -107437,8 +114246,8 @@ hZO
 sLN
 ean
 sLN
-kfi
-kfi
+snI
+snI
 nYS
 nYS
 tiZ
@@ -107694,7 +114503,7 @@ fZO
 fZO
 rSe
 nxc
-kfi
+nxc
 nYS
 nYS
 dhc
@@ -108203,9 +115012,9 @@ tjf
 edW
 rrB
 tcI
-rvR
-rvR
-fZO
+ibp
+ibp
+bXs
 fZO
 fZO
 nxc
@@ -108716,13 +115525,13 @@ tjf
 vcn
 edW
 rrB
-xnV
-gXe
+sNZ
+gCO
+gQq
 lMe
-wQk
-lMe
-lMe
-iik
+lBF
+tfp
+hnN
 mfd
 nYS
 dhc
@@ -108973,15 +115782,15 @@ tjf
 tjf
 pOz
 rrB
-xnV
-lMe
-oqj
-oqj
+sNZ
+sdE
 lMe
 lMe
+smh
+bhv
 gAA
 mfd
-oIa
+nYS
 dhc
 dhc
 dhc
@@ -109221,7 +116030,7 @@ cSf
 tJH
 gSw
 krV
-yhk
+tlB
 rHn
 tjf
 dqh
@@ -109230,12 +116039,12 @@ tjf
 tjf
 yhk
 omQ
-xnV
-jRc
-hqb
-iik
+sNZ
 lMe
 lMe
+cmL
+smh
+bhv
 xlF
 mfd
 nYS
@@ -109478,7 +116287,7 @@ cSf
 tJH
 uyd
 krV
-yhk
+bFg
 aZd
 tjf
 dqh
@@ -109487,13 +116296,13 @@ dqh
 dqh
 edW
 rrB
-xnV
-lMe
-iik
-uth
+olG
+noc
 lMe
 lMe
-iik
+pHJ
+iMh
+kXU
 mfd
 nYS
 dhc
@@ -109744,12 +116553,12 @@ dqh
 tjf
 vUu
 rrB
-xnV
-lMe
-sTa
-sTa
-lMe
-lMe
+olG
+ygk
+cYy
+tMv
+dJT
+wmY
 tHD
 mfd
 nYS
@@ -110001,16 +116810,16 @@ tjf
 tjf
 trM
 rrB
-xnV
+sNZ
 pTe
+snf
+vth
 lMe
-lMe
-lMe
-lMe
-lMe
+sLn
+lYy
 mfd
 nYS
-dhc
+nYS
 dhc
 dhc
 dhc
@@ -110258,16 +117067,16 @@ txM
 tjf
 yhk
 rrB
-xnV
-nxY
-lMe
 mfd
-vui
-auM
+mfd
+mfd
+sNZ
+euW
+mfd
+mfd
 mfd
 mfd
 nYS
-dhc
 dhc
 dhc
 dhc
@@ -110516,15 +117325,15 @@ tjf
 edW
 rrB
 xnV
-diP
+cmL
+cmL
 lMe
-jTE
-mUZ
-mUZ
+lMe
+kCK
 nWC
+eYX
 mfd
 nYS
-dhc
 dhc
 dhc
 dhc
@@ -110774,14 +117583,14 @@ yhk
 rrB
 xnV
 rjV
-lMe
-jTE
-nkA
-mUZ
-mUZ
+nBb
+tRQ
+mfd
+txd
+kCz
+xKR
 mfd
 nYS
-dhc
 dhc
 dhc
 dhc
@@ -111030,15 +117839,15 @@ tjf
 pOz
 gJg
 xnV
-iik
-fBX
+cvP
+qRF
 jTE
 txd
 urX
 cPI
+giJ
 mfd
-nYS
-nYS
+tiZ
 nYS
 nYS
 nYS
@@ -111277,7 +118086,7 @@ cSf
 hns
 gSw
 krV
-yhk
+tlB
 anr
 tjf
 dqh
@@ -111294,7 +118103,7 @@ mfd
 mfd
 mfd
 mfd
-nYS
+mfd
 nYS
 nxc
 nxc
@@ -111534,7 +118343,7 @@ cSf
 tJH
 cVp
 krV
-yhk
+bFg
 aZd
 dqh
 rsp
@@ -114099,13 +120908,13 @@ cSf
 cSf
 cSf
 cSf
-cSf
-cSf
-tJH
-gSw
+gkZ
+gkZ
+gkZ
+gkZ
 xgR
-dth
-nxc
+lpU
+gkZ
 nYS
 leI
 leI
@@ -114356,13 +121165,13 @@ cSf
 cSf
 cSf
 cSf
-mfd
-mfd
-mfd
+xgR
+wiz
+xKj
 ydF
-mfd
-mfd
-mfd
+ulD
+lMe
+gkZ
 nYS
 eDf
 eDf
@@ -114614,12 +121423,12 @@ cSf
 cSf
 cSf
 cXg
-iik
+nkB
 gXe
+bdL
+vSm
 lMe
-wQk
-bgB
-mfd
+gkZ
 nYS
 eDf
 bqp
@@ -114871,12 +121680,12 @@ cSf
 cSf
 cSf
 cXg
-iik
+oxb
+fct
+bdL
+vSm
 lMe
-lMe
-lMe
-lMe
-mfd
+gkZ
 nYS
 eDf
 sMO
@@ -115129,11 +121938,11 @@ cSf
 cSf
 cXg
 bns
+chO
+uvz
+vSm
 lMe
-lMe
-lMe
-lMe
-mfd
+gkZ
 nYS
 eDf
 bqp
@@ -115384,13 +122193,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
+xgR
 oHg
+hRd
+hRd
+nan
 lMe
-lMe
-lMe
-lMe
-mfd
+gkZ
 nYS
 eDf
 bqp
@@ -115641,13 +122450,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
-iik
+xgR
+dXf
 lMe
-lMe
-lMe
-lMe
-mfd
+tCu
+tCu
+vIh
+gkZ
 nYS
 eDf
 sMO
@@ -115898,13 +122707,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
+efV
 uMr
-lMe
-lMe
+bYE
+wSL
 oqj
-gFP
-mfd
+lMe
+gkZ
 nYS
 eDf
 bqp
@@ -116155,13 +122964,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
+efV
+vlQ
+bYE
+qDI
+iMh
 lMe
-lMe
-lMe
-uth
-iik
-mfd
+gkZ
 nYS
 eDf
 eDf
@@ -116412,13 +123221,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
-jRc
+fMm
+moT
+bYE
+xeX
+xKR
 lMe
-lMe
-iik
-iik
-mfd
+gkZ
 nYS
 rro
 icm
@@ -116669,13 +123478,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
-lMe
-lMe
-lMe
+fMm
+ciV
+bYE
+quu
 sTa
-sTa
-mfd
+lMe
+gkZ
 nYS
 rro
 goy
@@ -116926,13 +123735,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
-fBX
-lMe
-lMe
-qRF
-lMe
-mfd
+gkZ
+gkZ
+gkZ
+gkZ
+xgR
+vIh
+gkZ
 nYS
 rro
 hkI
@@ -117183,13 +123992,13 @@ cSf
 cSf
 cSf
 cSf
-mfd
+xzW
 udJ
-bMx
-mfd
-mfd
-mfd
-mfd
+tCu
+ixS
+xgR
+lMe
+gkZ
 nYS
 rro
 mrL
@@ -117440,13 +124249,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
+agB
+nxY
 lMe
 lMe
+cGr
 lMe
-lMe
-nIG
-mfd
+gkZ
 nYS
 rro
 kht
@@ -117697,13 +124506,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
+xzW
+ehV
 lMe
-lMe
-lMe
-lMe
-sdF
-mfd
+iDb
+xgR
+mFC
+gkZ
 nYS
 rro
 rhB
@@ -117954,13 +124763,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
-nxY
-lMe
-jTE
-auM
-mfd
-mfd
+gkZ
+gkZ
+gkZ
+gkZ
+xgR
+euW
+gkZ
 nYS
 rro
 rhB
@@ -118211,13 +125020,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
-diP
-lMe
-jTE
-hBd
 bYE
-mfd
+diP
+wFc
+xgR
+hBd
+lMe
+gkZ
 nYS
 rro
 iQr
@@ -118468,13 +125277,13 @@ cSf
 cSf
 cSf
 cSf
-cXg
-iik
-iik
-jTE
-txd
-urX
-mfd
+bYE
+fGf
+lMe
+cGr
+lMe
+wFc
+gkZ
 nYS
 rro
 hzK
@@ -118725,13 +125534,13 @@ cSf
 cSf
 cSf
 cSf
-mfd
-mfd
-mfd
-mfd
-mfd
-mfd
-mfd
+gkZ
+gkZ
+gkZ
+gkZ
+gkZ
+gkZ
+gkZ
 nYS
 rro
 qty
@@ -163243,7 +170052,7 @@ ozP
 daK
 ozP
 ozP
-ozP
+xJH
 aoa
 noj
 hOP


### PR DESCRIPTION

## About The Pull Request

* Expanded the Maze, with bear traps, hidden walls and etc. designed to be as confusing as possible
* Added in an additional entry point into the sewers hidden away underneath a boulder at the beach right behind the Trujah's domain.
* Warrens have been expanded! Adding in: Tighter security, spawning pools, more housing, multiple entrances, An improved bar, a computer/security room for flavor, Jail cells, A very unsanitary operating room, and a basketball court.
* Also some minor additions for QOL purposes such as ATMs and a clothing store in both the warrens, and Nostown.
* Redecorated some of the apartments, and redesigned one into a store free for everyone to use.

## Why It's Good For The Game

The warren rework has been requested by Nos players, and other players beside Nosferatu like Gargoyles have been requesting a store they could easily go into and buy masks, and robes from. 

## Testing Photographs and Procedure

<summary>Screenshots&Videos</summary>

The extra entrypoint
![image](https://github.com/user-attachments/assets/8a2b039a-7f79-4207-88dc-6c7773939d05)
![image](https://github.com/user-attachments/assets/f83e6f81-4499-4603-bfb4-5cc88a511c9f)
![image](https://github.com/user-attachments/assets/7eda32d6-0a78-4485-a775-6bb2190d8e90)
![image](https://github.com/user-attachments/assets/f0f4958f-b8d6-4ecc-b95e-b7b8ccdfcfd3)
![image](https://github.com/user-attachments/assets/4738872b-940d-4d90-a04f-77d0700e0e0f)
![image](https://github.com/user-attachments/assets/cdc2a3f5-bb5d-4897-8e8c-563f29e5ce58)
![image](https://github.com/user-attachments/assets/5263583d-d676-4283-80bc-8769491995dc)
![image](https://github.com/user-attachments/assets/f22d6c5f-b9f2-4db8-b264-e11af781ff68)
![image](https://github.com/user-attachments/assets/33962084-f50b-4de3-a1b3-6f59fc237641)
![image](https://github.com/user-attachments/assets/bcd59804-5f09-4832-b2bb-c43ca40aa6c4)
![image](https://github.com/user-attachments/assets/a07dfbed-c247-4f71-87d5-a41c42c85238)
![image](https://github.com/user-attachments/assets/ee6af526-700b-4c3f-b9ec-105ed44ac175)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:

qol: easier access to stores for masquerade violating individuals
map: added and modified some buildings in Nosferatu town and the Warrens

/:cl:

