### PR TITLE
Debtor quirk now works, Ventrue money changed

### DIFF
--- a/code/modules/vtmb/electronics/atms/atm.dm
+++ b/code/modules/vtmb/electronics/atms/atm.dm
@@ -36,11 +36,9 @@
 	var/bank_id = 0
 	var/balance = 0
 	var/code = ""
-	var/list/credit_cards = list()
 
 
 /datum/vtm_bank_account/New()
-	..()
 	if(!code || code == "")
 		code = create_bank_code()
 		var/random_id = rand(1, 999999)
@@ -64,49 +62,61 @@
 
 	var/owner = ""
 	var/datum/vtm_bank_account/account
-	var/code
-	var/balance = 0
 	var/has_checked = FALSE
+	var/min_starting_wealth = 600
+	var/max_starting_wealth = 1000
 
 /obj/item/vamp/creditcard/prince
 	icon_state = "card2"
 	inhand_icon_state = "card2"
+	min_starting_wealth = 10000
+	max_starting_wealth = 15000
 
 /obj/item/vamp/creditcard/seneschal
 	icon_state = "card2"
 	inhand_icon_state = "card2"
+	min_starting_wealth = 4000
+	max_starting_wealth = 8000
 
 /obj/item/vamp/creditcard/elder
 	icon_state = "card3"
 	inhand_icon_state = "card3"
+	min_starting_wealth = 3000
+	max_starting_wealth = 7000
 
 /obj/item/vamp/creditcard/giovanniboss
 	icon_state = "card2"
 	inhand_icon_state = "card2"
+	min_starting_wealth = 8000
+	max_starting_wealth = 15000
 
 /obj/item/vamp/creditcard/rich
+	min_starting_wealth = 1000
+	max_starting_wealth = 4000
 
-/obj/item/vamp/creditcard/New(mob/user)
-	..()
-	if(!account || code == "")
+
+/obj/item/vamp/creditcard/Initialize(mapload)
+	. = ..()
+	if(!account)
 		account = new /datum/vtm_bank_account()
-	if(user)
-		owner = user.ckey
-	if(istype(src, /obj/item/vamp/creditcard/prince))
-		account.balance = rand(10000, 15000)
-	else if(istype(src, /obj/item/vamp/creditcard/elder))
-		account.balance = rand(3000, 7000)
-	else if(istype(src, /obj/item/vamp/creditcard/rich))
-		account.balance = rand(1000, 4000)
-	else if(istype(src, /obj/item/vamp/creditcard/giovanniboss))
-		account.balance = rand(8000, 15000)
-	else if(istype(src, /obj/item/vamp/creditcard/seneschal))
-		account.balance = rand(4000, 8000)
-	else
-		account.balance = rand(600, 1000)
+	var/mob/living/carbon/human/user = null
+	if(ishuman(loc)) // In pockets
+		user = loc
+	else if(ishuman(loc?.loc)) // In backpack
+		user = loc
+	if(!isnull(user))
+		owner = user.real_name
+		if(user.clane?.name == CLAN_VENTRUE)
+			min_starting_wealth = max(min_starting_wealth, 1000)
+			max_starting_wealth = clamp(max_starting_wealth * 1.5, 4000, 20000)
+	account.balance = rand(min_starting_wealth, max_starting_wealth)
 
-/obj/machinery/vamp/atm/Initialize()
-	..()
+
+/obj/item/vamp/creditcard/examine(mob/user)
+	. = ..()
+	if(owner)
+		. += span_notice("The card bears a name: [owner].")
+
 
 /obj/machinery/vamp/atm/attackby(obj/item/P, mob/user, params)
 	if(istype(P, /obj/item/vamp/creditcard))

--- a/code/modules/vtmb/jobs/jobs.dm
+++ b/code/modules/vtmb/jobs/jobs.dm
@@ -3,13 +3,6 @@
 
 /datum/outfit/job/post_equip(mob/living/carbon/human/H)
 	. = ..()
-	if(H.clane)
-		if(H.clane.name == "Ventrue")
-			var/obj/item/stack/dollar/hundred/HUN = new(H.loc)
-			for(var/obj/item/storage/backpack/B in H)
-				if(B)
-					HUN.forceMove(B)
-
 	var/obj/item/storage/backpack/b = locate() in H
 	if(b)
 		var/obj/item/vamp/creditcard/card = locate() in b.contents

--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -204,6 +204,20 @@ Dancer
 	gain_text = "<span class='warning'>You feel poorer.</span>"
 	lose_text = "<span class='notice'>You feel hope for your future finances.</span>"
 
+/datum/quirk/debtor/add()
+	. = ..()
+	if(!ishuman(quirk_holder))
+		return
+	var/mob/living/carbon/human/debtor = quirk_holder
+	for(var/datum/vtm_bank_account/account as anything in GLOB.bank_account_list)
+		if(debtor.bank_id != account.bank_id)
+			continue
+		if(debtor.clane?.name == CLAN_VENTRUE)
+			account.balance = 5 // Extra loss of dignitas.
+		else
+			account.balance = floor(account.balance * 0.5)
+		break
+
 /datum/quirk/messy_eater
 	name = "Messy Eater"
 	desc = "Blood doesn't make it in around your fangs correctly. Create bloodstains when you feed, and reduce your blood intake."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Debtor now actually halves your money as stated in the quirk description (it had no effect before, it was a free quirk).
Ventrue no longer get $100 in their backpack. Instead, they get fatter bank accounts.
However, if Ventrue have the Debtor quirk, all they get in their bank account is $5 and an extra loss of dignitas.

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->
Makes the quirk work.
More interesting relationship between the clan of power and money.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

Regular debtor citizen:
![image](https://github.com/user-attachments/assets/6dc7b74a-2bf6-4147-9b73-9f4fcd16c1e5)

Ventrue citizen:
![image](https://github.com/user-attachments/assets/2627beff-e963-4dbf-873f-1cac7fae1581)

Ventrue debtor:
![image](https://github.com/user-attachments/assets/d2e82259-1374-4067-8454-22d3f20e8c3f)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Debtor quirk now works as advertised.
add: Ventrue no longer get $100 in their backpacks. Instead, their bank accounts are fatter.
add: Ventrue with the Debtor quirk get an extra loss of dignitas, reflected in their savings.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
