### PR TITLE
Gangrel Claw Buff + Other Tweaks

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/protean.dm
+++ b/code/modules/wod13/datums/powers/discipline/protean.dm
@@ -65,7 +65,6 @@
 	owner.drop_all_held_items()
 	owner.put_in_r_hand(new /obj/item/melee/vampirearms/knife/gangrel(owner))
 	owner.put_in_l_hand(new /obj/item/melee/vampirearms/knife/gangrel(owner))
-	owner.add_client_colour(/datum/client_colour/glass_colour/red)
 	owner.add_movespeed_modifier(/datum/movespeed_modifier/protean2)
 
 /datum/discipline_power/protean/feral_claws/deactivate()

--- a/code/modules/wod13/datums/powers/discipline/protean.dm
+++ b/code/modules/wod13/datums/powers/discipline/protean.dm
@@ -28,13 +28,11 @@
 /datum/discipline_power/protean/eyes_of_the_beast/activate()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_PROTEAN_VISION, TRAIT_GENERIC)
-	owner.add_client_colour(/datum/client_colour/glass_colour/red)
 	owner.update_sight()
 
 /datum/discipline_power/protean/eyes_of_the_beast/deactivate()
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_PROTEAN_VISION, TRAIT_GENERIC)
-	owner.remove_client_colour(/datum/client_colour/glass_colour/red)
 	owner.update_sight()
 
 //FERAL CLAWS

--- a/code/modules/wod13/melee.dm
+++ b/code/modules/wod13/melee.dm
@@ -462,7 +462,7 @@
 	name = "claws"
 	icon_state = "gangrel"
 	w_class = WEIGHT_CLASS_BULKY
-	force = 10
+	force = 20
 	armour_penetration = 100	//It's magical damage
 	block_chance = 20
 	item_flags = DROPDEL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Buffs the gangrel claws' damage and removes the oppressive red filter from both Protean 1 and 2.
## Why It's Good For The Game
Gangrels are in a pretty rough spot right now, with a weak warform and claws when these should be the clan's main threat. There is currently a claimed code bounty for a rework so I have decided only to perform a minor tweak here by upping the damage of the claws (Protean 2) and removing the red filter from their disciplines. 

## Testing Photographs and Procedure
![Screenshot 2025-05-09 065555](https://github.com/user-attachments/assets/4f31309c-c37b-41bc-8d00-5308b045e9d3)
Without eyes of the beast

![Screenshot 2025-05-09 065608](https://github.com/user-attachments/assets/ed168410-bb3c-408f-a9fc-43b0e96b700e)
With eyes of the beast

![Screenshot 2025-05-09 065621](https://github.com/user-attachments/assets/8697968d-69ef-4d57-83ea-3c4f4e1f90d1)
Feral claws without red filter

## Changelog
:cl:
balance: increased damage of Protean 2's claws
del: removed red screen filter from Protean 1 and 2
