### PR TITLE
remove bhopping for speed increase

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -237,6 +237,11 @@
 
 	var/distance = get_dist(loc, target)
 	var/turf/adjusted_target = target
+
+	if(!do_after(src, 1 SECONDS))
+		to_chat(src, span_warning("Your jump was interrupted!"))
+		return
+
 	if(distance > adjusted_jump_range)
 		var/dx = target.x - loc.x
 		var/dy = target.y - loc.y


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a do_after of a 1 second delay to the jump command, as approved by Xeon. It inputs a message if your interrupted, and jumps as normal if you are not.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People spam jump like they're phoon without zblock enabled on The Final Nights, chase scenes become spamming the jump, and even traversing across town has people doing lrp jump spam for convenience. It doesn't add anything to the game when its used like that. This preserves jumping for its intended usages, dedicated long movement in a short time frame. While removing its spammy, lrp usage. 1 second felt right to me and is what was suggested, but it can be easily lowered or raised.

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/7a0950d2-6e6b-49aa-94ca-97b906ce316b)


</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Adds a delay before jumping to avoid it being abused as a chase, bhop and speed increase tool, while preserving its intended function and usage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
