### PR TITLE
Masquerade Bugfixes

### DIFF
--- a/modular_tfn/modules/masquerade/code/subsystem/masquerade.dm
+++ b/modular_tfn/modules/masquerade/code/subsystem/masquerade.dm
@@ -44,6 +44,8 @@ SUBSYSTEM_DEF(masquerade)
  * reason - Optional, the reason for the breach. For example,
  */
 /datum/controller/subsystem/masquerade/proc/masquerade_reinforce(atom/source, mob/living/player_breacher, reason)
+	if(!GLOB.canon_event)
+		return
 	. = FALSE
 	for(var/masquerade_breach as anything in masquerade_breachers)
 		var/breach_sources = masquerade_breach[2]
@@ -91,6 +93,8 @@ SUBSYSTEM_DEF(masquerade)
  * reason - The reason for the breach. For example,
  */
 /datum/controller/subsystem/masquerade/proc/masquerade_breach(atom/source, mob/living/player_breacher, reason)
+	if(!GLOB.canon_event)
+		return
 	var/pre_breach_score = player_breacher.masquerade_score
 	if(pre_breach_score == 0)
 		return


### PR DESCRIPTION
## About The Pull Request

This PR introduces two bugfixes to the masquerade system. One is the fixing of the bloodhunt skull to fix round-persistent masquerade breaches. Another is the ability for one player to rack up 5+ breaches, introducing a vulnerability where one Nosferatu player could take their mask off and run through the streets, accumulate 20+ breaches, and end the round.

This bug was happening in the first place because round-persistent masq breaches had a list of sources (all the bloodhunt skulls on the map) rather than one specific source (like an NPC who heard you say 'Lasombra'), which is whats expected in the masquerade_breachers list, causing the source, the bloodhunt skull, to be hidden in a list inside of a list. I also introduced checks for if the reason listed was 'Preferences', which is the reason listed for round-persistent masq breaches. 

The 'player accumulating 20+ breaches' bug is fixed by introducing a check to masquerade_breach which only lowers the global masquerade if the players masquerade score was actually lowered by one (which, if their score is 0 and they breach, it doesn't). 

## Why It's Good For The Game

bugfixes 

## Testing Photographs and Procedure
before
<img width="1901" height="864" alt="dreamseeker_nyglzmFR4s" src="https://github.com/user-attachments/assets/b29dc669-afc5-44e9-8cb2-545e6bb595e8" />


after
<img width="1914" height="826" alt="dreamseeker_axWEqOUAtx" src="https://github.com/user-attachments/assets/ef7bb403-35f0-40ba-b12f-835622840e92" />


saying 'lasombra' in front of 8 npcs with an already 0/5 masq score and the global score does not decrease
<img width="1451" height="915" alt="dreamseeker_K31fDWOjTy" src="https://github.com/user-attachments/assets/dc973038-dcc6-462c-85f7-23b4e6017835" />

more:

before
<img width="1920" height="897" alt="dreamseeker_IFeCOJs13a" src="https://github.com/user-attachments/assets/d4b3eb48-c4ba-4cbe-b813-5a3353743861" />

after
<img width="1920" height="900" alt="dreamseeker_Bhv8SbVIjA" src="https://github.com/user-attachments/assets/c2e11c1b-5ee7-4d18-b963-06314fa5c1a8" />



## Changelog
:cl:

bugfix: one player can no longer bring the global masquerade from 20 to 0 ending the round.
bugfix: the bloodhunt skull can once again fix breaches from previous rounds

/:cl:
