### PR TITLE
Protean Rank 1 Changes your Eye Color now

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/protean.dm
+++ b/code/modules/wod13/datums/powers/discipline/protean.dm
@@ -24,16 +24,32 @@
 	violates_masquerade = FALSE
 
 	toggled = TRUE
+	var/original_eye_color
 
 /datum/discipline_power/protean/eyes_of_the_beast/activate()
 	. = ..()
 	ADD_TRAIT(owner, TRAIT_PROTEAN_VISION, TRAIT_GENERIC)
 	owner.update_sight()
+	original_eye_color = owner.eye_color
+	owner.eye_color = "#ff0000"
+	var/obj/item/organ/eyes/organ_eyes = owner.getorganslot(ORGAN_SLOT_EYES)
+	if(!organ_eyes)
+		return
+	else
+		organ_eyes.eye_color = owner.eye_color
+	owner.update_body()
 
 /datum/discipline_power/protean/eyes_of_the_beast/deactivate()
 	. = ..()
 	REMOVE_TRAIT(owner, TRAIT_PROTEAN_VISION, TRAIT_GENERIC)
 	owner.update_sight()
+	owner.eye_color = original_eye_color
+	var/obj/item/organ/eyes/organ_eyes = owner.getorganslot(ORGAN_SLOT_EYES)
+	if(!organ_eyes)
+		return
+	else
+		organ_eyes.eye_color = owner.eye_color
+	owner.update_body()
 
 //FERAL CLAWS
 /datum/movespeed_modifier/protean2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This makes it so your eyes changes color when you use the Protean Rank 1 Ability to make it more similar to how in the tabletop it made your eyes shift to be more beastly red. Which I've implemented here, it also can change back when done.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

It makes it more lore accurate and is just a nice bit of fluff to make the Protean rank 1 immersive. I could probably fluff it up some more, but eye color changes to make it more unnatural is pretty good in of itself.

## Testing Photographs and Procedure
<!-- Include any screenshots/videos/debugging steps of the modified code functioning successfully, ideally including edge cases. -->
<!-- You can uncomment line 1 @ _maps/_basemap.dm to boot up a test map that loads much faster. -->
<details>
<summary>Screenshots&Videos</summary>

![image](https://github.com/user-attachments/assets/d43c5cf8-affb-4c98-bb9c-ea10bf54d029)
![image](https://github.com/user-attachments/assets/a3ed083c-424d-499f-9d76-c563b5eb22d2)
![image](https://github.com/user-attachments/assets/69112eb6-6f4c-4d19-8c30-72a5b5cd1548)



</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and its effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Eye color change when you use Protean Rank 1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
