### PR TITLE
Catwalks make catwalk footstep noises

### DIFF
--- a/code/game/objects/structures/lattice.dm
+++ b/code/game/objects/structures/lattice.dm
@@ -81,6 +81,53 @@
 	canSmoothWith = list(SMOOTH_GROUP_CATWALK)
 	obj_flags = CAN_BE_HIT | BLOCK_Z_OUT_DOWN | BLOCK_Z_IN_UP
 
+	// storing original turf sounds so that catwalks may make appropriate noises
+	var/original_footstep
+	var/original_barefootstep
+	var/original_clawfootstep
+	var/original_heavyfootstep
+
+/obj/structure/lattice/catwalk/Initialize(mapload)
+	. = ..() //uses parent initialize
+	if(. == INITIALIZE_HINT_QDEL) // if parent initialize wants to delete this catwalk dont modify the turf underneath
+		return
+
+	var/turf/T = get_turf(src)
+	if(T)
+		// Store original sounds if they exist
+		if("footstep" in T.vars)
+			original_footstep = T.vars["footstep"]
+		if("barefootstep" in T.vars)
+			original_barefootstep = T.vars["barefootstep"]
+		if("clawfootstep" in T.vars)
+			original_clawfootstep = T.vars["clawfootstep"]
+		if("heavyfootstep" in T.vars)
+			original_heavyfootstep = T.vars["heavyfootstep"]
+
+		// Set catwalk sounds if possible
+		if("footstep" in T.vars)
+			T.vars["footstep"] = FOOTSTEP_PLATING
+		if("barefootstep" in T.vars)
+			T.vars["barefootstep"] = FOOTSTEP_HARD_BAREFOOT
+		if("clawfootstep" in T.vars)
+			T.vars["clawfootstep"] = FOOTSTEP_HARD_CLAW
+		if("heavyfootstep" in T.vars)
+			T.vars["heavyfootstep"] = FOOTSTEP_GENERIC_HEAVY
+
+/obj/structure/lattice/catwalk/Destroy()
+	var/turf/T = get_turf(src)
+	if(T)
+		// Restore original sounds
+		if("footstep" in T.vars)
+			T.vars["footstep"] = original_footstep
+		if("barefootstep" in T.vars)
+			T.vars["barefootstep"] = original_barefootstep
+		if("clawfootstep" in T.vars)
+			T.vars["clawfootstep"] = original_clawfootstep
+		if("heavyfootstep" in T.vars)
+			T.vars["heavyfootstep"] = original_heavyfootstep
+	. = ..() // Call parent Destroy
+
 /obj/structure/lattice/catwalk/deconstruction_hints(mob/user)
 	return "<span class='notice'>The supporting rods look like they could be <b>cut</b>.</span>"
 


### PR DESCRIPTION

## About The Pull Request

This PR makes it so that tiles with catwalks on them (like the catwalks in the sewer section of the map) actually make metallic catwalk foostep noises, rather than the noise of whatever turf the catwalk is placed on, for example, if youd walk over a sewer tile with a catwalk placed atop it, your footstep would be footstep_water. If you walked over an empty space with a catwalk placed atop of it, youd hear nothing. this PR corrects that.

it does this by, upon initialization of the catwalk structure, it stores the original footstep vars of the turf it is placed ontop of, and overwrites the turf's noises with appropriate, catwalk-y footstep sounds. Then, upon deletion of the catwalk (from being destroyed or whatever), it restores the original footstep sound vars. 

## Why It's Good For The Game

I dont know about anyone else but this was a pet peeve for me. I suppose this is good for immersion.


## Testing Photographs and Procedure

https://www.youtube.com/watch?v=zXW3WV9SRis

## Changelog
:cl:
sound: catwalks now make catwalk noises rather than the sound of the turf they're placed atop of.
/:cl:


