### PR TITLE
Coraxes can be evil mode even while going from Crow to Were Crow

### DIFF
--- a/modular_tfn/modules/werewolf/werewolf_mob/transformation.dm
+++ b/modular_tfn/modules/werewolf/werewolf_mob/transformation.dm
@@ -58,6 +58,8 @@
 	transfer_to.setCloneLoss(target_clone_damage)
 	if(HAS_TRAIT(transfer_from, TRAIT_WARRIOR) && !HAS_TRAIT(transfer_to, TRAIT_WARRIOR))
 		ADD_TRAIT(transfer_to, TRAIT_WARRIOR, ROUNDSTART_TRAIT)
+	if(HAS_TRAIT(transfer_from, TRAIT_WYRMTAINTED) && !HAS_TRAIT(transfer_to, TRAIT_WYRMTAINTED))
+		ADD_TRAIT(transfer_to, TRAIT_WYRMTAINTED, ROUNDSTART_TRAIT)
 
 	transfer_from.fire_stacks = transfer_to.fire_stacks
 	transfer_from.on_fire = transfer_to.on_fire


### PR DESCRIPTION

## About The Pull Request

As Corax, when you transform from cow to were crow, if you had wyrm taint trait, it didn't apply properly so it looked like normal crow. Turns out the WYRM TAINTED trait wasn't applied properly to all forms so had to fix it
## Why It's Good For The Game

Bug fixes
## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

It a bug fix

</details>

## Changelog
:cl:
fix: Made it so Traits apply properly between Corvid Forms
/:cl:
