### PR TITLE
Fixes The Setite Curse

### DIFF
--- a/code/modules/vtmb/vampire_clan/ministry.dm
+++ b/code/modules/vtmb/vampire_clan/ministry.dm
@@ -12,6 +12,6 @@
 
 /datum/vampire_clan/ministry/on_gain(mob/living/carbon/human/H)
 	. = ..()
-	H.add_quirk(/datum/quirk/lightophobia)
+	H.physiology.burn_mod = 1.5 // Setites take extra damage from sunlight, so burn mod is a better flaw than the shitty fear of light quirk
 	var/obj/item/organ/eyes/night_vision/NV = new()
 	NV.Insert(H, TRUE, FALSE)


### PR DESCRIPTION
The Fix
## About The Pull Request

Setites currently have the lightophobia trait, I replaced it with a 1.5x mod to burn damage.
## Why It's Good For The Game

Lightophobia is taken from vanilla SS13, meant for the Nightmare antagonist. Not only is this incredibly inaccurate to the Setite bane, but it is incredibly unfun to play around with and basically every Setite player ever agrees it fucking sucks and sometimes bars them from playing it entirely. The 1.5x to burn is more accurate, as it captures the Setites relation with light and fire much more accurately- though, if we were going 100% tabletop accurate, they'd have a sunlight weakness (meaningless) and be more susceptible to things like flashbangs.

Lightophobia also has the extreme downside of being a trait that any observer can witness by examining you, thus revealing that your character is a Setite without a doubt.
## Testing Photographs and Procedure
<details>

Example of my Setite after being hit with a lighter one time
<img width="314" height="68" alt="image" src="https://github.com/user-attachments/assets/a4905469-cc85-49a5-9bbb-7c5f24143387" />


Example of an NPC after being hit with a lighter one time 
<img width="315" height="77" alt="image" src="https://github.com/user-attachments/assets/857e5456-b625-4a8d-8caa-45a99925e3a8" />\

The burn mod works
I can walk around lights like normal, now.

## Changelog
:cl:
fix: Setites no longer crawl like snails around lights and have a more appropriate bane
/:cl:
