### PR TITLE
Ports IC verb to toggle underwear/shirt/socks visibilty on/off. 

### DIFF
--- a/code/__DEFINES/tfn/vtm_defines.dm
+++ b/code/__DEFINES/tfn/vtm_defines.dm
@@ -131,3 +131,7 @@
 // Rituals
 #define COOLDOWN_RITUAL_INVOKE "ritual_invoke"
 
+//Defines for toggling underwear
+#define UNDERWEAR_HIDE_SOCKS (1<<0)
+#define UNDERWEAR_HIDE_SHIRT (1<<1)
+#define UNDERWEAR_HIDE_UNDIES (1<<2)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1233,7 +1233,7 @@
 	var/undershirt_button = underwear_visibility & UNDERWEAR_HIDE_SHIRT ? "Show shirt" : "Hide shirt"
 	var/socks_button = underwear_visibility & UNDERWEAR_HIDE_SOCKS ? "Show socks" : "Hide socks"
 	var/list/choice_list = list("[underwear_button]" = "underwear", "[undershirt_button]" = "shirt", "[socks_button]" = "socks","Show all" = "show", "Hide all" = "hide")
-	var/picked_visibility = input(src, "Choose visibility setting", "Show/Hide underwear") as null|anything in choice_list
+	var/picked_visibility = tgui_input_list(src, "Choose visibility setting", "Show/Hide underwear", choice_list)
 	if(picked_visibility)
 		var/picked_choice = choice_list[picked_visibility]
 		switch(picked_choice)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1219,6 +1219,39 @@
 /mob/living/carbon/human/monkeybrain
 	ai_controller = /datum/ai_controller/monkey
 
+
+/mob/living/carbon/human/verb/toggle_undies()
+	set category = "IC"
+	set name = "Toggle underwear visibility"
+	set desc = "Allows you to toggle which underwear should show or be hidden."
+
+	if(stat != CONSCIOUS)
+		to_chat(usr, span_warning("You can't toggle underwear visibility right now..."))
+		return
+
+	var/underwear_button = underwear_visibility & UNDERWEAR_HIDE_UNDIES ? "Show underwear" : "Hide underwear"
+	var/undershirt_button = underwear_visibility & UNDERWEAR_HIDE_SHIRT ? "Show shirt" : "Hide shirt"
+	var/socks_button = underwear_visibility & UNDERWEAR_HIDE_SOCKS ? "Show socks" : "Hide socks"
+	var/list/choice_list = list("[underwear_button]" = "underwear", "[undershirt_button]" = "shirt", "[socks_button]" = "socks","Show all" = "show", "Hide all" = "hide")
+	var/picked_visibility = input(src, "Choose visibility setting", "Show/Hide underwear") as null|anything in choice_list
+	if(picked_visibility)
+		var/picked_choice = choice_list[picked_visibility]
+		switch(picked_choice)
+			if("underwear")
+				underwear_visibility ^= UNDERWEAR_HIDE_UNDIES
+			if("shirt")
+				underwear_visibility ^= UNDERWEAR_HIDE_SHIRT
+			if("socks")
+				underwear_visibility ^= UNDERWEAR_HIDE_SOCKS
+			if("show")
+				underwear_visibility = NONE
+			if("hide")
+				underwear_visibility = UNDERWEAR_HIDE_UNDIES | UNDERWEAR_HIDE_SHIRT | UNDERWEAR_HIDE_SOCKS
+		update_body()
+	return
+
+
+
 /mob/living/carbon/human/species
 	var/race = null
 	var/use_random_name = TRUE

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -46,6 +46,7 @@
 	var/socks = "Nude" //Which socks the player wants
 	var/backpack = DBACKPACK		//Which backpack type the player has chosen.
 	var/jumpsuit_style = PREF_SUIT		//suit/skirt
+	var/underwear_visibility = NONE ///Flag for showing/hiding underwear, toggleable by a verb
 
 	//Equipment slots
 	var/obj/item/clothing/wear_suit = null

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -738,7 +738,7 @@ GLOBAL_LIST_EMPTY(selectable_races)
 
 	//Underwear, Undershirts & Socks
 	if(!(NO_UNDERWEAR in species_traits))
-		if(H.underwear)
+		if(H.underwear && !(H.underwear_visibility & UNDERWEAR_HIDE_UNDIES))
 			var/datum/sprite_accessory/underwear/underwear = GLOB.underwear_list[H.underwear]
 			var/mutable_appearance/underwear_overlay
 			if(underwear)
@@ -754,7 +754,7 @@ GLOBAL_LIST_EMPTY(selectable_races)
 					underwear_overlay.color = H.underwear_color
 				standing += underwear_overlay
 
-		if(H.undershirt)
+		if(H.undershirt && !(H.underwear_visibility & UNDERWEAR_HIDE_SHIRT))
 			var/datum/sprite_accessory/undershirt/undershirt = GLOB.undershirt_list[H.undershirt]
 			var/mutable_appearance/undershirt_overlay
 			if(undershirt)
@@ -768,7 +768,7 @@ GLOBAL_LIST_EMPTY(selectable_races)
 					undershirt_overlay = mutable_appearance('icons/mob/clothing/underwear_f.dmi', undershirt.icon_state, -BODY_LAYER)
 				standing += undershirt_overlay
 
-		if(H.socks && H.num_legs >= 2 && !(DIGITIGRADE in species_traits))
+		if(H.socks && H.num_legs >= 2 && !(DIGITIGRADE in species_traits) && !(H.underwear_visibility & UNDERWEAR_HIDE_SOCKS))
 			var/datum/sprite_accessory/socks/socks = GLOB.socks_list[H.socks]
 			var/mutable_appearance/socks_overlay
 			if(socks)


### PR DESCRIPTION
## About The Pull Request
Ports the IC verb to toggle underwear/shirt/socks visibility on/off from Skyrat, the one found in this PR (Hopefully I got the right one): https://github.com/Skyrat-SS13/Skyrat-tg/commit/fb6720c7f9e8b5b4105d99b8bb42168da936d793 . All credits to Azarak and/or Gandalf2k15 for it.

The functionality is simple. You can hide your underwear, undershirt and socks and put them back on with the use of a new verb in the IC tab. That is all. You'd still need to find a dresser to change the underwear style.

## Why It's Good For The Game

Having to run to a dresser every time one needs to take off a piece of underwear stifles emerging roleplay. A quick toggle like this makes it far more comfortable. (I don't want to to have to take four elevator rides and run up and down a flight of stairs just because my socks offend the prince again.)

## Testing Photographs and Procedure

<details>
Tested the buttons on a Human, Ghoul, Vampire and Werewolf character. 

![image](https://github.com/user-attachments/assets/5e21bfce-026c-496c-a00a-fc72e1caf28b)
![image](https://github.com/user-attachments/assets/b0882b62-b681-4f50-a2de-b228752a6e59)
![image](https://github.com/user-attachments/assets/e9fdedac-082e-45c7-b19c-724d5600da21)

</details>

## Changelog



:cl: 
add: Adds IC verb to toggle underwear/short/socks visibilty on/off. 
/:cl:


