### PR TITLE
Fixes Conditioning

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/dominate.dm
+++ b/code/modules/wod13/datums/powers/discipline/dominate.dm
@@ -95,7 +95,7 @@
 			theirpower -= 2
 
 	if(target.conditioned)
-		theirpower += 3
+		theirpower -= 3
 
 	return (mypower > theirpower && owner.generation <= target.generation)
 
@@ -375,7 +375,7 @@
 	level = 6
 
 	check_flags = DISC_CHECK_CAPABLE|DISC_CHECK_SPEAK|DISC_CHECK_SEE
-	target_type = TARGET_HUMAN 
+	target_type = TARGET_HUMAN
 
 	cooldown_length = 15 SECONDS
 	range = 7


### PR DESCRIPTION
## About The Pull Request
This changes a plus + to a minus -.
The current code has the opposite intended effect of, which is supposed to be making conditioned targets have 3 successes taken away flatly from their roll. This fixes that, and a floating whitespace that it auto fixed when I saved the file.
## Why It's Good For The Game
The effect is intended to hinder Conditioned characters, not aid them.
## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

</details>

## Changelog
:cl:
fix: fixed conditioning to provide its intended effect, not the opposite.
/:cl:
