### PR TITLE
Psychomachia Bug Fix

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/daimonion.dm
+++ b/code/modules/wod13/datums/powers/discipline/daimonion.dm
@@ -268,11 +268,11 @@
 		if(!lowest_virtue || target_stat < lowest_virtue.score)
 			lowest_virtue = target.st_get_stat_datum(virtue)
 
-	if(SSroll.storyteller_roll(target.st_get_stat(lowest_virtue), 6, mobs_to_show_output = list(owner, target)) == !ROLL_SUCCESS)
-		to_chat(owner, span_warning("[target] is too pure to manifest their fears!"))
-		return FALSE
-	to_chat(owner, span_cult("[target] will suffer greatly."))
-	return TRUE
+	if(SSroll.storyteller_roll(target.st_get_stat(lowest_virtue), 6, mobs_to_show_output = list(target)) == !ROLL_SUCCESS)
+		to_chat(owner, span_cult("[target] will suffer greatly."))
+		return TRUE
+	to_chat(owner, span_warning("[target] is too pure to manifest their fears!"))
+	return FALSE
 
 /datum/discipline_power/daimonion/psychomachia/activate(mob/living/target)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Flips the Boolean logic for Psychomachia, making the ability "Activate" upon roll failure and not "Activate" on success.

## Why It's Good For The Game

Going off the ability description from VTM 20E DA, Psychomachia is rolled **for the victim** by using a dice amount equivalent to their lowest virtue. Instead of being rolled for the victim, the current implementation rolled using lowest virtue dice of the **target** for the **user**, meaning that the ability would almost never activate because you were always rolling one dice at difficulty 6. By swapping around the logic, making the effects proc upon roll failure, the ability becomes usable and _correctly_ book compliant.

For the purpose of clarity, I've removed the visible roll from the users side as it would be confusing to be given a roll failure, which is associated with disciplines FAILING to activate and instead getting a success.
## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.
<img width="255" height="48" alt="testing proof" src="https://github.com/user-attachments/assets/e667b04c-cef9-4bc7-8a8f-d57f3f901ff8" />
from the victims side
</details>

## Changelog
:cl:
fix: Psychomachia 4 Rolling Logic
/:cl:
