### PR TITLE
Updates Perma Fangs Trait to be a +1pt Flaw 

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -643,7 +643,7 @@ Dancer
 /datum/quirk/permafangs
 	name = "Permanent Fangs"
 	desc = "Your fangs do not retract, making it impossible for you to hide your true nature. While some mortals may think you’ve had your teeth filed or are wearing prosthetics, sooner or later you’re going to run into someone who knows what you truly are."
-	value = 0
+	value = -1
 	mob_trait = TRAIT_PERMAFANGS
 	gain_text = "<span class='notice'>Your fangs become stuck.</span>"
 	lose_text = "<span class='notice'>You feel your fangs retract again.</span>"


### PR DESCRIPTION
## About The Pull Request

This is a matter of accuracy, I suppose. The Permanent Fangs trait, in Tabletop, is a **Three** Point  Flaw. So, it was somewhat baffling to me that it was a completely neutral trait in game.

<img width="849" height="149" alt="3b6b96f3-ba80-4f86-a05f-3d6561b13ffe" src="https://github.com/user-attachments/assets/e9d19cb9-78ab-408e-b114-86842a4c72a6" />



## Why It's Good For The Game

I believe that having this trait become a negative flaw would be good for the game on account of it rewarding players that choose to take the trait with a little extra wiggle room for their builds, as one extra point may be another language or other small trait. Additionally, I believe actually making it a flaw rather than a trait a Kindred can have would allow for players to be more aware that it is, in fact, a bad thing that their fangs don't retract.

 I didn't give it the full +3pts it would have received in tabletop, as we do not have an appearance rating. On top of that, it has virtually no gameplay effect beyond making you a potential target for would-be hunters that know who/what you are. Much like how Debtor can be circumvented by doing work in game and money not being that hard to come by. It's a neat little trait and I am glad we have it, I

## Testing Photographs and Procedure

<details>
<img width="283" height="92" alt="109c61bf-81f3-408c-839b-af5975061292" src="https://github.com/user-attachments/assets/6e675510-672d-4dfe-ae35-054306c5b314" />
<img width="869" height="71" alt="2c31e362-3914-417b-82e8-de1eaa0b2a98" src="https://github.com/user-attachments/assets/473d16a7-58aa-4555-873e-a2d7a9cc03a6" />

</details>

## Changelog
:cl:
balance: Changed "Permanent Fangs" trait from a neutral quirk to a negative quirk to reflect tabletop
code: Changed variable from 0 to -1
/:cl:
