### PR TITLE
unbonding quirk removal

### DIFF
--- a/code/modules/wod13/quirks.dm
+++ b/code/modules/wod13/quirks.dm
@@ -693,15 +693,6 @@ Dancer
 	lose_text = "<span class='notice'>You don't feel charismatic anymore.</span>"
 	allowed_species = list("Vampire", "Kuei-Jin")
 
-/datum/quirk/unbonding
-	name = "Unbonding"
-	desc = "Your vitae, for one reason or another, doesn't produce blood bonds with anybody."
-	value = -1
-	mob_trait = TRAIT_DEFICIENT_VITAE
-	gain_text = "<span class='notice'>Your blood feels vacant.</span>"
-	lose_text = "<span class='notice'>You feel like something that was missing just came back to you.</span>"
-	allowed_species = list("Vampire")
-
 /datum/quirk/permafangs
 	name = "Permanent Fangs"
 	desc = "Your fangs do not retract, making it impossible for you to hide your true nature. While some mortals may think you’ve had your teeth filed or are wearing prosthetics, sooner or later you’re going to run into someone who knows what you truly are."


### PR DESCRIPTION

## About The Pull Request
gets rid of the unbonding quirk specifically, but not the trait itself so the tremere still have their flaw


## Why It's Good For The Game
not tt accurate + people using it to get around having bloodbonds when you teach disciplines - loreteam


## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="887" height="696" alt="image" src="https://github.com/user-attachments/assets/9059a68a-5909-4067-9dde-a53cc900044d" />


</details>

## Changelog
:cl:
del: Removed unbonding quirk
/:cl:
