### PR TITLE
Dementation 4 nerf

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1475,11 +1475,11 @@ GLOBAL_LIST_INIT(malk_hallucinations, list(
 		else
 			fakemob = target //ever been so lonely you had to haunt yourself?
 		if(fakemob)
-			delay += 1 SECONDS //tfn edit
+			delay += 1 SECONDS //TFN EDIT CHANGE - Original: delay = rand(20, 50)
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), target, "<span class='deadsay'><b>DEAD: [fakemob.name]</b> says, \"[pick("rip","why did i just drop dead?","hey [target.first_name()]","git gud","you too?","is the AI rogue?",\
 				"i[prob(50)?" fucking":""] hate [pick("blood cult", "clock cult", "revenants", "this round","this","myself","admins","you")]")]\"</span>"), delay)
 
-	addtimer(CALLBACK(src, PROC_REF(cleanup)), delay + 2 SECONDS) //tfn edit
+	addtimer(CALLBACK(src, PROC_REF(cleanup)), delay + 2 SECONDS) //TFN EDIT CHANGE - Original: addtimer(CALLBACK(src, PROC_REF(cleanup)), delay + rand(70, 90))
 
 /datum/hallucination/death/proc/cleanup()
 	if (target)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1459,7 +1459,7 @@ GLOBAL_LIST_INIT(malk_hallucinations, list(
 	set waitfor = FALSE
 	..()
 	target.set_screwyhud(SCREWYHUD_DEAD)
-	target.Paralyze(20)
+	target.Paralyze(300)
 	target.silent += 10
 	to_chat(target, "<span class='deadsay'><b>[target.real_name]</b> has died at <b>[get_area_name(target)]</b>.</span>")
 
@@ -1475,11 +1475,11 @@ GLOBAL_LIST_INIT(malk_hallucinations, list(
 		else
 			fakemob = target //ever been so lonely you had to haunt yourself?
 		if(fakemob)
-			delay = rand(20, 50)
+			delay += 1 SECONDS //tfn edit
 			addtimer(CALLBACK(GLOBAL_PROC, GLOBAL_PROC_REF(to_chat), target, "<span class='deadsay'><b>DEAD: [fakemob.name]</b> says, \"[pick("rip","why did i just drop dead?","hey [target.first_name()]","git gud","you too?","is the AI rogue?",\
 				"i[prob(50)?" fucking":""] hate [pick("blood cult", "clock cult", "revenants", "this round","this","myself","admins","you")]")]\"</span>"), delay)
 
-	addtimer(CALLBACK(src, PROC_REF(cleanup)), delay + rand(70, 90))
+	addtimer(CALLBACK(src, PROC_REF(cleanup)), delay + 2 SECONDS) //tfn edit
 
 /datum/hallucination/death/proc/cleanup()
 	if (target)

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -1459,7 +1459,7 @@ GLOBAL_LIST_INIT(malk_hallucinations, list(
 	set waitfor = FALSE
 	..()
 	target.set_screwyhud(SCREWYHUD_DEAD)
-	target.Paralyze(300)
+	target.Paralyze(20)
 	target.silent += 10
 	to_chat(target, "<span class='deadsay'><b>[target.real_name]</b> has died at <b>[get_area_name(target)]</b>.</span>")
 


### PR DESCRIPTION
## About The Pull Request

This turns Dementate 4 from an 8 second hardstun to a 2 second one with you feeling funny for a bit afterwards. 

## Why It's Good For The Game

Hardstuns are bullshit and I'm completely biased in making this PR. It's probably good for the health of the game in general though so you can actually fight a Malkavian instead of needing to bring all the backup you can for a single guy. This may also introduce some roleplay opportunities as well since you still have the 0 health effect after getting up so maybe you think your heart got stopped and that you should get to the hospital. Additionally, this still has some use over Dem 1 since it also prevents you from speaking until the effect is over so your target can't call for help.

## Testing Photographs and Procedure

<details>
<summary>Screenshots&Videos</summary>


https://github.com/user-attachments/assets/ab8d110b-bf46-4d61-b89c-211063744d7a



</details>

## Changelog


:cl:
balance: Nerfs Dementation 4's stun. 
/:cl: