### PR TITLE
Unwhitelists the FBI

### DIFF
--- a/code/modules/vtmb/jobs/fbi.dm
+++ b/code/modules/vtmb/jobs/fbi.dm
@@ -23,7 +23,6 @@
 	duty = "You are here on an officially unofficial assignment, to look into local oddities and sort them out as deemed reasonable, whatever that means. To the point you arent even assigned a proper office, as much a ghetto hideout in the local Hotel, quietly paid for with some renovations. If anyone asks? Make something mundane up, they wouldnt believe the truth anyways."
 	minimal_masquerade = 0
 	known_contacts = list("Police Chief")
-	whitelisted = TRUE
 
 /datum/outfit/job/fbi
 	name = "Federal Investigator"


### PR DESCRIPTION
## About The Pull Request

Unwhitelists the FBI. I figure this is easier than applying for trusted player just to play a federal agent.

If this dramatically reduces the quality of FBI players, it'll be literally one line to put it back to whitelisted.

## Why It's Good For The Game

More federal agents in town equals more fun? Give our boys in blue jackets some friends.

Just look at how much fun these guys are having!

![image](https://github.com/user-attachments/assets/9c9c3b28-58b1-498e-9900-789c4501b9c1)


## Testing Photographs and Procedure

Deadminned and checked prefs, proceeded to join game as FBI but forgot to screenshot that. It works.

![1](https://github.com/user-attachments/assets/10a0609e-d649-42ec-b08b-7d17f6a11d21)


## Changelog

:cl:
code: FBI agents are no longer a whitelisted role.
/:cl: