### PR TITLE
Presence Tweaks

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/presence.dm
+++ b/code/modules/wod13/datums/powers/discipline/presence.dm
@@ -129,9 +129,9 @@
 		target.apply_overlay(MUTATIONS_LAYER)
 
 		target.Stun(1 SECONDS)
-		to_chat(target, span_userlove("REST"))
+		to_chat(target, span_userlove("DOWN"))
 		to_chat(owner, span_warning("You've enthralled [target] with your commanding aura!"))
-		owner.say("REST!!")
+		owner.say("Down!")
 		if(target.body_position == STANDING_UP)
 			target.toggle_resting()
 		SEND_SOUND(target, sound('code/modules/wod13/sounds/presence_activate.ogg'))
@@ -185,8 +185,8 @@
 		var/obj/item/I2 = target.get_inactive_held_item()
 
 		to_chat(owner, span_warning("You've enthralled [target] with your commanding aura!"))
-		to_chat(target, span_userlove("PLEASE ME"))
-		owner.say("PLEASE ME!!")
+		to_chat(target, span_userlove("GIVE IT HERE"))
+		owner.say("Give it here.")
 
 		target.face_atom(owner)
 		target.do_jitter_animation(3 SECONDS)
@@ -244,8 +244,8 @@
 		target.apply_overlay(MUTATIONS_LAYER)
 
 		to_chat(owner, span_warning("You've compelled [target] to heed your presence!"))
-		to_chat(target, span_userlove("FEAR ME"))
-		owner.say("FEAR ME!!")
+		to_chat(target, span_userlove("LEAVE"))
+		owner.say("Leave!")
 
 		var/datum/cb = CALLBACK(target, TYPE_PROC_REF(/mob/living/carbon/human, step_away_caster), owner)
 		for(var/i in 1 to 30)
@@ -307,8 +307,8 @@
 		target.apply_overlay(MUTATIONS_LAYER)
 
 		to_chat(owner, span_warning("You've overwhelmed [target] with your majestic aura!"))
-		to_chat(target, span_userlove("UNDRESS YOURSELF"))
-		owner.say("UNDRESS YOURSELF!!")
+		to_chat(target, span_userlove("DISROBE"))
+		owner.say("Disrobe.")
 		target.Immobilize(1 SECONDS)
 		for(var/obj/item/clothing/W in target.contents)
 			target.dropItemToGround(W, TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Re-flavours presence to be a more subtle social command, reflecting what the discipline actually is. 

## Why It's Good For The Game
Right now anything but the first pip of presence makes you YELL REALLY LOUD!! and generally misunderstands the role of presence as a subtle social discipline in most circumstances. This giant chat message isn't neccesary because the victim already gets a huge, glowing message in chat when a roll succeeds on them.

I'm weighing up doing a more comprehensive presence re-work in future to make it more usable in regular RP (it's crazy that THE social discipline from VtM is purely mechanical) but for now this is a stop-gap which will hopefully stop people from crying foul about what should be a subtle, none masquerade breaching power.
## Testing Photographs and Procedure

https://youtu.be/4jzwtX3gaEo