### PR TITLE
Not all ids are publicly identifiable

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -88,6 +88,8 @@
 	var/uses_overlays = TRUE
 	var/icon/cached_flat_icon
 	var/registered_age = 13 // default age for ss13 players
+	/// Whether one can learn about the name registered to this ID at a glance.
+	var/registered_name_is_public = TRUE
 
 /obj/item/card/id/Initialize(mapload)
 	. = ..()
@@ -333,8 +335,8 @@ update_label()
 */
 
 /obj/item/card/id/proc/update_label()
-	var/blank = !registered_name
-	name = "[blank ? id_type_name : "[registered_name]'s"] [initial(name)]"
+	var/blank = !(registered_name && registered_name_is_public)
+	name = blank ? id_type_name : "[registered_name]'s [initial(name)]"
 	update_appearance()
 
 /obj/item/card/id/silver

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -65,7 +65,7 @@
 	var/obj/item/modular_computer/tablet/tablet = wear_id
 	if(istype(wallet))
 		id = wallet.front_id
-	if(istype(id))
+	if(istype(id) && id.registered_name_is_public)
 		. = id.registered_name
 	else if(istype(pda))
 		. = pda.owner

--- a/code/modules/vtmb/jobs/jobs.dm
+++ b/code/modules/vtmb/jobs/jobs.dm
@@ -186,6 +186,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "bruiser_badge"
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/sweeper
 	name = "sweeper badge"
@@ -199,6 +200,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "sweeper_badge"
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/emissary
 	name = "emissary badge"
@@ -212,6 +214,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "emissary_badge"
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/baron
 	name = "eagle badge"
@@ -225,6 +228,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "eagle_badge"
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/clinic
 	name = "medical badge"
@@ -335,6 +339,7 @@
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id11"
 	slot_flags = ITEM_SLOT_NECK|ITEM_SLOT_ID
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/primogen
 	name = "mysterious primogen badge"
@@ -348,6 +353,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id12"
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/police
 	name = "police officer badge"
@@ -399,6 +405,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id14"
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/noddist
 	name = "cultist badge"
@@ -412,6 +419,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id15"
+	registered_name_is_public = FALSE
 
 //TZIMISCE ROLES
 
@@ -427,6 +435,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id12"
+	registered_name_is_public = FALSE
 
 /obj/item/card/id/bogatyr
 	name = "dusty badge"
@@ -440,6 +449,7 @@
 	onflooricon = 'code/modules/wod13/onfloor.dmi'
 	worn_icon = 'code/modules/wod13/worn.dmi'
 	worn_icon_state = "id12"
+	registered_name_is_public = FALSE
 
 // PRIMOGEN STAFF (Distributed in game by Primogen)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Makes it so that IDs can have their assigned names/users less publicly identifiable. You can still learn who is the owner if you get to examine them directly (due to the SS13 account code part), but not at a glance when someone is wearing it.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Some of these "id"s are small pins that would not realistically carry names. We have the Fame feature for that. Others, like the Anarch ones, not merely don't carry names, but they are meant to be transferable. And for the antag ones (noddists, infernalists) it goes without say, I guess.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/f6ab9f8f-26ca-4aa6-a5ac-c7ab6b4f8203)
![image](https://github.com/user-attachments/assets/d9133614-dcc8-4d96-b0a8-65c39f826ed2)
![image](https://github.com/user-attachments/assets/b1bde8ab-b80e-4803-a711-d135b796dfe9)
![image](https://github.com/user-attachments/assets/084e9399-0efd-4806-8707-fdfa5fe02a68)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Anarch, Tzmisce, Primogen, Noddist and Bahari id/pins no longer identify their users at a glance.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
