### PR TITLE
Discipline Sharing Softcapp+Caitiff Discipline Chargen Cap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -232,4 +232,3 @@ define_sanity_output.txt
 # Running OpenDream locally
 tgstation.json
 rust_g64.dll
-/config

--- a/.gitignore
+++ b/.gitignore
@@ -232,3 +232,4 @@ define_sanity_output.txt
 # Running OpenDream locally
 tgstation.json
 rust_g64.dll
+/config

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2375,6 +2375,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if (discipline.clan_restricted)
 							possible_new_disciplines -= discipline_type
 						qdel(discipline)
+					if(length(discipline_types) >= 3)
+						to_chat(user, span_notice("You cannot select more than three disciplines! Acquire more through roleplay!"))
+						return
 					var/new_discipline = tgui_input_list(user, "Select your new Discipline", "Discipline Selection", sort_list(possible_new_disciplines))
 					if(new_discipline)
 						discipline_types += new_discipline

--- a/code/modules/vtmb/kindred_species.dm
+++ b/code/modules/vtmb/kindred_species.dm
@@ -733,6 +733,11 @@
 		to_chat(teacher, span_warning("You need to have fed your student your blood to teach them Disciplines!"))
 		return
 
+	if(length(student_prefs.discipline_types) >= 5 && !SSwhitelists.is_whitelisted(student.ckey, TRUSTED_PLAYER))
+		to_chat(teacher, span_warning("Your student must be whitelisted to learn more than five disciplines!"))
+		to_chat(student, span_warning("You must be whitelisted to learn more than five disciplines!"))
+		return
+
 	var/possible_disciplines = teacher_prefs.discipline_types - student_prefs.discipline_types
 	var/teaching_discipline = input(teacher, "What Discipline do you want to teach [student.name]?", "Discipline Selection") as null|anything in possible_disciplines
 


### PR DESCRIPTION
## About The Pull Request

On request of Headmin Sorayew does two things: 

-Caps caitiff learning disciplines from their character creation menu to 3, if ya want more, learn them through rp.
-Softcaps player discipline sharing to 5. Whitelisted players can learn more than 5 through discipline sharing, however they are under higher scrutiny and collecting them like pokemon cards without proper roleplay and buildup is likely grounds for removal of whitelist. Admins can also still reward disciplines over the cap with no issues.

## Why It's Good For The Game

Headmin request good, also this makes it more functionally like the tabletop and permits for less in the way of nonmechanical rule enforcement. Mechanical restrictions for otherwise unenforceable administrative rules = good! 

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

![Screenshot 2025-05-25 232418](https://github.com/user-attachments/assets/5af1a7e7-59b6-4a90-b554-019cc14e4579)
![Screenshot 2025-05-26 120730](https://github.com/user-attachments/assets/7307e053-98bf-47af-a1b2-9e6fd143b496)
![imsssssssage](https://github.com/user-attachments/assets/deec7f9e-2bcc-436d-b8f9-4ca698c92ceb)


</details>

## Changelog

:cl:
qol: Mechanically enforces Discipline Cap 
balance: Caitiffs can no longer select eight disciplines out the gate.
admin: Trusted players can bypass discipline learning softcap, as can admin discipline rewards.
/:cl: