### PR TITLE
Alter the areas for Veil Regen to happen.

### DIFF
--- a/modular_tfn/modules/werewolf/werewolf_mob/life.dm
+++ b/modular_tfn/modules/werewolf/werewolf_mob/life.dm
@@ -5,19 +5,19 @@
 
 	switch(auspice.tribe.name)
 		if("Galestalkers", "Ghost Council", "Hart Wardens", "Get of Fenris", "Black Furies", "Silent Striders", "Red Talons", "Silver Fangs", "Stargazers", "Corax")
-			if(istype(get_area(src), /area/vtm/forest/caves) || istype(get_area(src), /area/vtm/forest))
+			if(istype(get_area(src), /area/vtm/forest/caves))
 				SEND_SIGNAL(SSmasquerade, COMSIG_PLAYER_MASQUERADE_REINFORCE, src)
 
 		if("Bone Gnawers", "Children of Gaia", "Shadow Lords", "Corax")
-			if(istype(get_area(src), /area/vtm/interior/cog/caern) || istype(get_area(src), /area/vtm/interior/cog/pantry))
+			if(istype(get_area(src), /area/vtm/interior/cog/caern))
 				SEND_SIGNAL(SSmasquerade, COMSIG_PLAYER_MASQUERADE_REINFORCE, src)
 
 		if("Glass Walkers", "Corax")
-			if(istype(get_area(src), /area/vtm/interior/glasswalker) || istype(get_area(src), /area/vtm/interior/techshop))
+			if(istype(get_area(src), /area/vtm/interior/glasswalker))
 				SEND_SIGNAL(SSmasquerade, COMSIG_PLAYER_MASQUERADE_REINFORCE, src)
 
 		if("Black Spiral Dancers")
-			if(istype(get_area(src), /area/vtm/interior/endron_facility/restricted) || istype(get_area(src), /area/vtm/interior/wyrm_corrupted))
+			if(istype(get_area(src), /area/vtm/interior/wyrm_corrupted))
 				SEND_SIGNAL(SSmasquerade, COMSIG_PLAYER_MASQUERADE_REINFORCE, src)
 
 


### PR DESCRIPTION

## About The Pull Request

Alter the list of areas Veil can be healed in to match where the totems are.

## Why It's Good For The Game
Now players can be around their totems and actually heal their Veil where they expect it to happen.

## Testing Photographs and Procedure
This is exceedingly hard to test because though I can fire it off at certain times, I can't at others. The areas are all that's changed, but it interacts very weirdly with the masquerade signal code and I think about half the time the timer breaks, but I don't know why.

I'm working on it.

## Changelog
:cl:
balance: All Garou now regain Veils around the areas their totems are, rather than areas their totems used to be.
/:cl:
