### PR TITLE
nerf zulo form

### DIFF
--- a/modular_tfn/modules/tzimisce/code/zulo.dm
+++ b/modular_tfn/modules/tzimisce/code/zulo.dm
@@ -12,7 +12,7 @@
 	wings_icon = "Dragon"
 	mutant_bodyparts = list("tail_human" = "None", "ears" = "None", "wings" = "None")
 	mutantbrain = /obj/item/organ/brain/vampire
-	brutemod = 0.33 //Armoured plating and warform - You're going to be the biggest and most obvious target around.
+	brutemod = 0.5
 	heatmod = 1
 	burnmod = 2
 	punchdamagelow = 15 //A little more than Glabro, since this is a Crinos equivalent.
@@ -33,10 +33,6 @@
 	H.st_add_stat_mod(STAT_STAMINA, 3, "Zulo")
 	H.st_add_stat_mod(STAT_DEXTERITY, 3, "Zulo")
 	H.st_set_stat(0, STAT_APPEARANCE)
-	H.physiology.armor.melee += 50
-	H.physiology.armor.bullet += 50
-	H.physiology.armor.wound += 10
-	H.add_movespeed_modifier(/datum/movespeed_modifier/zulo)
 	H.dna.add_mutation(GIGANTISM)
 
 /datum/species/kindred/zulo/on_species_loss(mob/living/carbon/human/H)
@@ -50,12 +46,6 @@
 	H.st_remove_stat_mod(STAT_STAMINA, 3, "Zulo")
 	H.st_remove_stat_mod(STAT_DEXTERITY, 3, "Zulo")
 	H.st_set_stat(old_appearance, STAT_APPEARANCE)
-	H.physiology.armor.melee -= 50
-	H.physiology.armor.bullet -= 50
-	H.physiology.armor.wound += 10
-	H.remove_movespeed_modifier(/datum/movespeed_modifier/zulo)
 	H.dna.remove_mutation(GIGANTISM)
 
-/datum/movespeed_modifier/zulo
-	blacklisted_movetypes = FLOATING|FLYING
-	multiplicative_slowdown = -0.25
+


### PR DESCRIPTION
removes zulo armor and movement speed buff
## About The Pull Request
## Why It's Good For The Game
Horrid Form is incredibly overpowered
## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="712" height="686" alt="image" src="https://github.com/user-attachments/assets/b3fe18d6-2474-4463-9ca6-20169b137fa0" />

<img width="805" height="707" alt="image" src="https://github.com/user-attachments/assets/f16dcb16-5c6d-49a6-af2b-dbf2c448797f" />



Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
del: Removed Horrid Form armor and movement speed buff.
balance: Resets brute mod from .33 to .5

/:cl:
