### PR TITLE
Updates Primogen Agelocks, matching rules

### DIFF
--- a/code/modules/vtmb/jobs/primogen.dm
+++ b/code/modules/vtmb/jobs/primogen.dm
@@ -19,7 +19,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_MALKAVIAN)
 	minimal_generation = 12
-	minimum_character_age = 100
+	minimum_vampire_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. You likely have a hold over the local hospital, make good use of it and ensure the blood bags remain available."
 	experience_addition = 20
@@ -69,7 +69,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_NOSFERATU)
 	minimal_generation = 12
-	minimum_character_age = 100
+	minimum_vampire_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City, and run the warren, your domain watches over the sewers."
 	experience_addition = 20
@@ -116,7 +116,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_VENTRUE)
 	minimal_generation = 12
-	minimum_character_age = 100
+	minimum_vampire_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. Maintain the local Jazz Club, in front of the Tower, and its Elysium."
 	experience_addition = 20
@@ -162,7 +162,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_TOREADOR)
 	minimal_generation = 12
-	minimum_character_age = 100
+	minimum_vampire_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. Take care of the Strip Club and its Elysium, for it is your domain and a social center within the city."
 	experience_addition = 20
@@ -209,7 +209,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_BANU_HAQIM)
 	minimal_generation = 12
-	minimum_character_age = 100
+	minimum_vampire_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City, while overseeing the Banu Haqim in the city. Monitor their contracts and ensure they remain true to the ways of the Clan. You have an official cover with the Police Department as a local civilian consultant, ensure things run smoothly, on either end."
 	experience_addition = 20
@@ -255,7 +255,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_LASOMBRA)
 	minimal_generation = 12
-	minimum_character_age = 100
+	minimum_vampire_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. Monitor those of your Clan and your lesser cousins, while holding a Court of Blood as need be, for all it takes for the Camarilla to turn on you is one mistake. You and Your Clan were given a domain in the local Church and in the vicinity of a swarm of Lupines, keep matters under control."
 	experience_addition = 20

--- a/code/modules/vtmb/jobs/primogen.dm
+++ b/code/modules/vtmb/jobs/primogen.dm
@@ -19,8 +19,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_MALKAVIAN)
 	minimal_generation = 12
-//	minimum_character_age = 100
-	minimum_vampire_age = 5 // Actually Malkavian Primo is whoever showed for work that day. Crazy bunch.
+	minimum_character_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. You likely have a hold over the local hospital, make good use of it and ensure the blood bags remain available."
 	experience_addition = 20
@@ -70,8 +69,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_NOSFERATU)
 	minimal_generation = 12
-//	minimum_character_age = 100 //Uncomment if age restriction wanted
-	minimum_vampire_age = 50
+	minimum_character_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City, and run the warren, your domain watches over the sewers."
 	experience_addition = 20
@@ -118,8 +116,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_VENTRUE)
 	minimal_generation = 12
-//	minimum_character_age = 100 //Uncomment if age restriction wanted
-	minimum_vampire_age = 50
+	minimum_character_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. Maintain the local Jazz Club, in front of the Tower, and its Elysium."
 	experience_addition = 20
@@ -165,8 +162,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_TOREADOR)
 	minimal_generation = 12
-//	minimum_character_age = 100 //Uncomment if age restriction wanted
-	minimum_vampire_age = 50
+	minimum_character_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. Take care of the Strip Club and its Elysium, for it is your domain and a social center within the city."
 	experience_addition = 20
@@ -213,8 +209,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_BANU_HAQIM)
 	minimal_generation = 12
-//	minimum_character_age = 100 //Uncomment if age restriction wanted
-	minimum_vampire_age = 50
+	minimum_character_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City, while overseeing the Banu Haqim in the city. Monitor their contracts and ensure they remain true to the ways of the Clan. You have an official cover with the Police Department as a local civilian consultant, ensure things run smoothly, on either end."
 	experience_addition = 20
@@ -260,8 +255,7 @@
 	allowed_species = list("Vampire")
 	allowed_bloodlines = list(CLAN_LASOMBRA)
 	minimal_generation = 12
-//	minimum_character_age = 100
-	minimum_vampire_age = 5 // Heavily meritocratic and new to the Camarilla, plus, Julia Sowinski *shrug
+	minimum_character_age = 100
 
 	v_duty = "Offer your infinite knowledge to Prince of the City. Monitor those of your Clan and your lesser cousins, while holding a Court of Blood as need be, for all it takes for the Camarilla to turn on you is one mistake. You and Your Clan were given a domain in the local Church and in the vicinity of a swarm of Lupines, keep matters under control."
 	experience_addition = 20


### PR DESCRIPTION
## About The Pull Request
Simply changes all Primogen Minimum Age reqs to be 100+, and also makes it check vampire_age and not character_age.

Also downloading the rebase in the background to update this over there as well, just doing this here quickly because I have the time.

## Why It's Good For The Game
It's good to have code match the actual rules, so just quickly making this PR to hopefully fix that!

## Testing Photographs and Procedure
<img width="285" height="29" alt="image" src="https://github.com/user-attachments/assets/85807698-bbe4-4ae4-a4dc-849673d9e4df" /> (staff bypass locks)
<img width="581" height="339" alt="image" src="https://github.com/user-attachments/assets/894e7523-be40-4ca9-998c-e9e26703d9cd" />
<img width="588" height="169" alt="image" src="https://github.com/user-attachments/assets/226543a5-c42c-4830-a36f-c732e127bdbc" />



## Changelog

:cl:
add: Re-adjust Primogen Minimum Age to be 100+
/:cl:

