### PR TITLE
Fixes wine glasses disappearing when they're being filled.

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -298,8 +298,6 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "wineglass"
 	glass_name = "glass of wine"
 	glass_desc = "A very classy looking drink."
-	shot_glass_icon_state = "shotglassred"
-	empty_glass_icon_state = "wine_glass"
 
 /datum/reagent/consumable/ethanol/wine/wine_glass
 	name = "red wine"


### PR DESCRIPTION
## About The Pull Request
A silly overlay would previously cause wine glasses to disappear when you started filling them with any reagent, this fixes that.

## Why It's Good For The Game

Makes barkeeps happy. Fixes #73 .

## Testing Photographs and Procedure

<details>

https://github.com/user-attachments/assets/c19bc084-1da5-4028-92e7-cc6a68522e27

</details>

## Changelog

:cl:

fix: glasses of wine will no longer disappear when you start filling them with reagents.

/:cl:

