### PR TITLE
Fixes Endron Executive latespawning

### DIFF
--- a/code/modules/vtmb/jobs/garou/poisonshore.dm
+++ b/code/modules/vtmb/jobs/garou/poisonshore.dm
@@ -64,7 +64,7 @@
 	icon_state = "Prince"
 
 /datum/job/vamp/garou/spiral/executive
-	title = "Endron Regional Executive"
+	title = "Endron Executive"
 	auto_deadmin_role_flags = DEADMIN_POSITION_HEAD|DEADMIN_POSITION_SECURITY
 	department_head = list("Endron International")
 	faction = "Vampire"
@@ -100,7 +100,7 @@
 	v_duty = "You are an Executive for Endron International, operating out of San Francisco. With discretion to the Branch Leader, a position you may aim for, your job is to fuel production, aid in bringing forth banes, and sate the heads of the Wyrm. Expand!"
 
 /datum/outfit/job/garou/endronexec
-	name = "Endron Regional Executive"
+	name = "Endron Executive"
 	jobtype = /datum/job/vamp/garou/spiral/executive
 
 	id = /obj/item/card/id/garou/spiral/executive
@@ -164,7 +164,7 @@
 
 /datum/outfit/job/garou/endronaffairs
 	name = "Endron Internal Affairs"
-	jobtype = /datum/job/vamp/garou/spiral/executive
+	jobtype = /datum/job/vamp/garou/spiral/affairs
 
 	id = /obj/item/card/id/garou/spiral/affairs
 	ears = /obj/item/p25radio


### PR DESCRIPTION

## About The Pull Request

Currently, you cannot latejoin as the Endron Regional Executive role. This fixes that. Also changes the role's default name to "Endron Executive" for consistency with its alt titles.

## Why It's Good For The Game

Bugfix. Roles that are intended to be usable should be usable.

## Testing Photographs and Procedure
<img width="218" height="289" alt="image" src="https://github.com/user-attachments/assets/03b546d0-d48a-468b-80ee-e0e9a8167fd4" />

<details>
<summary>Screenshots&Videos</summary>

Put screenshots and videos here with an empty line between the screenshots and the `<details>` tags.

</details>

## Changelog
:cl:
bugfix: the Endron Executive role is selectable again
/:cl:
