### PR TITLE
Presence General Fixes.

### DIFF
--- a/code/modules/wod13/datums/powers/discipline/presence.dm
+++ b/code/modules/wod13/datums/powers/discipline/presence.dm
@@ -34,7 +34,7 @@
 		return 0
 
 	if((owner.generation - 3) >= target.generation)
-		to_chat(owner, span_warning("Your supernatural allure seemd to simply slide off of [target], they must be too low generation to influence!")) //Adds feedback for if the roll fails due to lower generation.
+		to_chat(owner, span_warning("Your supernatural allure seems to simply slide off of [target], they must be too low generation to influence!")) //Adds feedback for if the roll fails due to lower generation.
 		return 0
 
 	//is the difficulty pre-defined? if not, its probably their current willpower.


### PR DESCRIPTION

## About The Pull Request

Changes Presence 3 to utilise Temporary Willpower instead of Permanent Willpower, as per lore.

Makes Presence 1 check eligibility - Generation and Presence immunity - before applying the effect on them.

Gives feedback for if Presence failed due to generational differences, and moved fail state to before the roll to avoid confusion.

Adds mention that victims of Presence are not aware of any supernatural influence.

Adds clarifying message for if Presence is resisted via Willpower, to reduce confusion. 


## Why It's Good For The Game

Improves lore accuracy, reduces potential for confusion or miscommunication with regards to Presence use and Resistance, and overall clarifies matters.  

## Testing Photographs and Procedure
<details>
<summary>Screenshots&Videos</summary>

<img width="1647" height="825" alt="Presence Fix Image" src="https://github.com/user-attachments/assets/0546de10-4afb-4feb-b43a-923573e0be82" />


https://github.com/user-attachments/assets/7d96a0e3-697c-4b20-b68e-49d3a1b60fb7



</details>


## Changelog
:cl:
bugfix: Fixed bug allowing individuals not intended to be vulnerable to Presence to be affected by it.
fix: Changed Presence to use correct willpower metric.
qol: Added feedback from Willpower and Generational resist of Presence.
/:cl:
