### PR TITLE
Deletes Graveyard Zombies on Death

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/zombie.dm
+++ b/code/modules/mob/living/simple_animal/hostile/zombie.dm
@@ -22,7 +22,7 @@
 	maxbloodpool = 0
 	speed = 1
 	AIStatus = AI_OFF
-	del_on_death = 1
+	del_on_death = TRUE
 	var/mob/living/target_to_zombebe
 
 /mob/living/simple_animal/hostile/zombie/Destroy()


### PR DESCRIPTION
## About The Pull Request

This PR deletes graveyard zombies when they are killed. 

The zombies would remain dead but with an invisible sprite that would somehow still move around chasing after living mobs (despite being dead and unable to attack themselves). Similar to how when you kill certain mobs you can butcher them once they die - these mobs just didnt have a sprite for their 'dead' state where it would be ready to be butchered. 

## Why It's Good For The Game

This bug was discovered on live and I investigated it on a test server where the graveyard subsystem and mob subsystem was being clogged up by dead zombies who would still be running around after people while invisible. You can see the dead zombies with auspex 3 health huds on the live server.

## Testing Photographs and Procedure

auspex 3 huds on

<img width="496" height="434" alt="dreamseeker_XFGtcOUgys" src="https://github.com/user-attachments/assets/a947cfc7-7d9a-4ff7-a7f2-a03709c5f003" />

<img width="556" height="376" alt="dreamseeker_d1qccafpT7" src="https://github.com/user-attachments/assets/35bc5224-446d-4ad6-8c56-352cf89a3b36" />


## Changelog

:cl:

fix: deletes graveyard zombies upon death

/:cl:


